### PR TITLE
Malcohol/fewer dynamic casts

### DIFF
--- a/BabelWires/Commands/activateOptionalCommand.cpp
+++ b/BabelWires/Commands/activateOptionalCommand.cpp
@@ -34,7 +34,7 @@ bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
         return false;
     }
 
-    auto recordFeature = dynamic_cast<const RecordWithOptionalsFeature*>(m_pathToRecord.tryFollow(*inputFeature));
+    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>();
     if (!recordFeature) {
         return false;
     }

--- a/BabelWires/Commands/activateOptionalCommand.cpp
+++ b/BabelWires/Commands/activateOptionalCommand.cpp
@@ -48,7 +48,7 @@ bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
     }
 
     if (const Modifier* modifier = elementToModify->findModifier(m_pathToRecord)) {
-        if (dynamic_cast<const ActivateOptionalsModifierData*>(&modifier->getModifierData())) {
+        if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/activateOptionalCommand.cpp
+++ b/BabelWires/Commands/activateOptionalCommand.cpp
@@ -34,7 +34,7 @@ bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
         return false;
     }
 
-    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>();
+    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->as<const RecordWithOptionalsFeature>();
     if (!recordFeature) {
         return false;
     }
@@ -48,7 +48,7 @@ bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
     }
 
     if (const Modifier* modifier = elementToModify->findModifier(m_pathToRecord)) {
-        if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
+        if (modifier->getModifierData().as<ActivateOptionalsModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/addElementCommand.cpp
+++ b/BabelWires/Commands/addElementCommand.cpp
@@ -38,7 +38,7 @@ void babelwires::AddElementCommand::undo(Project& project) const {
 }
 
 bool babelwires::AddElementCommand::shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const {
-    const auto* moveElementCommand = dynamic_cast<const MoveElementCommand*>(&subsequentCommand);
+    const auto* moveElementCommand = subsequentCommand.asA<MoveElementCommand>();
     if (!moveElementCommand) {
         return false;
     }
@@ -55,7 +55,7 @@ bool babelwires::AddElementCommand::shouldSubsume(const Command& subsequentComma
 }
 
 void babelwires::AddElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(dynamic_cast<const MoveElementCommand*>(subsequentCommand.get()) && "subsume should not have been called");
+    assert(subsequentCommand->asA<MoveElementCommand>() && "subsume should not have been called");
     MoveElementCommand* moveElementCommand = static_cast<MoveElementCommand*>(subsequentCommand.get());
     if (auto optionalPosition = moveElementCommand->getPositionForOnlyNode(m_elementToAdd->m_id)) {
         m_elementToAdd->m_uiData.m_uiPosition = *optionalPosition;

--- a/BabelWires/Commands/addElementCommand.cpp
+++ b/BabelWires/Commands/addElementCommand.cpp
@@ -38,7 +38,7 @@ void babelwires::AddElementCommand::undo(Project& project) const {
 }
 
 bool babelwires::AddElementCommand::shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const {
-    const auto* moveElementCommand = subsequentCommand.asA<MoveElementCommand>();
+    const auto* moveElementCommand = subsequentCommand.as<MoveElementCommand>();
     if (!moveElementCommand) {
         return false;
     }
@@ -55,7 +55,7 @@ bool babelwires::AddElementCommand::shouldSubsume(const Command& subsequentComma
 }
 
 void babelwires::AddElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(subsequentCommand->asA<MoveElementCommand>() && "subsume should not have been called");
+    assert(subsequentCommand->as<MoveElementCommand>() && "subsume should not have been called");
     MoveElementCommand* moveElementCommand = static_cast<MoveElementCommand*>(subsequentCommand.get());
     if (auto optionalPosition = moveElementCommand->getPositionForOnlyNode(m_elementToAdd->m_id)) {
         m_elementToAdd->m_uiData.m_uiPosition = *optionalPosition;

--- a/BabelWires/Commands/addEntryToArrayCommand.cpp
+++ b/BabelWires/Commands/addEntryToArrayCommand.cpp
@@ -35,7 +35,7 @@ bool babelwires::AddEntryToArrayCommand::initialize(const Project& project) {
         return false;
     }
 
-    auto arrayFeature = dynamic_cast<const ArrayFeature*>(m_pathToArray.tryFollow(*inputFeature));
+    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->asA<const ArrayFeature>();
     if (!arrayFeature) {
         return false;
     }

--- a/BabelWires/Commands/addEntryToArrayCommand.cpp
+++ b/BabelWires/Commands/addEntryToArrayCommand.cpp
@@ -53,7 +53,7 @@ bool babelwires::AddEntryToArrayCommand::initialize(const Project& project) {
     }
 
     if (const Modifier* modifier = elementToModify->findModifier(m_pathToArray)) {
-        if (dynamic_cast<const ArraySizeModifierData*>(&modifier->getModifierData())) {
+        if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/addEntryToArrayCommand.cpp
+++ b/BabelWires/Commands/addEntryToArrayCommand.cpp
@@ -35,7 +35,7 @@ bool babelwires::AddEntryToArrayCommand::initialize(const Project& project) {
         return false;
     }
 
-    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->asA<const ArrayFeature>();
+    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->as<const ArrayFeature>();
     if (!arrayFeature) {
         return false;
     }
@@ -53,7 +53,7 @@ bool babelwires::AddEntryToArrayCommand::initialize(const Project& project) {
     }
 
     if (const Modifier* modifier = elementToModify->findModifier(m_pathToArray)) {
-        if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
+        if (modifier->getModifierData().as<ArraySizeModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/changeFileCommand.cpp
+++ b/BabelWires/Commands/changeFileCommand.cpp
@@ -24,7 +24,7 @@ bool babelwires::ChangeFileCommand::initialize(const Project& project) {
         return false;
     }
 
-    const FileElement* const fileElement = dynamic_cast<const FileElement*>(element);
+    const FileElement* const fileElement = element->asA<FileElement>();
 
     if (!fileElement) {
         return false;
@@ -37,7 +37,7 @@ bool babelwires::ChangeFileCommand::initialize(const Project& project) {
 void babelwires::ChangeFileCommand::execute(Project& project) const {
     FeatureElement* const element = project.getFeatureElement(m_elementId);
     assert(element && "The element should already be in the project");
-    FileElement* const fileElement = dynamic_cast<FileElement*>(element);
+    FileElement* const fileElement = element->asA<FileElement>();
     assert(fileElement && "The element should be a file element");
     fileElement->setFilePath(m_newFilePath);
     if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {
@@ -48,7 +48,7 @@ void babelwires::ChangeFileCommand::execute(Project& project) const {
 void babelwires::ChangeFileCommand::undo(Project& project) const {
     FeatureElement* const element = project.getFeatureElement(m_elementId);
     assert(element && "The element should already be in the project");
-    FileElement* const fileElement = dynamic_cast<FileElement*>(element);
+    FileElement* const fileElement = element->asA<FileElement>();
     assert(fileElement && "The element should be a file element");
     fileElement->setFilePath(m_oldFilePath);
     if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {

--- a/BabelWires/Commands/changeFileCommand.cpp
+++ b/BabelWires/Commands/changeFileCommand.cpp
@@ -24,7 +24,7 @@ bool babelwires::ChangeFileCommand::initialize(const Project& project) {
         return false;
     }
 
-    const FileElement* const fileElement = element->asA<FileElement>();
+    const FileElement* const fileElement = element->as<FileElement>();
 
     if (!fileElement) {
         return false;
@@ -37,7 +37,7 @@ bool babelwires::ChangeFileCommand::initialize(const Project& project) {
 void babelwires::ChangeFileCommand::execute(Project& project) const {
     FeatureElement* const element = project.getFeatureElement(m_elementId);
     assert(element && "The element should already be in the project");
-    FileElement* const fileElement = element->asA<FileElement>();
+    FileElement* const fileElement = element->as<FileElement>();
     assert(fileElement && "The element should be a file element");
     fileElement->setFilePath(m_newFilePath);
     if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {
@@ -48,7 +48,7 @@ void babelwires::ChangeFileCommand::execute(Project& project) const {
 void babelwires::ChangeFileCommand::undo(Project& project) const {
     FeatureElement* const element = project.getFeatureElement(m_elementId);
     assert(element && "The element should already be in the project");
-    FileElement* const fileElement = element->asA<FileElement>();
+    FileElement* const fileElement = element->as<FileElement>();
     assert(fileElement && "The element should be a file element");
     fileElement->setFilePath(m_oldFilePath);
     if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {

--- a/BabelWires/Commands/commands.hpp
+++ b/BabelWires/Commands/commands.hpp
@@ -12,6 +12,8 @@
 #include "BabelWires/Features/Path/featurePath.hpp"
 #include "BabelWires/Project/projectIds.hpp"
 
+#include "Common/types.hpp"
+
 #include <chrono>
 #include <memory>
 #include <ostream>
@@ -28,6 +30,8 @@ namespace babelwires {
     /// Commands define undoable ways of mutating the project.
     class Command {
       public:
+        DOWNCASTABLE_TYPE_HIERARCHY(Command);
+
         /// CommandName should be a displayable name
         /// The timestamp is set to the current time.
         Command(std::string commandName);

--- a/BabelWires/Commands/deactivateOptionalCommand.cpp
+++ b/BabelWires/Commands/deactivateOptionalCommand.cpp
@@ -35,7 +35,7 @@ bool babelwires::DeactivateOptionalCommand::initializeAndExecute(Project& projec
         return false;
     }
 
-    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>();
+    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->as<const RecordWithOptionalsFeature>();
     if (!recordFeature) {
         return false;
     }
@@ -50,7 +50,7 @@ bool babelwires::DeactivateOptionalCommand::initializeAndExecute(Project& projec
 
     if (const Modifier* modifier = elementToModify->getEdits().findModifier(m_pathToRecord)) {
         const auto& modifierData = modifier->getModifierData();
-        if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
+        if (modifier->getModifierData().as<ActivateOptionalsModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/deactivateOptionalCommand.cpp
+++ b/BabelWires/Commands/deactivateOptionalCommand.cpp
@@ -35,7 +35,7 @@ bool babelwires::DeactivateOptionalCommand::initializeAndExecute(Project& projec
         return false;
     }
 
-    auto recordFeature = dynamic_cast<const RecordWithOptionalsFeature*>(m_pathToRecord.tryFollow(*inputFeature));
+    auto recordFeature = m_pathToRecord.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>();
     if (!recordFeature) {
         return false;
     }

--- a/BabelWires/Commands/deactivateOptionalCommand.cpp
+++ b/BabelWires/Commands/deactivateOptionalCommand.cpp
@@ -50,7 +50,7 @@ bool babelwires::DeactivateOptionalCommand::initializeAndExecute(Project& projec
 
     if (const Modifier* modifier = elementToModify->getEdits().findModifier(m_pathToRecord)) {
         const auto& modifierData = modifier->getModifierData();
-        if (dynamic_cast<const ActivateOptionalsModifierData*>(&modifier->getModifierData())) {
+        if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/moveElementCommand.cpp
+++ b/BabelWires/Commands/moveElementCommand.cpp
@@ -40,7 +40,7 @@ void babelwires::MoveElementCommand::undo(Project& project) const {
 }
 
 bool babelwires::MoveElementCommand::shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const {
-    const auto* moveElementCommand = dynamic_cast<const MoveElementCommand*>(&subsequentCommand);
+    const auto* moveElementCommand = subsequentCommand.asA<MoveElementCommand>();
     if (!moveElementCommand) {
         return false;
     }
@@ -55,7 +55,7 @@ bool babelwires::MoveElementCommand::shouldSubsume(const Command& subsequentComm
 }
 
 void babelwires::MoveElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(dynamic_cast<const MoveElementCommand*>(subsequentCommand.get()) && "subsume should not have been called");
+    assert(subsequentCommand->asA<MoveElementCommand>() && "subsume should not have been called");
     MoveElementCommand* moveElementCommand = static_cast<MoveElementCommand*>(subsequentCommand.get());
     for (const auto& p : moveElementCommand->m_newPositions) {
         m_newPositions[p.first] = p.second;

--- a/BabelWires/Commands/moveElementCommand.cpp
+++ b/BabelWires/Commands/moveElementCommand.cpp
@@ -40,7 +40,7 @@ void babelwires::MoveElementCommand::undo(Project& project) const {
 }
 
 bool babelwires::MoveElementCommand::shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const {
-    const auto* moveElementCommand = subsequentCommand.asA<MoveElementCommand>();
+    const auto* moveElementCommand = subsequentCommand.as<MoveElementCommand>();
     if (!moveElementCommand) {
         return false;
     }
@@ -55,7 +55,7 @@ bool babelwires::MoveElementCommand::shouldSubsume(const Command& subsequentComm
 }
 
 void babelwires::MoveElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(subsequentCommand->asA<MoveElementCommand>() && "subsume should not have been called");
+    assert(subsequentCommand->as<MoveElementCommand>() && "subsume should not have been called");
     MoveElementCommand* moveElementCommand = static_cast<MoveElementCommand*>(subsequentCommand.get());
     for (const auto& p : moveElementCommand->m_newPositions) {
         m_newPositions[p.first] = p.second;

--- a/BabelWires/Commands/pasteElementsCommand.cpp
+++ b/BabelWires/Commands/pasteElementsCommand.cpp
@@ -49,7 +49,7 @@ bool babelwires::PasteElementsCommand::initialize(const Project& project) {
             element->m_modifiers.begin(), element->m_modifiers.end(),
             [this, &remappingTable, preserveInConnections, newElementId,
              &project](std::unique_ptr<ModifierData>& modData) {
-                if (auto* assignFromData = dynamic_cast<ConnectionModifierData*>(modData.get())) {
+                if (auto* assignFromData = modData.get()->asA<ConnectionModifierData>()) {
                     ElementId& sourceId = assignFromData->m_sourceId;
                     auto it = remappingTable.find(sourceId);
                     if (it == remappingTable.end()) {

--- a/BabelWires/Commands/pasteElementsCommand.cpp
+++ b/BabelWires/Commands/pasteElementsCommand.cpp
@@ -49,7 +49,7 @@ bool babelwires::PasteElementsCommand::initialize(const Project& project) {
             element->m_modifiers.begin(), element->m_modifiers.end(),
             [this, &remappingTable, preserveInConnections, newElementId,
              &project](std::unique_ptr<ModifierData>& modData) {
-                if (auto* assignFromData = modData.get()->asA<ConnectionModifierData>()) {
+                if (auto* assignFromData = modData.get()->as<ConnectionModifierData>()) {
                     ElementId& sourceId = assignFromData->m_sourceId;
                     auto it = remappingTable.find(sourceId);
                     if (it == remappingTable.end()) {

--- a/BabelWires/Commands/removeElementCommand.cpp
+++ b/BabelWires/Commands/removeElementCommand.cpp
@@ -122,7 +122,7 @@ bool babelwires::RemoveElementCommand::initialize(const Project& project) {
         auto newEnd = std::remove_if(
             newElementData->m_modifiers.begin(), newElementData->m_modifiers.end(),
             [this, elementId, &connectionsBeingRemoved](const std::unique_ptr<ModifierData>& modData) {
-                if (const auto* assignFromData = dynamic_cast<const ConnectionModifierData*>(modData.get())) {
+                if (const auto* assignFromData = modData.get()->asA<ConnectionModifierData>()) {
                     ConnectionDescription connection(elementId, *assignFromData);
                     if (connectionsBeingRemoved.insert(connection).second) {
                         m_connections.emplace_back(connection);

--- a/BabelWires/Commands/removeElementCommand.cpp
+++ b/BabelWires/Commands/removeElementCommand.cpp
@@ -122,7 +122,7 @@ bool babelwires::RemoveElementCommand::initialize(const Project& project) {
         auto newEnd = std::remove_if(
             newElementData->m_modifiers.begin(), newElementData->m_modifiers.end(),
             [this, elementId, &connectionsBeingRemoved](const std::unique_ptr<ModifierData>& modData) {
-                if (const auto* assignFromData = modData.get()->asA<ConnectionModifierData>()) {
+                if (const auto* assignFromData = modData.get()->as<ConnectionModifierData>()) {
                     ConnectionDescription connection(elementId, *assignFromData);
                     if (connectionsBeingRemoved.insert(connection).second) {
                         m_connections.emplace_back(connection);
@@ -180,11 +180,11 @@ void babelwires::RemoveElementCommand::undo(Project& project) const {
 
 bool babelwires::RemoveElementCommand::shouldSubsume(const Command& subsequentCommand,
                                                      bool thisIsAlreadyExecuted) const {
-    return !thisIsAlreadyExecuted && subsequentCommand.asA<RemoveElementCommand>();
+    return !thisIsAlreadyExecuted && subsequentCommand.as<RemoveElementCommand>();
 }
 
 void babelwires::RemoveElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(subsequentCommand->asA<RemoveElementCommand>() && "subsume should not have been called");
+    assert(subsequentCommand->as<RemoveElementCommand>() && "subsume should not have been called");
     RemoveElementCommand* removeElementCommand = static_cast<RemoveElementCommand*>(subsequentCommand.get());
     m_elementIds.insert(m_elementIds.end(), removeElementCommand->m_elementIds.begin(),
                         removeElementCommand->m_elementIds.end());

--- a/BabelWires/Commands/removeElementCommand.cpp
+++ b/BabelWires/Commands/removeElementCommand.cpp
@@ -180,11 +180,11 @@ void babelwires::RemoveElementCommand::undo(Project& project) const {
 
 bool babelwires::RemoveElementCommand::shouldSubsume(const Command& subsequentCommand,
                                                      bool thisIsAlreadyExecuted) const {
-    return !thisIsAlreadyExecuted && dynamic_cast<const RemoveElementCommand*>(&subsequentCommand);
+    return !thisIsAlreadyExecuted && subsequentCommand.asA<RemoveElementCommand>();
 }
 
 void babelwires::RemoveElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(dynamic_cast<const RemoveElementCommand*>(subsequentCommand.get()) && "subsume should not have been called");
+    assert(subsequentCommand->asA<RemoveElementCommand>() && "subsume should not have been called");
     RemoveElementCommand* removeElementCommand = static_cast<RemoveElementCommand*>(subsequentCommand.get());
     m_elementIds.insert(m_elementIds.end(), removeElementCommand->m_elementIds.begin(),
                         removeElementCommand->m_elementIds.end());

--- a/BabelWires/Commands/removeEntryFromArrayCommand.cpp
+++ b/BabelWires/Commands/removeEntryFromArrayCommand.cpp
@@ -60,7 +60,7 @@ bool babelwires::RemoveEntryFromArrayCommand::initializeAndExecute(Project& proj
 
     if (const Modifier* modifier = elementToModify->getEdits().findModifier(m_pathToArray)) {
         const auto& modifierData = modifier->getModifierData();
-        if (dynamic_cast<const ArraySizeModifierData*>(&modifier->getModifierData())) {
+        if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/removeEntryFromArrayCommand.cpp
+++ b/BabelWires/Commands/removeEntryFromArrayCommand.cpp
@@ -41,7 +41,7 @@ bool babelwires::RemoveEntryFromArrayCommand::initializeAndExecute(Project& proj
         return false;
     }
 
-    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->asA<const ArrayFeature>();
+    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->as<const ArrayFeature>();
     if (!arrayFeature) {
         return false;
     }
@@ -60,7 +60,7 @@ bool babelwires::RemoveEntryFromArrayCommand::initializeAndExecute(Project& proj
 
     if (const Modifier* modifier = elementToModify->getEdits().findModifier(m_pathToArray)) {
         const auto& modifierData = modifier->getModifierData();
-        if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
+        if (modifier->getModifierData().as<ArraySizeModifierData>()) {
             m_wasModifier = true;
         }
     }

--- a/BabelWires/Commands/removeEntryFromArrayCommand.cpp
+++ b/BabelWires/Commands/removeEntryFromArrayCommand.cpp
@@ -41,7 +41,7 @@ bool babelwires::RemoveEntryFromArrayCommand::initializeAndExecute(Project& proj
         return false;
     }
 
-    auto arrayFeature = dynamic_cast<const ArrayFeature*>(m_pathToArray.tryFollow(*inputFeature));
+    auto arrayFeature = m_pathToArray.tryFollow(*inputFeature)->asA<const ArrayFeature>();
     if (!arrayFeature) {
         return false;
     }

--- a/BabelWires/Commands/removeModifierCommand.cpp
+++ b/BabelWires/Commands/removeModifierCommand.cpp
@@ -48,7 +48,7 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
 
     // TODO: There should be a way to move this to a virtual function on modifiers, so these modifiers know how to
     // remove themselves cleanly.
-    if (dynamic_cast<const ArraySizeModifierData*>(&modifier->getModifierData())) {
+    if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
         if (auto arrayFeature = path.tryFollow(*inputFeature)->asA<const ArrayFeature>()) {
             const int numEntriesToRemove = arrayFeature->getNumFeatures() - arrayFeature->getSizeRange().m_min;
             if (numEntriesToRemove > 0) {
@@ -58,7 +58,7 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
             }
         }
     }
-    else if (dynamic_cast<const ActivateOptionalsModifierData*>(&modifier->getModifierData())) {
+    else if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
         if (auto optionalFeature = path.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>()) {
             for (auto optionalField : optionalFeature->getOptionalFields()) {
                 if (optionalFeature->isActivated(optionalField)) {

--- a/BabelWires/Commands/removeModifierCommand.cpp
+++ b/BabelWires/Commands/removeModifierCommand.cpp
@@ -49,7 +49,7 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
     // TODO: There should be a way to move this to a virtual function on modifiers, so these modifiers know how to
     // remove themselves cleanly.
     if (dynamic_cast<const ArraySizeModifierData*>(&modifier->getModifierData())) {
-        if (auto arrayFeature = dynamic_cast<const ArrayFeature*>(path.tryFollow(*inputFeature))) {
+        if (auto arrayFeature = path.tryFollow(*inputFeature)->asA<const ArrayFeature>()) {
             const int numEntriesToRemove = arrayFeature->getNumFeatures() - arrayFeature->getSizeRange().m_min;
             if (numEntriesToRemove > 0) {
                 const int lastEntryIndex = arrayFeature->getSizeRange().m_min;
@@ -59,7 +59,7 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
         }
     }
     else if (dynamic_cast<const ActivateOptionalsModifierData*>(&modifier->getModifierData())) {
-        if (auto optionalFeature = dynamic_cast<const RecordWithOptionalsFeature*>(path.tryFollow(*inputFeature))) {
+        if (auto optionalFeature = path.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>()) {
             for (auto optionalField : optionalFeature->getOptionalFields()) {
                 if (optionalFeature->isActivated(optionalField)) {
                     addSubCommand(std::make_unique<DeactivateOptionalCommand>("DeactivateOptionalCommand subcommand", elementId, path, optionalField));

--- a/BabelWires/Commands/removeModifierCommand.cpp
+++ b/BabelWires/Commands/removeModifierCommand.cpp
@@ -48,8 +48,8 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
 
     // TODO: There should be a way to move this to a virtual function on modifiers, so these modifiers know how to
     // remove themselves cleanly.
-    if (modifier->getModifierData().asA<ArraySizeModifierData>()) {
-        if (auto arrayFeature = path.tryFollow(*inputFeature)->asA<const ArrayFeature>()) {
+    if (modifier->getModifierData().as<ArraySizeModifierData>()) {
+        if (auto arrayFeature = path.tryFollow(*inputFeature)->as<const ArrayFeature>()) {
             const int numEntriesToRemove = arrayFeature->getNumFeatures() - arrayFeature->getSizeRange().m_min;
             if (numEntriesToRemove > 0) {
                 const int lastEntryIndex = arrayFeature->getSizeRange().m_min;
@@ -58,8 +58,8 @@ bool babelwires::RemoveModifierCommand::initializeAndExecute(Project& project) {
             }
         }
     }
-    else if (modifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
-        if (auto optionalFeature = path.tryFollow(*inputFeature)->asA<const RecordWithOptionalsFeature>()) {
+    else if (modifier->getModifierData().as<ActivateOptionalsModifierData>()) {
+        if (auto optionalFeature = path.tryFollow(*inputFeature)->as<const RecordWithOptionalsFeature>()) {
             for (auto optionalField : optionalFeature->getOptionalFields()) {
                 if (optionalFeature->isActivated(optionalField)) {
                     addSubCommand(std::make_unique<DeactivateOptionalCommand>("DeactivateOptionalCommand subcommand", elementId, path, optionalField));

--- a/BabelWires/Commands/resizeElementCommand.cpp
+++ b/BabelWires/Commands/resizeElementCommand.cpp
@@ -36,7 +36,7 @@ void babelwires::ResizeElementCommand::undo(Project& project) const {
 
 bool babelwires::ResizeElementCommand::shouldSubsume(const Command& subsequentCommand,
                                                      bool thisIsAlreadyExecuted) const {
-    const auto* resizeElementCommand = dynamic_cast<const ResizeElementCommand*>(&subsequentCommand);
+    const auto* resizeElementCommand = subsequentCommand.asA<ResizeElementCommand>();
     if (!resizeElementCommand) {
         return false;
     }
@@ -54,7 +54,7 @@ bool babelwires::ResizeElementCommand::shouldSubsume(const Command& subsequentCo
 }
 
 void babelwires::ResizeElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(dynamic_cast<const ResizeElementCommand*>(subsequentCommand.get()) && "subsume should not have been called");
+    assert(subsequentCommand->asA<ResizeElementCommand>() && "subsume should not have been called");
     ResizeElementCommand* resizeElementCommand = static_cast<ResizeElementCommand*>(subsequentCommand.get());
 
     m_newSize = resizeElementCommand->m_newSize;

--- a/BabelWires/Commands/resizeElementCommand.cpp
+++ b/BabelWires/Commands/resizeElementCommand.cpp
@@ -36,7 +36,7 @@ void babelwires::ResizeElementCommand::undo(Project& project) const {
 
 bool babelwires::ResizeElementCommand::shouldSubsume(const Command& subsequentCommand,
                                                      bool thisIsAlreadyExecuted) const {
-    const auto* resizeElementCommand = subsequentCommand.asA<ResizeElementCommand>();
+    const auto* resizeElementCommand = subsequentCommand.as<ResizeElementCommand>();
     if (!resizeElementCommand) {
         return false;
     }
@@ -54,7 +54,7 @@ bool babelwires::ResizeElementCommand::shouldSubsume(const Command& subsequentCo
 }
 
 void babelwires::ResizeElementCommand::subsume(std::unique_ptr<Command> subsequentCommand) {
-    assert(subsequentCommand->asA<ResizeElementCommand>() && "subsume should not have been called");
+    assert(subsequentCommand->as<ResizeElementCommand>() && "subsume should not have been called");
     ResizeElementCommand* resizeElementCommand = static_cast<ResizeElementCommand*>(subsequentCommand.get());
 
     m_newSize = resizeElementCommand->m_newSize;

--- a/BabelWires/Commands/setExpandedCommand.cpp
+++ b/BabelWires/Commands/setExpandedCommand.cpp
@@ -33,11 +33,11 @@ bool babelwires::SetExpandedCommand::initialize(const Project& project) {
 
     const CompoundFeature* compoundFeature = nullptr;
     if (const Feature* feature = element->getInputFeature()) {
-        compoundFeature = m_pathToCompound.tryFollow(*feature)->asA<const CompoundFeature>();
+        compoundFeature = m_pathToCompound.tryFollow(*feature)->as<const CompoundFeature>();
     }
     if (!compoundFeature) {
         if (const Feature* feature = element->getOutputFeature()) {
-            compoundFeature = m_pathToCompound.tryFollow(*feature)->asA<const CompoundFeature>();
+            compoundFeature = m_pathToCompound.tryFollow(*feature)->as<const CompoundFeature>();
         }
     }
     if (!compoundFeature) {

--- a/BabelWires/Commands/setExpandedCommand.cpp
+++ b/BabelWires/Commands/setExpandedCommand.cpp
@@ -33,11 +33,11 @@ bool babelwires::SetExpandedCommand::initialize(const Project& project) {
 
     const CompoundFeature* compoundFeature = nullptr;
     if (const Feature* feature = element->getInputFeature()) {
-        compoundFeature = dynamic_cast<const CompoundFeature*>(m_pathToCompound.tryFollow(*feature));
+        compoundFeature = m_pathToCompound.tryFollow(*feature)->asA<const CompoundFeature>();
     }
     if (!compoundFeature) {
         if (const Feature* feature = element->getOutputFeature()) {
-            compoundFeature = dynamic_cast<const CompoundFeature*>(m_pathToCompound.tryFollow(*feature));
+            compoundFeature = m_pathToCompound.tryFollow(*feature)->asA<const CompoundFeature>();
         }
     }
     if (!compoundFeature) {

--- a/BabelWires/Features/Path/featurePath.cpp
+++ b/BabelWires/Features/Path/featurePath.cpp
@@ -100,7 +100,7 @@ namespace {
 
     template <typename T> T& followPath(T& start, const babelwires::FeaturePath& p, int& index) {
         if (index < p.getNumSteps()) {
-            if (auto* compound = start.template asA<babelwires::CompoundFeature>()) {
+            if (auto* compound = start.template as<babelwires::CompoundFeature>()) {
                 T& child = compound->getChildFromStep(p.getStep(index));
                 ++index;
                 return followPath(child, p, index);
@@ -136,7 +136,7 @@ namespace {
 
     template <typename T> T* tryFollowPath(T* start, const babelwires::FeaturePath& p, int index = 0) {
         if (index < p.getNumSteps()) {
-            if (auto* compound = start->template asA<babelwires::CompoundFeature>()) {
+            if (auto* compound = start->template as<babelwires::CompoundFeature>()) {
                 T* child = compound->tryGetChildFromStep(p.getStep(index));
                 return tryFollowPath(child, p, index + 1);
             } else {

--- a/BabelWires/Features/Path/featurePath.cpp
+++ b/BabelWires/Features/Path/featurePath.cpp
@@ -99,9 +99,8 @@ babelwires::FeaturePath babelwires::FeaturePath::deserializeFromString(const std
 namespace {
 
     template <typename T> T& followPath(T& start, const babelwires::FeaturePath& p, int& index) {
-        typedef typename babelwires::CopyConst<T, babelwires::CompoundFeature>::type Compound;
         if (index < p.getNumSteps()) {
-            if (Compound* compound = dynamic_cast<Compound*>(&start)) {
+            if (auto* compound = start.template asA<babelwires::CompoundFeature>()) {
                 T& child = compound->getChildFromStep(p.getStep(index));
                 ++index;
                 return followPath(child, p, index);
@@ -136,9 +135,8 @@ const babelwires::Feature& babelwires::FeaturePath::follow(const Feature& start)
 namespace {
 
     template <typename T> T* tryFollowPath(T* start, const babelwires::FeaturePath& p, int index = 0) {
-        typedef typename babelwires::CopyConst<T, babelwires::CompoundFeature>::type Compound;
         if (index < p.getNumSteps()) {
-            if (Compound* compound = dynamic_cast<Compound*>(start)) {
+            if (auto* compound = start->template asA<babelwires::CompoundFeature>()) {
                 T* child = compound->tryGetChildFromStep(p.getStep(index));
                 return tryFollowPath(child, p, index + 1);
             } else {

--- a/BabelWires/Features/Utilities/featureXml.cpp
+++ b/BabelWires/Features/Utilities/featureXml.cpp
@@ -65,15 +65,15 @@ namespace {
         }
 
         void featureToXml(const babelwires::Feature& feature) {
-            if (auto intFeature = feature.asA<const babelwires::IntFeature>()) {
+            if (auto intFeature = feature.as<const babelwires::IntFeature>()) {
                 intFeatureToXml(*intFeature);
-            } else if (auto ratFeature = feature.asA<const babelwires::RationalFeature>()) {
+            } else if (auto ratFeature = feature.as<const babelwires::RationalFeature>()) {
                 rationalFeatureToXml(*ratFeature);
-            } else if (auto stringFeature = feature.asA<const babelwires::StringFeature>()) {
+            } else if (auto stringFeature = feature.as<const babelwires::StringFeature>()) {
                 stringFeatureToXml(*stringFeature);
-            } else if (auto recordFeature = feature.asA<const babelwires::RecordFeature>()) {
+            } else if (auto recordFeature = feature.as<const babelwires::RecordFeature>()) {
                 recordFeatureToXml(*recordFeature);
-            } else if (auto arrayFeature = feature.asA<const babelwires::ArrayFeature>()) {
+            } else if (auto arrayFeature = feature.as<const babelwires::ArrayFeature>()) {
                 arrayFeatureToXml(*arrayFeature);
             } else {
                 assert(!"Unrecognized feature encountered");

--- a/BabelWires/Features/Utilities/featureXml.cpp
+++ b/BabelWires/Features/Utilities/featureXml.cpp
@@ -65,15 +65,15 @@ namespace {
         }
 
         void featureToXml(const babelwires::Feature& feature) {
-            if (auto intFeature = dynamic_cast<const babelwires::IntFeature*>(&feature)) {
+            if (auto intFeature = feature.asA<const babelwires::IntFeature>()) {
                 intFeatureToXml(*intFeature);
-            } else if (auto ratFeature = dynamic_cast<const babelwires::RationalFeature*>(&feature)) {
+            } else if (auto ratFeature = feature.asA<const babelwires::RationalFeature>()) {
                 rationalFeatureToXml(*ratFeature);
-            } else if (auto stringFeature = dynamic_cast<const babelwires::StringFeature*>(&feature)) {
+            } else if (auto stringFeature = feature.asA<const babelwires::StringFeature>()) {
                 stringFeatureToXml(*stringFeature);
-            } else if (auto recordFeature = dynamic_cast<const babelwires::RecordFeature*>(&feature)) {
+            } else if (auto recordFeature = feature.asA<const babelwires::RecordFeature>()) {
                 recordFeatureToXml(*recordFeature);
-            } else if (auto arrayFeature = dynamic_cast<const babelwires::ArrayFeature*>(&feature)) {
+            } else if (auto arrayFeature = feature.asA<const babelwires::ArrayFeature>()) {
                 arrayFeatureToXml(*arrayFeature);
             } else {
                 assert(!"Unrecognized feature encountered");

--- a/BabelWires/Features/features.hpp
+++ b/BabelWires/Features/features.hpp
@@ -28,6 +28,8 @@ namespace babelwires {
     /// Features are structured in a tree, which also defines ownership.
     class Feature {
       public:
+        DOWNCASTABLE_TYPE_HIERARCHY(Feature);
+
         Feature() = default;
         virtual ~Feature();
 
@@ -54,14 +56,6 @@ namespace babelwires {
         /// Get a hash of the feature contents _of a feature of this type_.
         /// This is not required to distinguish the contents of features of different types.
         std::size_t getHash() const;
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<Feature, T>, std::nullptr_t> = nullptr>
-        T* asA() { return dynamic_cast<T*>(this); }
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<Feature, T>, std::nullptr_t> = nullptr>
-        const T* asA() const { return dynamic_cast<const T*>(this); }
 
       protected:
         /// Set the isChanged flag and that of all parents.

--- a/BabelWires/Features/features.hpp
+++ b/BabelWires/Features/features.hpp
@@ -55,6 +55,14 @@ namespace babelwires {
         /// This is not required to distinguish the contents of features of different types.
         std::size_t getHash() const;
 
+        /// Return a pointer to a T if this is a T, otherwise return nullptr.
+        template <typename T, std::enable_if_t<std::is_base_of_v<Feature, T>, std::nullptr_t> = nullptr>
+        T* asA() { return dynamic_cast<T*>(this); }
+
+        /// Return a pointer to a T if this is a T, otherwise return nullptr.
+        template <typename T, std::enable_if_t<std::is_base_of_v<Feature, T>, std::nullptr_t> = nullptr>
+        const T* asA() const { return dynamic_cast<const T*>(this); }
+
       protected:
         /// Set the isChanged flag and that of all parents.
         void setChanged(Changes changes);

--- a/BabelWires/Features/heavyValueFeature_inl.hpp
+++ b/BabelWires/Features/heavyValueFeature_inl.hpp
@@ -35,7 +35,7 @@ template <typename T> void babelwires::HeavyValueFeature<T>::set(std::unique_ptr
 }
 
 template <typename T> void babelwires::HeavyValueFeature<T>::doAssign(const ValueFeature& other) {
-    assert(dynamic_cast<const HeavyValueFeature<T>*>(&other) && "Other is not a compatible type");
+    assert(other.asA<HeavyValueFeature<T>>() && "Other is not a compatible type");
     const babelwires::HeavyValueFeature<T>& otherH = static_cast<const babelwires::HeavyValueFeature<T>&>(other);
     if (otherH.m_value != m_value) {
         if (*otherH.m_value != *m_value) {

--- a/BabelWires/Features/heavyValueFeature_inl.hpp
+++ b/BabelWires/Features/heavyValueFeature_inl.hpp
@@ -35,7 +35,7 @@ template <typename T> void babelwires::HeavyValueFeature<T>::set(std::unique_ptr
 }
 
 template <typename T> void babelwires::HeavyValueFeature<T>::doAssign(const ValueFeature& other) {
-    assert(other.asA<HeavyValueFeature<T>>() && "Other is not a compatible type");
+    assert(other.as<HeavyValueFeature<T>>() && "Other is not a compatible type");
     const babelwires::HeavyValueFeature<T>& otherH = static_cast<const babelwires::HeavyValueFeature<T>&>(other);
     if (otherH.m_value != m_value) {
         if (*otherH.m_value != *m_value) {

--- a/BabelWires/Features/numericFeature_inl.hpp
+++ b/BabelWires/Features/numericFeature_inl.hpp
@@ -36,7 +36,7 @@ template <typename T> void babelwires::NumericFeature<T>::doSetToDefault() {
 }
 
 template <typename T> void babelwires::NumericFeature<T>::doAssign(const ValueFeature& other) {
-    const NumericFeature<T>& otherNum = *other.asA<NumericFeature<T>>();
+    const NumericFeature<T>& otherNum = *other.as<NumericFeature<T>>();
     set(otherNum.get());
 }
 

--- a/BabelWires/Features/numericFeature_inl.hpp
+++ b/BabelWires/Features/numericFeature_inl.hpp
@@ -36,7 +36,7 @@ template <typename T> void babelwires::NumericFeature<T>::doSetToDefault() {
 }
 
 template <typename T> void babelwires::NumericFeature<T>::doAssign(const ValueFeature& other) {
-    const NumericFeature<T>& otherNum = dynamic_cast<const NumericFeature<T>&>(other);
+    const NumericFeature<T>& otherNum = *other.asA<NumericFeature<T>>();
     set(otherNum.get());
 }
 

--- a/BabelWires/Features/stringFeature.cpp
+++ b/BabelWires/Features/stringFeature.cpp
@@ -27,7 +27,7 @@ std::string babelwires::StringFeature::doGetValueType() const {
 }
 
 void babelwires::StringFeature::doAssign(const ValueFeature& other) {
-    const auto& otherString = *other.asA<StringFeature>();
+    const auto& otherString = *other.as<StringFeature>();
     set(otherString.get());
 }
 

--- a/BabelWires/Features/stringFeature.cpp
+++ b/BabelWires/Features/stringFeature.cpp
@@ -27,7 +27,7 @@ std::string babelwires::StringFeature::doGetValueType() const {
 }
 
 void babelwires::StringFeature::doAssign(const ValueFeature& other) {
-    const auto& otherString = dynamic_cast<const StringFeature&>(other);
+    const auto& otherString = *other.asA<StringFeature>();
     set(otherString.get());
 }
 

--- a/BabelWires/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWires/Project/FeatureElements/contentsCache.cpp
@@ -62,9 +62,9 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), f, nullptr, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* record = f->asA<const babelwires::RecordFeature>()) {
+            if (const auto* record = f->as<const babelwires::RecordFeature>()) {
                 addInputRecordFeatureToCache(record, path, thisIndex);
-            } else if (const auto* array = f->asA<const babelwires::ArrayFeature>()) {
+            } else if (const auto* array = f->as<const babelwires::ArrayFeature>()) {
                 addInputArrayFeatureToCache(array, path, thisIndex);
             }
         }
@@ -101,9 +101,9 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), nullptr, f, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* record = f->asA<const babelwires::RecordFeature>()) {
+            if (const auto* record = f->as<const babelwires::RecordFeature>()) {
                 addOutputRecordFeatureToCache(record, path, thisIndex);
-            } else if (const auto* array = f->asA<const babelwires::ArrayFeature>()) {
+            } else if (const auto* array = f->as<const babelwires::ArrayFeature>()) {
                 addOutputArrayFeatureToCache(array, path, thisIndex);
             }
         }
@@ -140,12 +140,12 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), inputFeature, outputFeature, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* const inputRecord = inputFeature->asA<const babelwires::RecordFeature>()) {
-                const auto* const outputRecord = outputFeature->asA<const babelwires::RecordFeature>();
+            if (const auto* const inputRecord = inputFeature->as<const babelwires::RecordFeature>()) {
+                const auto* const outputRecord = outputFeature->as<const babelwires::RecordFeature>();
                 assert(outputRecord && "If the input is a record, the output must be a record too");
                 addRecordContentsToCache(inputRecord, outputRecord, path, thisIndex);
-            } else if (const auto* const inputArray = inputFeature->asA<const babelwires::ArrayFeature>()) {
-                const auto* const outputArray = outputFeature->asA<const babelwires::ArrayFeature>();
+            } else if (const auto* const inputArray = inputFeature->as<const babelwires::ArrayFeature>()) {
+                const auto* const outputArray = outputFeature->as<const babelwires::ArrayFeature>();
                 assert(outputArray && "If the input is an array, the output must be an array too");
                 addArrayContentsToCache(inputArray, outputArray, path, thisIndex);
             }
@@ -220,7 +220,7 @@ void babelwires::ContentsCache::setFeatures(const babelwires::Feature* inputFeat
     m_rows.clear();
     ContentsCacheBuilder builder(m_rows, m_edits);
     const babelwires::Feature* const rootFeature = inputFeature ? inputFeature : outputFeature;
-    const char* rootLabel = rootFeature->asA<const babelwires::FileFeature>() ? "File" : "Root";
+    const char* rootLabel = rootFeature->as<const babelwires::FileFeature>() ? "File" : "Root";
     if (inputFeature && outputFeature) {
         builder.addFeatureToCache(rootLabel, inputFeature, outputFeature, FeaturePath(),
                                   ContentsCacheEntry::c_invalidIndex);
@@ -246,7 +246,7 @@ void babelwires::ContentsCache::setIndexOffset() {
     const ContentsCacheEntry& rootEntry = m_rows[0];
     const babelwires::Feature* const rootFeature = rootEntry.getInputThenOutputFeature();
     m_indexOffset =
-        (rootEntry.m_hasFailedHiddenModifiers || rootFeature->asA<const babelwires::FileFeature>()) ? 0 : 1;
+        (rootEntry.m_hasFailedHiddenModifiers || rootFeature->as<const babelwires::FileFeature>()) ? 0 : 1;
     if (oldIndexOffset != m_indexOffset) {
         setChanged(Changes::StructureChanged);
     }

--- a/BabelWires/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWires/Project/FeatureElements/contentsCache.cpp
@@ -62,9 +62,9 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), f, nullptr, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* record = dynamic_cast<const babelwires::RecordFeature*>(f)) {
+            if (const auto* record = f->asA<const babelwires::RecordFeature>()) {
                 addInputRecordFeatureToCache(record, path, thisIndex);
-            } else if (const auto* array = dynamic_cast<const babelwires::ArrayFeature*>(f)) {
+            } else if (const auto* array = f->asA<const babelwires::ArrayFeature>()) {
                 addInputArrayFeatureToCache(array, path, thisIndex);
             }
         }
@@ -101,9 +101,9 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), nullptr, f, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* record = dynamic_cast<const babelwires::RecordFeature*>(f)) {
+            if (const auto* record = f->asA<const babelwires::RecordFeature>()) {
                 addOutputRecordFeatureToCache(record, path, thisIndex);
-            } else if (const auto* array = dynamic_cast<const babelwires::ArrayFeature*>(f)) {
+            } else if (const auto* array = f->asA<const babelwires::ArrayFeature>()) {
                 addOutputArrayFeatureToCache(array, path, thisIndex);
             }
         }
@@ -140,12 +140,12 @@ namespace {
             }
             m_rows.emplace_back(ContentsCacheEntry(std::move(label), inputFeature, outputFeature, path, parentIndex));
             const std::uint8_t thisIndex = m_rows.size() - 1;
-            if (const auto* const inputRecord = dynamic_cast<const babelwires::RecordFeature*>(inputFeature)) {
-                const auto* const outputRecord = dynamic_cast<const babelwires::RecordFeature*>(outputFeature);
+            if (const auto* const inputRecord = inputFeature->asA<const babelwires::RecordFeature>()) {
+                const auto* const outputRecord = outputFeature->asA<const babelwires::RecordFeature>();
                 assert(outputRecord && "If the input is a record, the output must be a record too");
                 addRecordContentsToCache(inputRecord, outputRecord, path, thisIndex);
-            } else if (const auto* const inputArray = dynamic_cast<const babelwires::ArrayFeature*>(inputFeature)) {
-                const auto* const outputArray = dynamic_cast<const babelwires::ArrayFeature*>(outputFeature);
+            } else if (const auto* const inputArray = inputFeature->asA<const babelwires::ArrayFeature>()) {
+                const auto* const outputArray = outputFeature->asA<const babelwires::ArrayFeature>();
                 assert(outputArray && "If the input is an array, the output must be an array too");
                 addArrayContentsToCache(inputArray, outputArray, path, thisIndex);
             }
@@ -220,7 +220,7 @@ void babelwires::ContentsCache::setFeatures(const babelwires::Feature* inputFeat
     m_rows.clear();
     ContentsCacheBuilder builder(m_rows, m_edits);
     const babelwires::Feature* const rootFeature = inputFeature ? inputFeature : outputFeature;
-    const char* rootLabel = dynamic_cast<const babelwires::FileFeature*>(rootFeature) ? "File" : "Root";
+    const char* rootLabel = rootFeature->asA<const babelwires::FileFeature>() ? "File" : "Root";
     if (inputFeature && outputFeature) {
         builder.addFeatureToCache(rootLabel, inputFeature, outputFeature, FeaturePath(),
                                   ContentsCacheEntry::c_invalidIndex);
@@ -246,7 +246,7 @@ void babelwires::ContentsCache::setIndexOffset() {
     const ContentsCacheEntry& rootEntry = m_rows[0];
     const babelwires::Feature* const rootFeature = rootEntry.getInputThenOutputFeature();
     m_indexOffset =
-        (rootEntry.m_hasFailedHiddenModifiers || dynamic_cast<const babelwires::FileFeature*>(rootFeature)) ? 0 : 1;
+        (rootEntry.m_hasFailedHiddenModifiers || rootFeature->asA<const babelwires::FileFeature>()) ? 0 : 1;
     if (oldIndexOffset != m_indexOffset) {
         setChanged(Changes::StructureChanged);
     }

--- a/BabelWires/Project/FeatureElements/editTree_inl.hpp
+++ b/BabelWires/Project/FeatureElements/editTree_inl.hpp
@@ -77,7 +77,7 @@ template <typename EDIT_TREE, typename MODIFIER_TYPE> struct babelwires::EditTre
     }
     typename CopyConst<EDIT_TREE, MODIFIER_TYPE>::type* operator*() {
         auto* currentModifier = m_tree.m_nodes[m_index].m_modifier.get();
-        assert(dynamic_cast<MODIFIER_TYPE*>(currentModifier) && "The filter isn't working");
+        assert(currentModifier->template asA<MODIFIER_TYPE>() && "The filter isn't working");
         return static_cast<MODIFIER_TYPE*>(currentModifier);
     }
 

--- a/BabelWires/Project/FeatureElements/editTree_inl.hpp
+++ b/BabelWires/Project/FeatureElements/editTree_inl.hpp
@@ -77,7 +77,7 @@ template <typename EDIT_TREE, typename MODIFIER_TYPE> struct babelwires::EditTre
     }
     typename CopyConst<EDIT_TREE, MODIFIER_TYPE>::type* operator*() {
         auto* currentModifier = m_tree.m_nodes[m_index].m_modifier.get();
-        assert(currentModifier->template asA<MODIFIER_TYPE>() && "The filter isn't working");
+        assert(currentModifier->template as<MODIFIER_TYPE>() && "The filter isn't working");
         return static_cast<MODIFIER_TYPE*>(currentModifier);
     }
 

--- a/BabelWires/Project/FeatureElements/featureElement.hpp
+++ b/BabelWires/Project/FeatureElements/featureElement.hpp
@@ -35,6 +35,8 @@ namespace babelwires {
     /// FeatureElements expose input and output Features, and carry edits.
     class FeatureElement {
       public:
+        DOWNCASTABLE_TYPE_HIERARCHY(FeatureElement);
+
         FeatureElement(const ElementData& data, ElementId newId);
         virtual ~FeatureElement();
 

--- a/BabelWires/Project/FeatureElements/featureElementData.hpp
+++ b/BabelWires/Project/FeatureElements/featureElementData.hpp
@@ -53,6 +53,7 @@ namespace babelwires {
         CLONEABLE_ABSTRACT(ElementData);
         CUSTOM_CLONEABLE_ABSTRACT(ElementData);
         SERIALIZABLE_ABSTRACT(ElementData, "ElementData", void);
+        DOWNCASTABLE_TYPE_HIERARCHY(ElementData);
 
         ElementData() = default;
 

--- a/BabelWires/Project/FeatureElements/targetFileElement.cpp
+++ b/BabelWires/Project/FeatureElements/targetFileElement.cpp
@@ -104,7 +104,7 @@ bool babelwires::TargetFileElement::save(const ProjectContext& context, UserLogg
     }
     try {
         OutFileStream outStream(data.m_filePath);
-        const auto* fileFeature = m_feature.get()->asA<FileFeature>();
+        const auto* fileFeature = m_feature.get()->as<FileFeature>();
         const TargetFileFormat* format = context.m_targetFileFormatReg.getEntryByIdentifier(data.m_factoryIdentifier);
         assert(format && "FileFeature with unregistered file format");
         format->writeToFile(*fileFeature, outStream, userLogger);

--- a/BabelWires/Project/FeatureElements/targetFileElement.cpp
+++ b/BabelWires/Project/FeatureElements/targetFileElement.cpp
@@ -104,10 +104,10 @@ bool babelwires::TargetFileElement::save(const ProjectContext& context, UserLogg
     }
     try {
         OutFileStream outStream(data.m_filePath);
-        const auto& fileFeature = dynamic_cast<const FileFeature&>(*m_feature.get());
+        const auto* fileFeature = m_feature.get()->asA<FileFeature>();
         const TargetFileFormat* format = context.m_targetFileFormatReg.getEntryByIdentifier(data.m_factoryIdentifier);
         assert(format && "FileFeature with unregistered file format");
-        format->writeToFile(fileFeature, outStream, userLogger);
+        format->writeToFile(*fileFeature, outStream, userLogger);
         outStream.close();
         if (m_saveHashWhenSaved != m_saveHash) {
             setChanged(Changes::FeatureElementLabelChanged);

--- a/BabelWires/Project/Modifiers/activateOptionalsModifierData.cpp
+++ b/BabelWires/Project/Modifiers/activateOptionalsModifierData.cpp
@@ -23,7 +23,7 @@ void babelwires::ActivateOptionalsModifierData::deserializeContents(Deserializer
 }
 
 void babelwires::ActivateOptionalsModifierData::apply(Feature* targetFeature) const {
-    RecordWithOptionalsFeature* record = dynamic_cast<RecordWithOptionalsFeature*>(targetFeature);
+    RecordWithOptionalsFeature* record = targetFeature->asA<RecordWithOptionalsFeature>();
     if (!record) {
         throw ModelException() << "Cannot selection optionals from a feature which does not have optionals";
     }

--- a/BabelWires/Project/Modifiers/activateOptionalsModifierData.cpp
+++ b/BabelWires/Project/Modifiers/activateOptionalsModifierData.cpp
@@ -23,7 +23,7 @@ void babelwires::ActivateOptionalsModifierData::deserializeContents(Deserializer
 }
 
 void babelwires::ActivateOptionalsModifierData::apply(Feature* targetFeature) const {
-    RecordWithOptionalsFeature* record = targetFeature->asA<RecordWithOptionalsFeature>();
+    RecordWithOptionalsFeature* record = targetFeature->as<RecordWithOptionalsFeature>();
     if (!record) {
         throw ModelException() << "Cannot selection optionals from a feature which does not have optionals";
     }

--- a/BabelWires/Project/Modifiers/arraySizeModifier.cpp
+++ b/BabelWires/Project/Modifiers/arraySizeModifier.cpp
@@ -22,11 +22,11 @@ babelwires::ArraySizeModifier::ArraySizeModifier(const ArraySizeModifier& other)
     : LocalModifier(other) {}
 
 const babelwires::ArraySizeModifierData& babelwires::ArraySizeModifier::getModifierData() const {
-    return dynamic_cast<const babelwires::ArraySizeModifierData&>(Modifier::getModifierData());
+    return *Modifier::getModifierData().asA<babelwires::ArraySizeModifierData>();
 }
 
 babelwires::ArraySizeModifierData& babelwires::ArraySizeModifier::getModifierData() {
-    return dynamic_cast<babelwires::ArraySizeModifierData&>(Modifier::getModifierData());
+    return *Modifier::getModifierData().asA<babelwires::ArraySizeModifierData>();
 }
 
 bool babelwires::ArraySizeModifier::addArrayEntries(UserLogger& userLogger, Feature* container, int indexOfNewElement,

--- a/BabelWires/Project/Modifiers/arraySizeModifier.cpp
+++ b/BabelWires/Project/Modifiers/arraySizeModifier.cpp
@@ -22,11 +22,11 @@ babelwires::ArraySizeModifier::ArraySizeModifier(const ArraySizeModifier& other)
     : LocalModifier(other) {}
 
 const babelwires::ArraySizeModifierData& babelwires::ArraySizeModifier::getModifierData() const {
-    return *Modifier::getModifierData().asA<babelwires::ArraySizeModifierData>();
+    return *Modifier::getModifierData().as<babelwires::ArraySizeModifierData>();
 }
 
 babelwires::ArraySizeModifierData& babelwires::ArraySizeModifier::getModifierData() {
-    return *Modifier::getModifierData().asA<babelwires::ArraySizeModifierData>();
+    return *Modifier::getModifierData().as<babelwires::ArraySizeModifierData>();
 }
 
 bool babelwires::ArraySizeModifier::addArrayEntries(UserLogger& userLogger, Feature* container, int indexOfNewElement,

--- a/BabelWires/Project/Modifiers/arraySizeModifierData.cpp
+++ b/BabelWires/Project/Modifiers/arraySizeModifierData.cpp
@@ -17,7 +17,7 @@
 #include "Common/Serialization/serializer.hpp"
 
 void babelwires::ArraySizeModifierData::apply(Feature* targetFeature) const {
-    if (ArrayFeature* array = dynamic_cast<ArrayFeature*>(targetFeature)) {
+    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
         array->setSize(m_size);
     } else {
         throw babelwires::ModelException() << "Cannot initialize size of non-array";
@@ -42,7 +42,7 @@ void babelwires::ArraySizeModifierData::addEntries(Feature* targetFeature, int i
                                                      int numEntriesToAdd) {
     assert((numEntriesToAdd > 0) && "numEntriesToAdd must be strictly positive");
     m_size += numEntriesToAdd;
-    if (ArrayFeature* array = dynamic_cast<ArrayFeature*>(targetFeature)) {
+    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
         for (int i = 0; i < numEntriesToAdd; ++i) {
             array->addEntry(indexOfNewElement);
         }
@@ -56,7 +56,7 @@ void babelwires::ArraySizeModifierData::removeEntries(Feature* targetFeature, in
     assert((numEntriesToRemove > 0) && "numEntriesToRemove must be strictly positive");
     assert((m_size >= numEntriesToRemove) && "You can't have ArraySizeModifierData with negative size");
     m_size -= numEntriesToRemove;
-    if (ArrayFeature* array = dynamic_cast<ArrayFeature*>(targetFeature)) {
+    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
         for (int i = 0; i < numEntriesToRemove; ++i) {
             array->removeEntry(indexOfElementToRemove);
         }

--- a/BabelWires/Project/Modifiers/arraySizeModifierData.cpp
+++ b/BabelWires/Project/Modifiers/arraySizeModifierData.cpp
@@ -17,7 +17,7 @@
 #include "Common/Serialization/serializer.hpp"
 
 void babelwires::ArraySizeModifierData::apply(Feature* targetFeature) const {
-    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
+    if (ArrayFeature* array = targetFeature->as<ArrayFeature>()) {
         array->setSize(m_size);
     } else {
         throw babelwires::ModelException() << "Cannot initialize size of non-array";
@@ -42,7 +42,7 @@ void babelwires::ArraySizeModifierData::addEntries(Feature* targetFeature, int i
                                                      int numEntriesToAdd) {
     assert((numEntriesToAdd > 0) && "numEntriesToAdd must be strictly positive");
     m_size += numEntriesToAdd;
-    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
+    if (ArrayFeature* array = targetFeature->as<ArrayFeature>()) {
         for (int i = 0; i < numEntriesToAdd; ++i) {
             array->addEntry(indexOfNewElement);
         }
@@ -56,7 +56,7 @@ void babelwires::ArraySizeModifierData::removeEntries(Feature* targetFeature, in
     assert((numEntriesToRemove > 0) && "numEntriesToRemove must be strictly positive");
     assert((m_size >= numEntriesToRemove) && "You can't have ArraySizeModifierData with negative size");
     m_size -= numEntriesToRemove;
-    if (ArrayFeature* array = targetFeature->asA<ArrayFeature>()) {
+    if (ArrayFeature* array = targetFeature->as<ArrayFeature>()) {
         for (int i = 0; i < numEntriesToRemove; ++i) {
             array->removeEntry(indexOfElementToRemove);
         }

--- a/BabelWires/Project/Modifiers/connectionModifier.cpp
+++ b/BabelWires/Project/Modifiers/connectionModifier.cpp
@@ -23,13 +23,13 @@ babelwires::ConnectionModifier::ConnectionModifier(const ConnectionModifier& oth
     : Modifier(other) {}
 
 const babelwires::ConnectionModifierData& babelwires::ConnectionModifier::getModifierData() const {
-    assert(Modifier::getModifierData().asA<babelwires::ConnectionModifierData>() &&
+    assert(Modifier::getModifierData().as<babelwires::ConnectionModifierData>() &&
            "Holding wrong kind of data");
     return static_cast<const babelwires::ConnectionModifierData&>(Modifier::getModifierData());
 }
 
 babelwires::ConnectionModifierData& babelwires::ConnectionModifier::getModifierData() {
-    assert(Modifier::getModifierData().asA<babelwires::ConnectionModifierData>() &&
+    assert(Modifier::getModifierData().as<babelwires::ConnectionModifierData>() &&
            "Holding wrong kind of data");
     return static_cast<babelwires::ConnectionModifierData&>(Modifier::getModifierData());
 }

--- a/BabelWires/Project/Modifiers/connectionModifier.cpp
+++ b/BabelWires/Project/Modifiers/connectionModifier.cpp
@@ -23,13 +23,13 @@ babelwires::ConnectionModifier::ConnectionModifier(const ConnectionModifier& oth
     : Modifier(other) {}
 
 const babelwires::ConnectionModifierData& babelwires::ConnectionModifier::getModifierData() const {
-    assert(dynamic_cast<const babelwires::ConnectionModifierData*>(&Modifier::getModifierData()) &&
+    assert(Modifier::getModifierData().asA<babelwires::ConnectionModifierData>() &&
            "Holding wrong kind of data");
     return static_cast<const babelwires::ConnectionModifierData&>(Modifier::getModifierData());
 }
 
 babelwires::ConnectionModifierData& babelwires::ConnectionModifier::getModifierData() {
-    assert(dynamic_cast<const babelwires::ConnectionModifierData*>(&Modifier::getModifierData()) &&
+    assert(Modifier::getModifierData().asA<babelwires::ConnectionModifierData>() &&
            "Holding wrong kind of data");
     return static_cast<babelwires::ConnectionModifierData&>(Modifier::getModifierData());
 }

--- a/BabelWires/Project/Modifiers/connectionModifierData.cpp
+++ b/BabelWires/Project/Modifiers/connectionModifierData.cpp
@@ -53,12 +53,12 @@ void babelwires::ConnectionModifierData::apply(const Feature* sourceFeature, Fea
         return;
     }
 
-    auto targetValueFeature = dynamic_cast<babelwires::ValueFeature*>(targetFeature);
+    auto targetValueFeature = targetFeature->asA<babelwires::ValueFeature>();
     if (!targetValueFeature) {
         throw babelwires::ModelException() << "Cannot modify a non-value field";
     }
 
-    auto sourceValueFeature = dynamic_cast<const babelwires::ValueFeature*>(sourceFeature);
+    auto sourceValueFeature = sourceFeature->asA<const babelwires::ValueFeature>();
     if (!sourceValueFeature) {
         throw babelwires::ModelException()
             << "Cannot apply from the non-value field at " << m_pathToSourceFeature << " in element id=" << m_sourceId;

--- a/BabelWires/Project/Modifiers/connectionModifierData.cpp
+++ b/BabelWires/Project/Modifiers/connectionModifierData.cpp
@@ -53,12 +53,12 @@ void babelwires::ConnectionModifierData::apply(const Feature* sourceFeature, Fea
         return;
     }
 
-    auto targetValueFeature = targetFeature->asA<babelwires::ValueFeature>();
+    auto targetValueFeature = targetFeature->as<babelwires::ValueFeature>();
     if (!targetValueFeature) {
         throw babelwires::ModelException() << "Cannot modify a non-value field";
     }
 
-    auto sourceValueFeature = sourceFeature->asA<const babelwires::ValueFeature>();
+    auto sourceValueFeature = sourceFeature->as<const babelwires::ValueFeature>();
     if (!sourceValueFeature) {
         throw babelwires::ModelException()
             << "Cannot apply from the non-value field at " << m_pathToSourceFeature << " in element id=" << m_sourceId;

--- a/BabelWires/Project/Modifiers/localModifier.cpp
+++ b/BabelWires/Project/Modifiers/localModifier.cpp
@@ -22,11 +22,11 @@ babelwires::LocalModifier::LocalModifier(const LocalModifier& other)
     : Modifier(other) {}
 
 const babelwires::LocalModifierData& babelwires::LocalModifier::getModifierData() const {
-    return *Modifier::getModifierData().asA<babelwires::LocalModifierData>();
+    return *Modifier::getModifierData().as<babelwires::LocalModifierData>();
 }
 
 babelwires::LocalModifierData& babelwires::LocalModifier::getModifierData() {
-    return *Modifier::getModifierData().asA<babelwires::LocalModifierData>();
+    return *Modifier::getModifierData().as<babelwires::LocalModifierData>();
 }
 
 const babelwires::ConnectionModifier* babelwires::LocalModifier::doAsConnectionModifier() const {

--- a/BabelWires/Project/Modifiers/localModifier.cpp
+++ b/BabelWires/Project/Modifiers/localModifier.cpp
@@ -22,11 +22,11 @@ babelwires::LocalModifier::LocalModifier(const LocalModifier& other)
     : Modifier(other) {}
 
 const babelwires::LocalModifierData& babelwires::LocalModifier::getModifierData() const {
-    return dynamic_cast<const babelwires::LocalModifierData&>(Modifier::getModifierData());
+    return *Modifier::getModifierData().asA<babelwires::LocalModifierData>();
 }
 
 babelwires::LocalModifierData& babelwires::LocalModifier::getModifierData() {
-    return dynamic_cast<babelwires::LocalModifierData&>(Modifier::getModifierData());
+    return *Modifier::getModifierData().asA<babelwires::LocalModifierData>();
 }
 
 const babelwires::ConnectionModifier* babelwires::LocalModifier::doAsConnectionModifier() const {

--- a/BabelWires/Project/Modifiers/modifier.hpp
+++ b/BabelWires/Project/Modifiers/modifier.hpp
@@ -29,11 +29,12 @@ namespace babelwires {
     /// A Modifier changes the value of a feature in a FeatureElement, and corresponds to a user edit.
     class Modifier : public Cloneable {
       public:
+        CLONEABLE_ABSTRACT(Modifier);
+        DOWNCASTABLE_TYPE_HIERARCHY(Modifier);
+
         Modifier(std::unique_ptr<ModifierData> modifierData);
         Modifier(const Modifier& other);
         virtual ~Modifier();
-
-        CLONEABLE_ABSTRACT(Modifier);
 
         /// Describes whether the modifier succeeded or the type of failure.
         enum class State : unsigned int {

--- a/BabelWires/Project/Modifiers/modifierData.cpp
+++ b/BabelWires/Project/Modifiers/modifierData.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<babelwires::Modifier> babelwires::LocalModifierData::createModif
 }
 
 void babelwires::IntValueAssignmentData::apply(Feature* targetFeature) const {
-    if (IntFeature* intFeature = targetFeature->asA<IntFeature>()) {
+    if (IntFeature* intFeature = targetFeature->as<IntFeature>()) {
         intFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign an int to a non-int feature";
@@ -57,7 +57,7 @@ void babelwires::IntValueAssignmentData::deserializeContents(Deserializer& deser
 }
 
 void babelwires::RationalValueAssignmentData::apply(Feature* targetFeature) const {
-    if (RationalFeature* rationalFeature = targetFeature->asA<RationalFeature>()) {
+    if (RationalFeature* rationalFeature = targetFeature->as<RationalFeature>()) {
         rationalFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign a rational to a non-rational feature";
@@ -75,7 +75,7 @@ void babelwires::RationalValueAssignmentData::deserializeContents(Deserializer& 
 }
 
 void babelwires::StringValueAssignmentData::apply(Feature* targetFeature) const {
-    if (StringFeature* stringFeature = targetFeature->asA<StringFeature>()) {
+    if (StringFeature* stringFeature = targetFeature->as<StringFeature>()) {
         stringFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign a string to a non-string field";

--- a/BabelWires/Project/Modifiers/modifierData.cpp
+++ b/BabelWires/Project/Modifiers/modifierData.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<babelwires::Modifier> babelwires::LocalModifierData::createModif
 }
 
 void babelwires::IntValueAssignmentData::apply(Feature* targetFeature) const {
-    if (IntFeature* intFeature = dynamic_cast<IntFeature*>(targetFeature)) {
+    if (IntFeature* intFeature = targetFeature->asA<IntFeature>()) {
         intFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign an int to a non-int feature";
@@ -57,7 +57,7 @@ void babelwires::IntValueAssignmentData::deserializeContents(Deserializer& deser
 }
 
 void babelwires::RationalValueAssignmentData::apply(Feature* targetFeature) const {
-    if (RationalFeature* rationalFeature = dynamic_cast<RationalFeature*>(targetFeature)) {
+    if (RationalFeature* rationalFeature = targetFeature->asA<RationalFeature>()) {
         rationalFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign a rational to a non-rational feature";
@@ -75,7 +75,7 @@ void babelwires::RationalValueAssignmentData::deserializeContents(Deserializer& 
 }
 
 void babelwires::StringValueAssignmentData::apply(Feature* targetFeature) const {
-    if (StringFeature* stringFeature = dynamic_cast<StringFeature*>(targetFeature)) {
+    if (StringFeature* stringFeature = targetFeature->asA<StringFeature>()) {
         stringFeature->set(m_value);
     } else {
         throw babelwires::ModelException() << "Could not assign a string to a non-string field";

--- a/BabelWires/Project/Modifiers/modifierData.hpp
+++ b/BabelWires/Project/Modifiers/modifierData.hpp
@@ -43,6 +43,14 @@ namespace babelwires {
         /// (There is currently no scenario where a modifier references a filepath, but
         /// this is just here for future proofing.)
         void visitFilePaths(FilePathVisitor& visitor) override;
+
+        /// Return a pointer to a T if this is a T, otherwise return nullptr.
+        template <typename T, std::enable_if_t<std::is_base_of_v<ModifierData, T>, std::nullptr_t> = nullptr>
+        T* asA() { return dynamic_cast<T*>(this); }
+
+        /// Return a pointer to a T if this is a T, otherwise return nullptr.
+        template <typename T, std::enable_if_t<std::is_base_of_v<ModifierData, T>, std::nullptr_t> = nullptr>
+        const T* asA() const { return dynamic_cast<const T*>(this); }
     };
 
     /// Base class for ModifierData which construct LocalModifiers.

--- a/BabelWires/Project/Modifiers/modifierData.hpp
+++ b/BabelWires/Project/Modifiers/modifierData.hpp
@@ -25,6 +25,7 @@ namespace babelwires {
     struct ModifierData : Cloneable, Serializable, ProjectVisitable {
         CLONEABLE_ABSTRACT(ModifierData);
         SERIALIZABLE_ABSTRACT(ModifierData, "ModifierData", void);
+        DOWNCASTABLE_TYPE_HIERARCHY(ModifierData);
 
         /// Identifies the feature being modified.
         FeaturePath m_pathToFeature;
@@ -43,14 +44,6 @@ namespace babelwires {
         /// (There is currently no scenario where a modifier references a filepath, but
         /// this is just here for future proofing.)
         void visitFilePaths(FilePathVisitor& visitor) override;
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<ModifierData, T>, std::nullptr_t> = nullptr>
-        T* asA() { return dynamic_cast<T*>(this); }
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<ModifierData, T>, std::nullptr_t> = nullptr>
-        const T* asA() const { return dynamic_cast<const T*>(this); }
     };
 
     /// Base class for ModifierData which construct LocalModifiers.

--- a/BabelWires/Project/project.cpp
+++ b/BabelWires/Project/project.cpp
@@ -304,7 +304,7 @@ void babelwires::Project::tryToReloadAllSources() {
     int attemptedReloads = 0;
     int successfulReloads = 0;
     for (const auto& [_, f] : m_featureElements) {
-        if (FileElement* const fileElement = dynamic_cast<FileElement*>(f.get())) {
+        if (FileElement* const fileElement = f->asA<FileElement>()) {
             if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {
                 ++attemptedReloads;
                 if (fileElement->reload(m_context, m_userLogger)) {
@@ -320,7 +320,7 @@ void babelwires::Project::tryToSaveAllTargets() {
     int attemptedSaves = 0;
     int successfulSaves = 0;
     for (const auto& [_, f] : m_featureElements) {
-        if (FileElement* const fileElement = dynamic_cast<FileElement*>(f.get())) {
+        if (FileElement* const fileElement = f->asA<FileElement>()) {
             if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::save)) {
                 ++attemptedSaves;
                 if (fileElement->save(m_context, m_userLogger)) {
@@ -336,7 +336,7 @@ void babelwires::Project::tryToReloadSource(ElementId id) {
     assert((id != INVALID_ELEMENT_ID) && "Invalid id");
     FeatureElement* f = getFeatureElement(id);
     assert(f && "There was no such feature element");
-    FileElement* const fileElement = dynamic_cast<FileElement*>(f);
+    FileElement* const fileElement = f->asA<FileElement>();
     assert(fileElement && "There was no such file element");
     assert(isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload) &&
            "There was no such reloadable file element");
@@ -347,7 +347,7 @@ void babelwires::Project::tryToSaveTarget(ElementId id) {
     assert((id != INVALID_ELEMENT_ID) && "Invalid id");
     FeatureElement* f = getFeatureElement(id);
     assert(f && "There was no such feature element");
-    FileElement* const fileElement = dynamic_cast<FileElement*>(f);
+    FileElement* const fileElement = f->asA<FileElement>();
     assert(fileElement && "There was no such file element");
     assert(isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::save) &&
            "There was no such saveable file element");

--- a/BabelWires/Project/project.cpp
+++ b/BabelWires/Project/project.cpp
@@ -157,7 +157,7 @@ void babelwires::Project::addArrayEntries(ElementId elementId, const FeaturePath
                 // First, ensure there is an appropriate modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {
-                    arrayModifier = dynamic_cast<ArraySizeModifier*>(modifier);
+                    arrayModifier = modifier->asA<ArraySizeModifier>();
                     if (!arrayModifier) {
                         // Defensive: Wasn't an array modifier at the path, so let it be replaced.
                         // This won't be restored by an undo, but that shouldn't matter since it isn't
@@ -204,7 +204,7 @@ void babelwires::Project::removeArrayEntries(ElementId elementId, const FeatureP
                 // First, check if there is a modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {
-                    arrayModifier = dynamic_cast<ArraySizeModifier*>(modifier);
+                    arrayModifier = modifier->asA<ArraySizeModifier>();
                     if (!arrayModifier) {
                         // Defensive: Wasn't an array modifier at the path, so let it be replaced.
                         // This won't be restored by an undo, but that shouldn't matter since it isn't
@@ -600,7 +600,7 @@ void babelwires::Project::activateOptional(ElementId elementId, const FeaturePat
     
     if (Modifier* existingModifier = elementToModify->getEdits().findModifier(pathToRecord)) {
         if (auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
-            auto localModifier = dynamic_cast<LocalModifier*>(existingModifier);
+            auto localModifier = existingModifier->asA<LocalModifier>();
             assert(localModifier && "Non-local modifier carrying local data");
             modifierData = activateOptionalsModifierData;
             activateOptionalsModifierData->m_selectedOptionals.emplace_back(optional);
@@ -635,7 +635,7 @@ void babelwires::Project::deactivateOptional(ElementId elementId, const FeatureP
 
     auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>();
     assert(activateOptionalsModifierData);
-    assert(dynamic_cast<LocalModifier*>(existingModifier) && "Non-local modifier carrying local data");
+    assert(existingModifier->asA<LocalModifier>() && "Non-local modifier carrying local data");
     auto localModifier = static_cast<LocalModifier*>(existingModifier);
 
     auto it = std::find(activateOptionalsModifierData->m_selectedOptionals.begin(), activateOptionalsModifierData->m_selectedOptionals.end(), optional);

--- a/BabelWires/Project/project.cpp
+++ b/BabelWires/Project/project.cpp
@@ -153,7 +153,7 @@ void babelwires::Project::addArrayEntries(ElementId elementId, const FeaturePath
             Feature* featureAtPath = pathToArray.tryFollow(*inputFeature);
             assert(featureAtPath && "Path should lead to an array");
 
-            if (ArrayFeature* const arrayFeature = dynamic_cast<ArrayFeature*>(featureAtPath)) {
+            if (ArrayFeature* const arrayFeature = featureAtPath->asA<ArrayFeature>()) {
                 // First, ensure there is an appropriate modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {
@@ -200,7 +200,7 @@ void babelwires::Project::removeArrayEntries(ElementId elementId, const FeatureP
             Feature* featureAtPath = pathToArray.tryFollow(*inputFeature);
             assert(featureAtPath && "Path should lead to an array");
 
-            if (ArrayFeature* const arrayFeature = dynamic_cast<ArrayFeature*>(featureAtPath)) {
+            if (ArrayFeature* const arrayFeature = featureAtPath->asA<ArrayFeature>()) {
                 // First, check if there is a modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {

--- a/BabelWires/Project/project.cpp
+++ b/BabelWires/Project/project.cpp
@@ -599,7 +599,7 @@ void babelwires::Project::activateOptional(ElementId elementId, const FeaturePat
     ActivateOptionalsModifierData* modifierData = nullptr;
     
     if (Modifier* existingModifier = elementToModify->getEdits().findModifier(pathToRecord)) {
-        if (auto activateOptionalsModifierData = dynamic_cast<ActivateOptionalsModifierData*>(&existingModifier->getModifierData())) {
+        if (auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
             auto localModifier = dynamic_cast<LocalModifier*>(existingModifier);
             assert(localModifier && "Non-local modifier carrying local data");
             modifierData = activateOptionalsModifierData;
@@ -633,7 +633,7 @@ void babelwires::Project::deactivateOptional(ElementId elementId, const FeatureP
     Modifier* existingModifier = elementToModify->getEdits().findModifier(pathToRecord);
     assert(existingModifier);
 
-    auto activateOptionalsModifierData = dynamic_cast<ActivateOptionalsModifierData*>(&existingModifier->getModifierData());
+    auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>();
     assert(activateOptionalsModifierData);
     assert(dynamic_cast<LocalModifier*>(existingModifier) && "Non-local modifier carrying local data");
     auto localModifier = static_cast<LocalModifier*>(existingModifier);

--- a/BabelWires/Project/project.cpp
+++ b/BabelWires/Project/project.cpp
@@ -153,11 +153,11 @@ void babelwires::Project::addArrayEntries(ElementId elementId, const FeaturePath
             Feature* featureAtPath = pathToArray.tryFollow(*inputFeature);
             assert(featureAtPath && "Path should lead to an array");
 
-            if (ArrayFeature* const arrayFeature = featureAtPath->asA<ArrayFeature>()) {
+            if (ArrayFeature* const arrayFeature = featureAtPath->as<ArrayFeature>()) {
                 // First, ensure there is an appropriate modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {
-                    arrayModifier = modifier->asA<ArraySizeModifier>();
+                    arrayModifier = modifier->as<ArraySizeModifier>();
                     if (!arrayModifier) {
                         // Defensive: Wasn't an array modifier at the path, so let it be replaced.
                         // This won't be restored by an undo, but that shouldn't matter since it isn't
@@ -200,11 +200,11 @@ void babelwires::Project::removeArrayEntries(ElementId elementId, const FeatureP
             Feature* featureAtPath = pathToArray.tryFollow(*inputFeature);
             assert(featureAtPath && "Path should lead to an array");
 
-            if (ArrayFeature* const arrayFeature = featureAtPath->asA<ArrayFeature>()) {
+            if (ArrayFeature* const arrayFeature = featureAtPath->as<ArrayFeature>()) {
                 // First, check if there is a modifier at the array.
                 ArraySizeModifier* arrayModifier = nullptr;
                 if (Modifier* const modifier = element->findModifier(pathToArray)) {
-                    arrayModifier = modifier->asA<ArraySizeModifier>();
+                    arrayModifier = modifier->as<ArraySizeModifier>();
                     if (!arrayModifier) {
                         // Defensive: Wasn't an array modifier at the path, so let it be replaced.
                         // This won't be restored by an undo, but that shouldn't matter since it isn't
@@ -304,7 +304,7 @@ void babelwires::Project::tryToReloadAllSources() {
     int attemptedReloads = 0;
     int successfulReloads = 0;
     for (const auto& [_, f] : m_featureElements) {
-        if (FileElement* const fileElement = f->asA<FileElement>()) {
+        if (FileElement* const fileElement = f->as<FileElement>()) {
             if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload)) {
                 ++attemptedReloads;
                 if (fileElement->reload(m_context, m_userLogger)) {
@@ -320,7 +320,7 @@ void babelwires::Project::tryToSaveAllTargets() {
     int attemptedSaves = 0;
     int successfulSaves = 0;
     for (const auto& [_, f] : m_featureElements) {
-        if (FileElement* const fileElement = f->asA<FileElement>()) {
+        if (FileElement* const fileElement = f->as<FileElement>()) {
             if (isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::save)) {
                 ++attemptedSaves;
                 if (fileElement->save(m_context, m_userLogger)) {
@@ -336,7 +336,7 @@ void babelwires::Project::tryToReloadSource(ElementId id) {
     assert((id != INVALID_ELEMENT_ID) && "Invalid id");
     FeatureElement* f = getFeatureElement(id);
     assert(f && "There was no such feature element");
-    FileElement* const fileElement = f->asA<FileElement>();
+    FileElement* const fileElement = f->as<FileElement>();
     assert(fileElement && "There was no such file element");
     assert(isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::reload) &&
            "There was no such reloadable file element");
@@ -347,7 +347,7 @@ void babelwires::Project::tryToSaveTarget(ElementId id) {
     assert((id != INVALID_ELEMENT_ID) && "Invalid id");
     FeatureElement* f = getFeatureElement(id);
     assert(f && "There was no such feature element");
-    FileElement* const fileElement = f->asA<FileElement>();
+    FileElement* const fileElement = f->as<FileElement>();
     assert(fileElement && "There was no such file element");
     assert(isNonzero(fileElement->getSupportedFileOperations() & FileElement::FileOperations::save) &&
            "There was no such saveable file element");
@@ -599,8 +599,8 @@ void babelwires::Project::activateOptional(ElementId elementId, const FeaturePat
     ActivateOptionalsModifierData* modifierData = nullptr;
     
     if (Modifier* existingModifier = elementToModify->getEdits().findModifier(pathToRecord)) {
-        if (auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>()) {
-            auto localModifier = existingModifier->asA<LocalModifier>();
+        if (auto activateOptionalsModifierData = existingModifier->getModifierData().as<ActivateOptionalsModifierData>()) {
+            auto localModifier = existingModifier->as<LocalModifier>();
             assert(localModifier && "Non-local modifier carrying local data");
             modifierData = activateOptionalsModifierData;
             activateOptionalsModifierData->m_selectedOptionals.emplace_back(optional);
@@ -633,9 +633,9 @@ void babelwires::Project::deactivateOptional(ElementId elementId, const FeatureP
     Modifier* existingModifier = elementToModify->getEdits().findModifier(pathToRecord);
     assert(existingModifier);
 
-    auto activateOptionalsModifierData = existingModifier->getModifierData().asA<ActivateOptionalsModifierData>();
+    auto activateOptionalsModifierData = existingModifier->getModifierData().as<ActivateOptionalsModifierData>();
     assert(activateOptionalsModifierData);
-    assert(existingModifier->asA<LocalModifier>() && "Non-local modifier carrying local data");
+    assert(existingModifier->as<LocalModifier>() && "Non-local modifier carrying local data");
     auto localModifier = static_cast<LocalModifier*>(existingModifier);
 
     auto it = std::find(activateOptionalsModifierData->m_selectedOptionals.begin(), activateOptionalsModifierData->m_selectedOptionals.end(), optional);

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/changeSourceFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/changeSourceFileAction.cpp
@@ -36,7 +36,7 @@ void babelwires::ChangeSourceFileAction::actionTriggered(babelwires::FeatureMode
         if (!f) {
             return;
         }
-        const FileElement* const fileElement = dynamic_cast<const FileElement*>(f);
+        const FileElement* const fileElement = f->asA<FileElement>();
         if (!fileElement) {
             return;
         }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/changeSourceFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/changeSourceFileAction.cpp
@@ -36,7 +36,7 @@ void babelwires::ChangeSourceFileAction::actionTriggered(babelwires::FeatureMode
         if (!f) {
             return;
         }
-        const FileElement* const fileElement = f->asA<FileElement>();
+        const FileElement* const fileElement = f->as<FileElement>();
         if (!fileElement) {
             return;
         }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/reloadFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/reloadFileAction.cpp
@@ -26,7 +26,7 @@ void babelwires::ReloadFileAction::actionTriggered(babelwires::FeatureModel& mod
     if (!featureElement) {
         return;
     }
-    FileElement* const fileElement = dynamic_cast<FileElement*>(featureElement);
+    FileElement* const fileElement = featureElement->asA<FileElement>();
     if (!fileElement) {
         return;
     }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/reloadFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/reloadFileAction.cpp
@@ -26,7 +26,7 @@ void babelwires::ReloadFileAction::actionTriggered(babelwires::FeatureModel& mod
     if (!featureElement) {
         return;
     }
-    FileElement* const fileElement = featureElement->asA<FileElement>();
+    FileElement* const fileElement = featureElement->as<FileElement>();
     if (!fileElement) {
         return;
     }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAction.cpp
@@ -26,7 +26,7 @@ void babelwires::SaveFileAction::actionTriggered(babelwires::FeatureModel& model
     if (!featureElement) {
         return;
     }
-    FileElement* const fileElement = dynamic_cast<FileElement*>(featureElement);
+    FileElement* const fileElement = featureElement->asA<FileElement>();
     if (!fileElement) {
         return;
     }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAction.cpp
@@ -26,7 +26,7 @@ void babelwires::SaveFileAction::actionTriggered(babelwires::FeatureModel& model
     if (!featureElement) {
         return;
     }
-    FileElement* const fileElement = featureElement->asA<FileElement>();
+    FileElement* const fileElement = featureElement->as<FileElement>();
     if (!fileElement) {
         return;
     }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAsAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAsAction.cpp
@@ -34,7 +34,7 @@ void babelwires::SaveFileAsAction::actionTriggered(babelwires::FeatureModel& mod
         if (!featureElement) {
             return;
         }
-        const FileElement* const fileElement = featureElement->asA<FileElement>();
+        const FileElement* const fileElement = featureElement->as<FileElement>();
         if (!fileElement) {
             return;
         }

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAsAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/saveFileAsAction.cpp
@@ -34,7 +34,7 @@ void babelwires::SaveFileAsAction::actionTriggered(babelwires::FeatureModel& mod
         if (!featureElement) {
             return;
         }
-        const FileElement* const fileElement = dynamic_cast<const FileElement*>(featureElement);
+        const FileElement* const fileElement = featureElement->asA<FileElement>();
         if (!fileElement) {
             return;
         }

--- a/BabelWiresQtUi/ModelBridge/RowModels/arrayRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/arrayRowModel.cpp
@@ -15,7 +15,7 @@
 #include "BabelWires/Project/FeatureElements/contentsCache.hpp"
 
 const babelwires::ArrayFeature& babelwires::ArrayRowModel::getArrayFeature() const {
-    assert(dynamic_cast<const babelwires::ArrayFeature*>(getInputThenOutputFeature()) &&
+    assert(getInputThenOutputFeature()->asA<const babelwires::ArrayFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::ArrayFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/arrayRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/arrayRowModel.cpp
@@ -15,7 +15,7 @@
 #include "BabelWires/Project/FeatureElements/contentsCache.hpp"
 
 const babelwires::ArrayFeature& babelwires::ArrayRowModel::getArrayFeature() const {
-    assert(getInputThenOutputFeature()->asA<const babelwires::ArrayFeature>() &&
+    assert(getInputThenOutputFeature()->as<const babelwires::ArrayFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::ArrayFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
@@ -23,12 +23,12 @@
 #include <cassert>
 
 const babelwires::FileFeature& babelwires::FileRowModel::getFileFeature() const {
-    assert(getInputThenOutputFeature()->asA<const FileFeature>() && "Wrong type of feature stored");
+    assert(getInputThenOutputFeature()->as<const FileFeature>() && "Wrong type of feature stored");
     return *static_cast<const FileFeature*>(getInputThenOutputFeature());
 }
 
 const babelwires::FileElement& babelwires::FileRowModel::getFileElement() const {
-    assert(m_featureElement->asA<FileElement>() && "A file feature should only appear in a file element");
+    assert(m_featureElement->as<FileElement>() && "A file feature should only appear in a file element");
     return *static_cast<const FileElement*>(m_featureElement);
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
@@ -28,7 +28,7 @@ const babelwires::FileFeature& babelwires::FileRowModel::getFileFeature() const 
 }
 
 const babelwires::FileElement& babelwires::FileRowModel::getFileElement() const {
-    assert(dynamic_cast<const FileElement*>(m_featureElement) && "A file feature should only appear in a file element");
+    assert(m_featureElement->asA<FileElement>() && "A file feature should only appear in a file element");
     return *static_cast<const FileElement*>(m_featureElement);
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/fileRowModel.cpp
@@ -23,7 +23,7 @@
 #include <cassert>
 
 const babelwires::FileFeature& babelwires::FileRowModel::getFileFeature() const {
-    assert(dynamic_cast<const FileFeature*>(getInputThenOutputFeature()) && "Wrong type of feature stored");
+    assert(getInputThenOutputFeature()->asA<const FileFeature>() && "Wrong type of feature stored");
     return *static_cast<const FileFeature*>(getInputThenOutputFeature());
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
@@ -18,7 +18,7 @@
 #include <cassert>
 
 const babelwires::IntFeature& babelwires::IntRowModel::getIntFeature() const {
-    assert(dynamic_cast<const babelwires::IntFeature*>(getInputThenOutputFeature()) && "Wrong type of feature stored");
+    assert(getInputThenOutputFeature()->asA<const babelwires::IntFeature>() && "Wrong type of feature stored");
     return *static_cast<const babelwires::IntFeature*>(getInputThenOutputFeature());
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
@@ -18,7 +18,7 @@
 #include <cassert>
 
 const babelwires::IntFeature& babelwires::IntRowModel::getIntFeature() const {
-    assert(getInputThenOutputFeature()->asA<const babelwires::IntFeature>() && "Wrong type of feature stored");
+    assert(getInputThenOutputFeature()->as<const babelwires::IntFeature>() && "Wrong type of feature stored");
     return *static_cast<const babelwires::IntFeature*>(getInputThenOutputFeature());
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
@@ -17,7 +17,7 @@
 #include <cassert>
 
 const babelwires::RationalFeature& babelwires::RationalRowModel::getRationalFeature() const {
-    assert(dynamic_cast<const babelwires::RationalFeature*>(getInputThenOutputFeature()) &&
+    assert(getInputThenOutputFeature()->asA<const babelwires::RationalFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::RationalFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
@@ -17,7 +17,7 @@
 #include <cassert>
 
 const babelwires::RationalFeature& babelwires::RationalRowModel::getRationalFeature() const {
-    assert(getInputThenOutputFeature()->asA<const babelwires::RationalFeature>() &&
+    assert(getInputThenOutputFeature()->as<const babelwires::RationalFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::RationalFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/recordWithOptionalsRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/recordWithOptionalsRowModel.cpp
@@ -23,7 +23,7 @@
 #include "BabelWires/Project/FeatureElements/contentsCache.hpp"
 
 const babelwires::RecordWithOptionalsFeature& babelwires::RecordWithOptionalsRowModel::getRecordWithOptionalsFeature() const {
-    assert(getInputThenOutputFeature()->asA<const babelwires::RecordWithOptionalsFeature>() &&
+    assert(getInputThenOutputFeature()->as<const babelwires::RecordWithOptionalsFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::RecordWithOptionalsFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/recordWithOptionalsRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/recordWithOptionalsRowModel.cpp
@@ -23,7 +23,7 @@
 #include "BabelWires/Project/FeatureElements/contentsCache.hpp"
 
 const babelwires::RecordWithOptionalsFeature& babelwires::RecordWithOptionalsRowModel::getRecordWithOptionalsFeature() const {
-    assert(dynamic_cast<const babelwires::RecordWithOptionalsFeature*>(getInputThenOutputFeature()) &&
+    assert(getInputThenOutputFeature()->asA<const babelwires::RecordWithOptionalsFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::RecordWithOptionalsFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
@@ -132,7 +132,7 @@ void babelwires::RowModel::getContextMenuActions(
         actionsOut.emplace_back(std::make_unique<RemoveFailedModifiersAction>());
     }
     if (const babelwires::Feature* inputFeature = getInputFeature()) {
-        if (auto arrayFeature = dynamic_cast<const ArrayFeature*>(inputFeature->getOwner())) {
+        if (auto arrayFeature = inputFeature->getOwner()->asA<const ArrayFeature>()) {
             FeaturePath pathToArray(arrayFeature);
             const PathStep step = arrayFeature->getStepToChild(inputFeature);
             const ArrayIndex index = step.getIndex();

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
@@ -132,7 +132,7 @@ void babelwires::RowModel::getContextMenuActions(
         actionsOut.emplace_back(std::make_unique<RemoveFailedModifiersAction>());
     }
     if (const babelwires::Feature* inputFeature = getInputFeature()) {
-        if (auto arrayFeature = inputFeature->getOwner()->asA<const ArrayFeature>()) {
+        if (auto arrayFeature = inputFeature->getOwner()->as<const ArrayFeature>()) {
             FeaturePath pathToArray(arrayFeature);
             const PathStep step = arrayFeature->getStepToChild(inputFeature);
             const ArrayIndex index = step.getIndex();

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
@@ -30,22 +30,22 @@ babelwires::RowModelDispatcher::RowModelDispatcher(const RowModelRegistry& rowMo
     const babelwires::Feature* feature = entry->getInputThenOutputFeature();
     if (rowModelRegistry.handleFeature(feature, m_rowModel)) {
         // Handled by a registered handler.
-    } else if (feature->asA<const babelwires::StringFeature>()) {
+    } else if (feature->as<const babelwires::StringFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::StringRowModel));
         new (m_rowModel) babelwires::StringRowModel();
-    } else if (feature->asA<const babelwires::IntFeature>()) {
+    } else if (feature->as<const babelwires::IntFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::IntRowModel));
         new (m_rowModel) babelwires::IntRowModel();
-    } else if (feature->asA<const babelwires::RationalFeature>()) {
+    } else if (feature->as<const babelwires::RationalFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::RationalRowModel));
         new (m_rowModel) babelwires::RationalRowModel();
-    } else if (feature->asA<const babelwires::ArrayFeature>()) {
+    } else if (feature->as<const babelwires::ArrayFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::ArrayRowModel));
         new (m_rowModel) babelwires::ArrayRowModel();
-    } else if (feature->asA<const babelwires::FileFeature>()) {
+    } else if (feature->as<const babelwires::FileFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::FileRowModel));
         new (m_rowModel) babelwires::FileRowModel();
-    } else if (feature->asA<const babelwires::RecordWithOptionalsFeature>()) {
+    } else if (feature->as<const babelwires::RecordWithOptionalsFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::RecordWithOptionalsRowModel));
         new (m_rowModel) babelwires::RecordWithOptionalsRowModel();
     } else {

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
@@ -30,22 +30,22 @@ babelwires::RowModelDispatcher::RowModelDispatcher(const RowModelRegistry& rowMo
     const babelwires::Feature* feature = entry->getInputThenOutputFeature();
     if (rowModelRegistry.handleFeature(feature, m_rowModel)) {
         // Handled by a registered handler.
-    } else if (dynamic_cast<const babelwires::StringFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::StringFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::StringRowModel));
         new (m_rowModel) babelwires::StringRowModel();
-    } else if (dynamic_cast<const babelwires::IntFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::IntFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::IntRowModel));
         new (m_rowModel) babelwires::IntRowModel();
-    } else if (dynamic_cast<const babelwires::RationalFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::RationalFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::RationalRowModel));
         new (m_rowModel) babelwires::RationalRowModel();
-    } else if (dynamic_cast<const babelwires::ArrayFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::ArrayFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::ArrayRowModel));
         new (m_rowModel) babelwires::ArrayRowModel();
-    } else if (dynamic_cast<const babelwires::FileFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::FileFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::FileRowModel));
         new (m_rowModel) babelwires::FileRowModel();
-    } else if (dynamic_cast<const babelwires::RecordWithOptionalsFeature*>(feature)) {
+    } else if (feature->asA<const babelwires::RecordWithOptionalsFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::RecordWithOptionalsRowModel));
         new (m_rowModel) babelwires::RecordWithOptionalsRowModel();
     } else {

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp
@@ -26,7 +26,7 @@ namespace babelwires {
 
         template <typename FEATURE_TYPE, typename ROW_MODEL_TYPE> void registryHandler() {
             m_handlers.emplace_back([](const Feature* feature, RowModel* rowModelAllocation) {
-                if (feature->template asA<FEATURE_TYPE>()) {
+                if (feature->template as<FEATURE_TYPE>()) {
                     static_assert(sizeof(ROW_MODEL_TYPE) <= sizeof(babelwires::RowModel));
                     new (rowModelAllocation) ROW_MODEL_TYPE();
                     return true;

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModelRegistry.hpp
@@ -2,10 +2,12 @@
  * Allows the set of RowModels to be extended by client code.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
+
+#include "BabelWires/Features/features.hpp"
 
 #include "BabelWiresQtUi/ModelBridge/RowModels/rowModel.hpp"
 
@@ -13,8 +15,6 @@
 #include <vector>
 
 namespace babelwires {
-
-    class Feature;
     class RowModel;
 
     /// Allows the set of RowModels to be extended by client code.
@@ -26,7 +26,7 @@ namespace babelwires {
 
         template <typename FEATURE_TYPE, typename ROW_MODEL_TYPE> void registryHandler() {
             m_handlers.emplace_back([](const Feature* feature, RowModel* rowModelAllocation) {
-                if (dynamic_cast<const FEATURE_TYPE*>(feature)) {
+                if (feature->template asA<FEATURE_TYPE>()) {
                     static_assert(sizeof(ROW_MODEL_TYPE) <= sizeof(babelwires::RowModel));
                     new (rowModelAllocation) ROW_MODEL_TYPE();
                     return true;

--- a/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
@@ -16,7 +16,7 @@
 #include <cassert>
 
 const babelwires::StringFeature& babelwires::StringRowModel::getStringFeature() const {
-    assert(getInputThenOutputFeature()->asA<const babelwires::StringFeature>() &&
+    assert(getInputThenOutputFeature()->as<const babelwires::StringFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::StringFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
@@ -16,7 +16,7 @@
 #include <cassert>
 
 const babelwires::StringFeature& babelwires::StringRowModel::getStringFeature() const {
-    assert(dynamic_cast<const babelwires::StringFeature*>(getInputThenOutputFeature()) &&
+    assert(getInputThenOutputFeature()->asA<const babelwires::StringFeature>() &&
            "Wrong type of feature stored");
     return *static_cast<const babelwires::StringFeature*>(getInputThenOutputFeature());
 }

--- a/BabelWiresQtUi/ModelBridge/elementNodeModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/elementNodeModel.cpp
@@ -87,7 +87,7 @@ const babelwires::Feature* babelwires::ElementNodeModel::getOutputFeature(Access
 }
 
 QtNodes::NodeDataType babelwires::ElementNodeModel::getDataTypeFromFeature(const babelwires::Feature* f) {
-    if (auto v = dynamic_cast<const ValueFeature*>(f)) {
+    if (auto v = f->asA<const ValueFeature>()) {
         return QtNodes::NodeDataType{v->getValueType().c_str(), ""};
     }
     return QtNodes::NodeDataType();

--- a/BabelWiresQtUi/ModelBridge/elementNodeModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/elementNodeModel.cpp
@@ -87,7 +87,7 @@ const babelwires::Feature* babelwires::ElementNodeModel::getOutputFeature(Access
 }
 
 QtNodes::NodeDataType babelwires::ElementNodeModel::getDataTypeFromFeature(const babelwires::Feature* f) {
-    if (auto v = f->asA<const ValueFeature>()) {
+    if (auto v = f->as<const ValueFeature>()) {
         return QtNodes::NodeDataType{v->getValueType().c_str(), ""};
     }
     return QtNodes::NodeDataType();

--- a/Common/BlockStream/blockStream.hpp
+++ b/Common/BlockStream/blockStream.hpp
@@ -27,7 +27,7 @@ namespace babelwires {
         /// Add an event by moving or copying it into the track.
         template <typename EVENT> EVENT& addEvent(EVENT&& srcEvent) {
             StreamEvent& eventInTrack = addEventInternal(std::forward<EVENT>(srcEvent));
-            assert(dynamic_cast<typename std::remove_reference<EVENT>::type*>(&eventInTrack) != nullptr);
+            assert(eventInTrack.template asA<typename std::remove_reference<EVENT>::type>() != nullptr);
             return static_cast<EVENT&>(eventInTrack);
         };
 

--- a/Common/BlockStream/blockStream.hpp
+++ b/Common/BlockStream/blockStream.hpp
@@ -27,7 +27,7 @@ namespace babelwires {
         /// Add an event by moving or copying it into the track.
         template <typename EVENT> EVENT& addEvent(EVENT&& srcEvent) {
             StreamEvent& eventInTrack = addEventInternal(std::forward<EVENT>(srcEvent));
-            assert(eventInTrack.template asA<typename std::remove_reference<EVENT>::type>() != nullptr);
+            assert(eventInTrack.template as<typename std::remove_reference<EVENT>::type>() != nullptr);
             return static_cast<EVENT&>(eventInTrack);
         };
 

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -23,7 +23,7 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
     Iterator& operator++() {
         if (m_current->m_numBytesToNextEvent > 0) {
             auto* nextEvent = m_current->getNextEventInBlock();
-            assert((dynamic_cast<EVENT*>(nextEvent) != nullptr) && "The stream contained an event of unexpected type");
+            assert((nextEvent->template asA<EVENT>() != nullptr) && "The stream contained an event of unexpected type");
             m_current = static_cast<EVENT*>(nextEvent);
         } else {
             assert((m_current == m_blockStream->m_blocks[m_blockIndex]->m_lastEvent) &&
@@ -33,7 +33,7 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
                 m_current = nullptr;
             } else {
                 auto* nextEvent = m_blockStream->m_blocks[m_blockIndex]->m_firstEvent;
-                assert((dynamic_cast<EVENT*>(nextEvent) != nullptr) &&
+                assert((nextEvent->template asA<EVENT>() != nullptr) &&
                        "The stream contained an event of unexpected type");
                 m_current = static_cast<EVENT*>(nextEvent);
             }

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -23,7 +23,7 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
     Iterator& operator++() {
         if (m_current->m_numBytesToNextEvent > 0) {
             auto* nextEvent = m_current->getNextEventInBlock();
-            assert((nextEvent->template asA<EVENT>() != nullptr) && "The stream contained an event of unexpected type");
+            assert((nextEvent->template as<EVENT>() != nullptr) && "The stream contained an event of unexpected type");
             m_current = static_cast<EVENT*>(nextEvent);
         } else {
             assert((m_current == m_blockStream->m_blocks[m_blockIndex]->m_lastEvent) &&
@@ -33,7 +33,7 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
                 m_current = nullptr;
             } else {
                 auto* nextEvent = m_blockStream->m_blocks[m_blockIndex]->m_firstEvent;
-                assert((nextEvent->template asA<EVENT>() != nullptr) &&
+                assert((nextEvent->template as<EVENT>() != nullptr) &&
                        "The stream contained an event of unexpected type");
                 m_current = static_cast<EVENT*>(nextEvent);
             }

--- a/Common/BlockStream/streamEvent.hpp
+++ b/Common/BlockStream/streamEvent.hpp
@@ -68,10 +68,12 @@ namespace babelwires {
         virtual ~StreamEvent() = default;
 
         /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T> T* asA() { return dynamic_cast<T*>(this); }
+        template <typename T, std::enable_if_t<std::is_base_of_v<StreamEvent, T>, std::nullptr_t> = nullptr>
+        T* asA() { return dynamic_cast<T*>(this); }
 
         /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T> const T* asA() const { return dynamic_cast<const T*>(this); }
+        template <typename T, std::enable_if_t<std::is_base_of_v<StreamEvent, T>, std::nullptr_t> = nullptr>
+        const T* asA() const { return dynamic_cast<const T*>(this); }
 
       private:
         friend BlockStream;

--- a/Common/BlockStream/streamEvent.hpp
+++ b/Common/BlockStream/streamEvent.hpp
@@ -58,6 +58,7 @@ namespace babelwires {
     class StreamEvent : public Streamable {
       public:
         STREAM_EVENT(StreamEvent);
+        DOWNCASTABLE_TYPE_HIERARCHY(StreamEvent);
 
         StreamEvent() = default;
         StreamEvent(const StreamEvent& other)
@@ -66,14 +67,6 @@ namespace babelwires {
             : m_numBytesToNextEvent(0) {}
 
         virtual ~StreamEvent() = default;
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<StreamEvent, T>, std::nullptr_t> = nullptr>
-        T* asA() { return dynamic_cast<T*>(this); }
-
-        /// Return a pointer to a T if this is a T, otherwise return nullptr.
-        template <typename T, std::enable_if_t<std::is_base_of_v<StreamEvent, T>, std::nullptr_t> = nullptr>
-        const T* asA() const { return dynamic_cast<const T*>(this); }
 
       private:
         friend BlockStream;

--- a/Common/types.hpp
+++ b/Common/types.hpp
@@ -65,9 +65,9 @@ namespace babelwires {
 
 /// Adds "asA" methods to a hierarchy, allowing limited downcasting within the hierarchy.
 /// This neatens up dynamic_casting in client code, and should make refactors easier in future.
-/// foo.asA<BAR>() either returns a BAR* or nullptr.
+/// foo.as<BAR>() either returns a BAR* or nullptr.
 #define DOWNCASTABLE_TYPE_HIERARCHY(BASE) \
     template <typename T, std::enable_if_t<std::is_base_of_v<BASE, T>, std::nullptr_t> = nullptr> \
-    T* asA() { return dynamic_cast<T*>(this); } \
+    T* as() { return dynamic_cast<T*>(this); } \
     template <typename T, std::enable_if_t<std::is_base_of_v<BASE, T>, std::nullptr_t> = nullptr> \
-    const T* asA() const { return dynamic_cast<const T*>(this); }
+    const T* as() const { return dynamic_cast<const T*>(this); }

--- a/Common/types.hpp
+++ b/Common/types.hpp
@@ -61,5 +61,13 @@ namespace babelwires {
     template <typename T, typename U> struct CopyConst {
         typedef typename std::conditional<std::is_const<T>::value, typename std::add_const<U>::type, U>::type type;
     };
-
 } // namespace babelwires
+
+/// Adds "asA" methods to a hierarchy, allowing limited downcasting within the hierarchy.
+/// This neatens up dynamic_casting in client code, and should make refactors easier in future.
+/// foo.asA<BAR>() either returns a BAR* or nullptr.
+#define DOWNCASTABLE_TYPE_HIERARCHY(BASE) \
+    template <typename T, std::enable_if_t<std::is_base_of_v<BASE, T>, std::nullptr_t> = nullptr> \
+    T* asA() { return dynamic_cast<T*>(this); } \
+    template <typename T, std::enable_if_t<std::is_base_of_v<BASE, T>, std::nullptr_t> = nullptr> \
+    const T* asA() const { return dynamic_cast<const T*>(this); }

--- a/Tests/BabelWires/TestUtils/testFileFormats.cpp
+++ b/Tests/BabelWires/TestUtils/testFileFormats.cpp
@@ -106,6 +106,6 @@ std::unique_ptr<babelwires::FileFeature> libTestUtils::TestTargetFileFormat::cre
 
 void libTestUtils::TestTargetFileFormat::writeToFile(const babelwires::FileFeature& fileFeature, std::ostream& os,
                                                        babelwires::UserLogger& userLogger) const {
-    const TestFileFeature& testFileFeature = dynamic_cast<const TestFileFeature&>(fileFeature);
+    const TestFileFeature& testFileFeature = *fileFeature.asA<TestFileFeature>();
     os << s_fileFormatId << char(testFileFeature.m_intChildFeature->get());
 }

--- a/Tests/BabelWires/TestUtils/testFileFormats.cpp
+++ b/Tests/BabelWires/TestUtils/testFileFormats.cpp
@@ -106,6 +106,6 @@ std::unique_ptr<babelwires::FileFeature> libTestUtils::TestTargetFileFormat::cre
 
 void libTestUtils::TestTargetFileFormat::writeToFile(const babelwires::FileFeature& fileFeature, std::ostream& os,
                                                        babelwires::UserLogger& userLogger) const {
-    const TestFileFeature& testFileFeature = *fileFeature.asA<TestFileFeature>();
+    const TestFileFeature& testFileFeature = *fileFeature.as<TestFileFeature>();
     os << s_fileFormatId << char(testFileFeature.m_intChildFeature->get());
 }

--- a/Tests/BabelWires/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWires/TestUtils/testProcessor.cpp
@@ -15,7 +15,7 @@ void libTestUtils::TestProcessor::process(babelwires::UserLogger& userLogger) {
     m_outputFeature->m_intFeature2->set(m_inputFeature->m_intFeature2->get());
     int index = m_inputFeature->m_intFeature->get();
     for (auto c : babelwires::subfeatures(m_outputFeature->m_arrayFeature)) {
-        c->asA<babelwires::IntFeature>()->set(index);
+        c->as<babelwires::IntFeature>()->set(index);
         ++index;
     }
 }

--- a/Tests/BabelWires/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWires/TestUtils/testProcessor.cpp
@@ -15,7 +15,7 @@ void libTestUtils::TestProcessor::process(babelwires::UserLogger& userLogger) {
     m_outputFeature->m_intFeature2->set(m_inputFeature->m_intFeature2->get());
     int index = m_inputFeature->m_intFeature->get();
     for (auto c : babelwires::subfeatures(m_outputFeature->m_arrayFeature)) {
-        dynamic_cast<babelwires::IntFeature&>(*c).set(index);
+        c->asA<babelwires::IntFeature>()->set(index);
         ++index;
     }
 }

--- a/Tests/BabelWires/TestUtils/testProjectData.cpp
+++ b/Tests/BabelWires/TestUtils/testProjectData.cpp
@@ -87,7 +87,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
                       return a->m_pathToFeature < b->m_pathToFeature;
                   });
 
-        auto modData1 = dynamic_cast<const babelwires::ConnectionModifierData*>(sortedModifiers[0]);
+        auto modData1 = sortedModifiers[0]->asA<babelwires::ConnectionModifierData>();
         ASSERT_TRUE(modData1);
         EXPECT_EQ(*modData1->m_pathToFeature.getStep(0).asField(), libTestUtils::TestRecordFeature::s_intIdInitializer);
         EXPECT_EQ(modData1->m_pathToFeature.getStep(0).asField()->getDiscriminator(), recordIntDiscriminator);
@@ -116,7 +116,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
 
     EXPECT_EQ(sortedElements[2]->m_id, 45);
     ASSERT_EQ(sortedElements[2]->m_modifiers.size(), 1);
-    auto modData0 = dynamic_cast<const babelwires::ConnectionModifierData*>(sortedElements[2]->m_modifiers[0].get());
+    auto modData0 = sortedElements[2]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
     ASSERT_TRUE(modData0);
     EXPECT_EQ(*modData0->m_pathToFeature.getStep(0).asField(), libTestUtils::TestFileFeature::s_intChildInitializer);
     EXPECT_EQ(modData0->m_pathToFeature.getStep(0).asField()->getDiscriminator(), fileIntChildDiscriminator);
@@ -141,10 +141,10 @@ void libTestUtils::TestProjectData::resolvePathsInCurrentContext() {
     libTestUtils::TestFileFeature testFileFeature;
 
     // These have side-effects on the mutable field discriminators in the paths.
-    auto modData0 = dynamic_cast<const babelwires::ConnectionModifierData*>(m_elements[0]->m_modifiers[0].get());
+    auto modData0 = m_elements[0]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
     modData0->m_pathToFeature.tryFollow(testFileFeature);
     modData0->m_pathToSourceFeature.tryFollow(testRecord);
-    auto modData1 = dynamic_cast<const babelwires::ConnectionModifierData*>(m_elements[1]->m_modifiers[0].get());
+    auto modData1 = m_elements[1]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
     modData1->m_pathToFeature.tryFollow(testRecord);
     modData1->m_pathToSourceFeature.tryFollow(testFileFeature);
     auto modData2 = dynamic_cast<const babelwires::IntValueAssignmentData*>(m_elements[1]->m_modifiers[1].get());

--- a/Tests/BabelWires/TestUtils/testProjectData.cpp
+++ b/Tests/BabelWires/TestUtils/testProjectData.cpp
@@ -95,7 +95,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
                   libTestUtils::TestFileFeature::s_intChildInitializer);
         EXPECT_EQ(modData1->m_pathToSourceFeature.getStep(0).asField()->getDiscriminator(), fileIntChildDiscriminator);
 
-        auto modData2 = dynamic_cast<const babelwires::IntValueAssignmentData*>(sortedModifiers[1]);
+        auto modData2 = sortedModifiers[1]->asA<babelwires::IntValueAssignmentData>();
         ASSERT_TRUE(modData2);
         ASSERT_GE(modData2->m_pathToFeature.getNumSteps(), 2);
         EXPECT_EQ(*modData2->m_pathToFeature.getStep(0).asField(),
@@ -147,7 +147,7 @@ void libTestUtils::TestProjectData::resolvePathsInCurrentContext() {
     auto modData1 = m_elements[1]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
     modData1->m_pathToFeature.tryFollow(testRecord);
     modData1->m_pathToSourceFeature.tryFollow(testFileFeature);
-    auto modData2 = dynamic_cast<const babelwires::IntValueAssignmentData*>(m_elements[1]->m_modifiers[1].get());
+    auto modData2 = m_elements[1]->m_modifiers[1].get()->asA<babelwires::IntValueAssignmentData>();
     modData2->m_pathToFeature.tryFollow(testRecord);
     m_elements[1]->m_expandedPaths[0].tryFollow(testRecord);
 }

--- a/Tests/BabelWires/TestUtils/testProjectData.cpp
+++ b/Tests/BabelWires/TestUtils/testProjectData.cpp
@@ -61,8 +61,8 @@ libTestUtils::TestProjectData::TestProjectData()
 
 void libTestUtils::TestProjectData::setFilePaths(std::string_view sourceFilePath, std::string_view targetFilePath) {
     assert(m_elements.size() == 3);
-    dynamic_cast<babelwires::SourceFileElementData&>(*m_elements[2]).m_filePath = sourceFilePath;
-    dynamic_cast<babelwires::TargetFileElementData&>(*m_elements[0]).m_filePath = targetFilePath;
+    m_elements[2]->asA<babelwires::SourceFileElementData>()->m_filePath = sourceFilePath;
+    m_elements[0]->asA<babelwires::TargetFileElementData>()->m_filePath = targetFilePath;
     m_sourceFilePath = sourceFilePath;
     m_targetFilePath = targetFilePath;
 }

--- a/Tests/BabelWires/TestUtils/testProjectData.cpp
+++ b/Tests/BabelWires/TestUtils/testProjectData.cpp
@@ -61,8 +61,8 @@ libTestUtils::TestProjectData::TestProjectData()
 
 void libTestUtils::TestProjectData::setFilePaths(std::string_view sourceFilePath, std::string_view targetFilePath) {
     assert(m_elements.size() == 3);
-    m_elements[2]->asA<babelwires::SourceFileElementData>()->m_filePath = sourceFilePath;
-    m_elements[0]->asA<babelwires::TargetFileElementData>()->m_filePath = targetFilePath;
+    m_elements[2]->as<babelwires::SourceFileElementData>()->m_filePath = sourceFilePath;
+    m_elements[0]->as<babelwires::TargetFileElementData>()->m_filePath = targetFilePath;
     m_sourceFilePath = sourceFilePath;
     m_targetFilePath = targetFilePath;
 }
@@ -87,7 +87,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
                       return a->m_pathToFeature < b->m_pathToFeature;
                   });
 
-        auto modData1 = sortedModifiers[0]->asA<babelwires::ConnectionModifierData>();
+        auto modData1 = sortedModifiers[0]->as<babelwires::ConnectionModifierData>();
         ASSERT_TRUE(modData1);
         EXPECT_EQ(*modData1->m_pathToFeature.getStep(0).asField(), libTestUtils::TestRecordFeature::s_intIdInitializer);
         EXPECT_EQ(modData1->m_pathToFeature.getStep(0).asField()->getDiscriminator(), recordIntDiscriminator);
@@ -95,7 +95,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
                   libTestUtils::TestFileFeature::s_intChildInitializer);
         EXPECT_EQ(modData1->m_pathToSourceFeature.getStep(0).asField()->getDiscriminator(), fileIntChildDiscriminator);
 
-        auto modData2 = sortedModifiers[1]->asA<babelwires::IntValueAssignmentData>();
+        auto modData2 = sortedModifiers[1]->as<babelwires::IntValueAssignmentData>();
         ASSERT_TRUE(modData2);
         ASSERT_GE(modData2->m_pathToFeature.getNumSteps(), 2);
         EXPECT_EQ(*modData2->m_pathToFeature.getStep(0).asField(),
@@ -116,7 +116,7 @@ void libTestUtils::TestProjectData::testProjectDataAndDisciminators(
 
     EXPECT_EQ(sortedElements[2]->m_id, 45);
     ASSERT_EQ(sortedElements[2]->m_modifiers.size(), 1);
-    auto modData0 = sortedElements[2]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
+    auto modData0 = sortedElements[2]->m_modifiers[0].get()->as<babelwires::ConnectionModifierData>();
     ASSERT_TRUE(modData0);
     EXPECT_EQ(*modData0->m_pathToFeature.getStep(0).asField(), libTestUtils::TestFileFeature::s_intChildInitializer);
     EXPECT_EQ(modData0->m_pathToFeature.getStep(0).asField()->getDiscriminator(), fileIntChildDiscriminator);
@@ -141,13 +141,13 @@ void libTestUtils::TestProjectData::resolvePathsInCurrentContext() {
     libTestUtils::TestFileFeature testFileFeature;
 
     // These have side-effects on the mutable field discriminators in the paths.
-    auto modData0 = m_elements[0]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
+    auto modData0 = m_elements[0]->m_modifiers[0].get()->as<babelwires::ConnectionModifierData>();
     modData0->m_pathToFeature.tryFollow(testFileFeature);
     modData0->m_pathToSourceFeature.tryFollow(testRecord);
-    auto modData1 = m_elements[1]->m_modifiers[0].get()->asA<babelwires::ConnectionModifierData>();
+    auto modData1 = m_elements[1]->m_modifiers[0].get()->as<babelwires::ConnectionModifierData>();
     modData1->m_pathToFeature.tryFollow(testRecord);
     modData1->m_pathToSourceFeature.tryFollow(testFileFeature);
-    auto modData2 = m_elements[1]->m_modifiers[1].get()->asA<babelwires::IntValueAssignmentData>();
+    auto modData2 = m_elements[1]->m_modifiers[1].get()->as<babelwires::IntValueAssignmentData>();
     modData2->m_pathToFeature.tryFollow(testRecord);
     m_elements[1]->m_expandedPaths[0].tryFollow(testRecord);
 }

--- a/Tests/BabelWires/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/activateOptionalCommandTest.cpp
@@ -18,10 +18,10 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::ActivateOptionalCommand command("Test command", elementId,
@@ -40,7 +40,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     {
         const babelwires::Modifier* modifier = element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(), nullptr);
+        EXPECT_NE(modifier->getModifierData().as<babelwires::ActivateOptionalsModifierData>(), nullptr);
     }
 
     command.undo(context.m_project);
@@ -58,7 +58,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     {
         const babelwires::Modifier* modifier = element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(), nullptr);
+        EXPECT_NE(modifier->getModifierData().as<babelwires::ActivateOptionalsModifierData>(), nullptr);
     }
 }
 
@@ -100,7 +100,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     babelwires::FieldIdentifier opId("flerm");
@@ -118,11 +118,11 @@ TEST(ActivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::ActivateOptionalCommand command("Test command", elementId,
@@ -138,11 +138,11 @@ TEST(ActivateOptionalsCommandTest, failSafelyAlreadyActivated) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     inputFeature->m_subrecord->activateField(inputFeature->m_op0Id);

--- a/Tests/BabelWires/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/activateOptionalCommandTest.cpp
@@ -40,7 +40,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     {
         const babelwires::Modifier* modifier = element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(dynamic_cast<const babelwires::ActivateOptionalsModifierData*>(&modifier->getModifierData()), nullptr);
+        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(), nullptr);
     }
 
     command.undo(context.m_project);
@@ -58,7 +58,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     {
         const babelwires::Modifier* modifier = element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(dynamic_cast<const babelwires::ActivateOptionalsModifierData*>(&modifier->getModifierData()), nullptr);
+        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(), nullptr);
     }
 }
 

--- a/Tests/BabelWires/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/activateOptionalCommandTest.cpp
@@ -18,10 +18,10 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::ActivateOptionalCommand command("Test command", elementId,
@@ -100,7 +100,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     babelwires::FieldIdentifier opId("flerm");
@@ -118,11 +118,11 @@ TEST(ActivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::ActivateOptionalCommand command("Test command", elementId,
@@ -138,11 +138,11 @@ TEST(ActivateOptionalsCommandTest, failSafelyAlreadyActivated) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     inputFeature->m_subrecord->activateField(inputFeature->m_op0Id);

--- a/Tests/BabelWires/addElementCommandTest.cpp
+++ b/Tests/BabelWires/addElementCommandTest.cpp
@@ -23,7 +23,7 @@ TEST(AddElementCommandTest, executeAndUndo) {
 
     const babelwires::FeatureElement* newElement = context.m_project.getFeatureElement(command.getElementId());
     ASSERT_NE(newElement, nullptr);
-    EXPECT_NE(dynamic_cast<const libTestUtils::TestFeatureElement*>(newElement), nullptr);
+    EXPECT_NE(newElement->asA<libTestUtils::TestFeatureElement>(), nullptr);
 
     command.undo(context.m_project);
 
@@ -33,7 +33,7 @@ TEST(AddElementCommandTest, executeAndUndo) {
 
     const babelwires::FeatureElement* restoredElement = context.m_project.getFeatureElement(command.getElementId());
     ASSERT_NE(restoredElement, nullptr);
-    EXPECT_NE(dynamic_cast<const libTestUtils::TestFeatureElement*>(restoredElement), nullptr);
+    EXPECT_NE(restoredElement->asA<libTestUtils::TestFeatureElement>(), nullptr);
 }
 
 TEST(AddElementCommandTest, subsumeMoves) {

--- a/Tests/BabelWires/addElementCommandTest.cpp
+++ b/Tests/BabelWires/addElementCommandTest.cpp
@@ -23,7 +23,7 @@ TEST(AddElementCommandTest, executeAndUndo) {
 
     const babelwires::FeatureElement* newElement = context.m_project.getFeatureElement(command.getElementId());
     ASSERT_NE(newElement, nullptr);
-    EXPECT_NE(newElement->asA<libTestUtils::TestFeatureElement>(), nullptr);
+    EXPECT_NE(newElement->as<libTestUtils::TestFeatureElement>(), nullptr);
 
     command.undo(context.m_project);
 
@@ -33,7 +33,7 @@ TEST(AddElementCommandTest, executeAndUndo) {
 
     const babelwires::FeatureElement* restoredElement = context.m_project.getFeatureElement(command.getElementId());
     ASSERT_NE(restoredElement, nullptr);
-    EXPECT_NE(restoredElement->asA<libTestUtils::TestFeatureElement>(), nullptr);
+    EXPECT_NE(restoredElement->as<libTestUtils::TestFeatureElement>(), nullptr);
 }
 
 TEST(AddElementCommandTest, subsumeMoves) {
@@ -55,7 +55,7 @@ TEST(AddElementCommandTest, subsumeMoves) {
     addCommand.undo(context.m_project);
     addCommand.execute(context.m_project);
     const auto* element =
-        context.m_project.getFeatureElement(addCommand.getElementId())->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(addCommand.getElementId())->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, 14);
     EXPECT_EQ(element->getUiPosition().m_y, 88);

--- a/Tests/BabelWires/addElementCommandTest.cpp
+++ b/Tests/BabelWires/addElementCommandTest.cpp
@@ -54,8 +54,8 @@ TEST(AddElementCommandTest, subsumeMoves) {
     // Confirm that the move was subsumed
     addCommand.undo(context.m_project);
     addCommand.execute(context.m_project);
-    const auto* element = dynamic_cast<const libTestUtils::TestFeatureElement*>(
-        context.m_project.getFeatureElement(addCommand.getElementId()));
+    const auto* element =
+        context.m_project.getFeatureElement(addCommand.getElementId())->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, 14);
     EXPECT_EQ(element->getUiPosition().m_y, 88);

--- a/Tests/BabelWires/addEntryToArrayCommandTest.cpp
+++ b/Tests/BabelWires/addEntryToArrayCommandTest.cpp
@@ -20,7 +20,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtIndex) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestRecordFeature* inputFeature =
-        dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
 
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
@@ -58,7 +58,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtEnd) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
 
@@ -125,7 +125,7 @@ TEST(AddEntryToArrayCommandTest, failSafelyOutOfRange) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
 
-    const auto* inputFeature = dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+    const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
 

--- a/Tests/BabelWires/addEntryToArrayCommandTest.cpp
+++ b/Tests/BabelWires/addEntryToArrayCommandTest.cpp
@@ -17,7 +17,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtIndex) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestRecordFeature* inputFeature =
         element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
@@ -55,7 +55,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtEnd) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
         return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
@@ -122,7 +122,7 @@ TEST(AddEntryToArrayCommandTest, failSafelyOutOfRange) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();

--- a/Tests/BabelWires/addEntryToArrayCommandTest.cpp
+++ b/Tests/BabelWires/addEntryToArrayCommandTest.cpp
@@ -17,10 +17,10 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtIndex) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestRecordFeature* inputFeature =
-        element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
 
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
@@ -55,10 +55,10 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtEnd) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        return element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
 
@@ -122,10 +122,10 @@ TEST(AddEntryToArrayCommandTest, failSafelyOutOfRange) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
-    const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+    const auto* inputFeature = element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
 

--- a/Tests/BabelWires/addModifierCommandTest.cpp
+++ b/Tests/BabelWires/addModifierCommandTest.cpp
@@ -19,7 +19,7 @@ TEST(AddModifierCommandTest, executeAndUndo) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
     EXPECT_NE(getInputFeature()->m_intFeature2->get(), 86);
@@ -67,7 +67,7 @@ TEST(AddModifierCommandTest, executeAndUndoPreexistingModifier) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
     EXPECT_EQ(getInputFeature()->m_intFeature2->get(), 77);

--- a/Tests/BabelWires/addModifierCommandTest.cpp
+++ b/Tests/BabelWires/addModifierCommandTest.cpp
@@ -16,10 +16,10 @@ TEST(AddModifierCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        return element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
     EXPECT_NE(getInputFeature()->m_intFeature2->get(), 86);
@@ -64,10 +64,10 @@ TEST(AddModifierCommandTest, executeAndUndoPreexistingModifier) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        return element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     };
     ASSERT_NE(getInputFeature(), nullptr);
     EXPECT_EQ(getInputFeature()->m_intFeature2->get(), 77);

--- a/Tests/BabelWires/addModifierCommandTest.cpp
+++ b/Tests/BabelWires/addModifierCommandTest.cpp
@@ -16,7 +16,7 @@ TEST(AddModifierCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
         return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
@@ -64,7 +64,7 @@ TEST(AddModifierCommandTest, executeAndUndoPreexistingModifier) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto getInputFeature = [element]() {
         return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();

--- a/Tests/BabelWires/changeFileCommandTest.cpp
+++ b/Tests/BabelWires/changeFileCommandTest.cpp
@@ -36,11 +36,11 @@ namespace {
 
         const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
         const auto* element =
-            context.m_project.getFeatureElement(elementId)->asA<babelwires::SourceFileElement>();
+            context.m_project.getFeatureElement(elementId)->as<babelwires::SourceFileElement>();
         ASSERT_NE(element, nullptr);
 
         const auto getOutputFeature = [element]() {
-            return element->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
+            return element->getOutputFeature()->as<const libTestUtils::TestFileFeature>();
         };
 
         EXPECT_EQ(element->getFilePath(), filePath1.m_filePath);
@@ -110,7 +110,7 @@ TEST(ChangeFileCommandTest, executeAndUndoTarget) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<babelwires::TargetFileElement>();
+        context.m_project.getFeatureElement(elementId)->as<babelwires::TargetFileElement>();
     ASSERT_NE(element, nullptr);
 
     EXPECT_EQ(element->getFilePath(), filePath1);

--- a/Tests/BabelWires/changeFileCommandTest.cpp
+++ b/Tests/BabelWires/changeFileCommandTest.cpp
@@ -40,7 +40,7 @@ namespace {
         ASSERT_NE(element, nullptr);
 
         const auto getOutputFeature = [element]() {
-            return dynamic_cast<const libTestUtils::TestFileFeature*>(element->getOutputFeature());
+            return element->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
         };
 
         EXPECT_EQ(element->getFilePath(), filePath1.m_filePath);

--- a/Tests/BabelWires/changeFileCommandTest.cpp
+++ b/Tests/BabelWires/changeFileCommandTest.cpp
@@ -36,7 +36,7 @@ namespace {
 
         const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
         const auto* element =
-            dynamic_cast<const babelwires::SourceFileElement*>(context.m_project.getFeatureElement(elementId));
+            context.m_project.getFeatureElement(elementId)->asA<babelwires::SourceFileElement>();
         ASSERT_NE(element, nullptr);
 
         const auto getOutputFeature = [element]() {
@@ -110,7 +110,7 @@ TEST(ChangeFileCommandTest, executeAndUndoTarget) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const auto* element =
-        dynamic_cast<const babelwires::TargetFileElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<babelwires::TargetFileElement>();
     ASSERT_NE(element, nullptr);
 
     EXPECT_EQ(element->getFilePath(), filePath1);

--- a/Tests/BabelWires/commandManagerTest.cpp
+++ b/Tests/BabelWires/commandManagerTest.cpp
@@ -23,7 +23,7 @@ namespace {
         void undo(babelwires::Project& project) const override { m_eventTrace.emplace_back(Event::undone); }
 
         bool shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const override {
-            const auto* newCommand = dynamic_cast<const TestCommand*>(&subsequentCommand);
+            const auto* newCommand = subsequentCommand.asA<TestCommand>();
             return (newCommand && newCommand->m_isSubsumable);
         }
 

--- a/Tests/BabelWires/commandManagerTest.cpp
+++ b/Tests/BabelWires/commandManagerTest.cpp
@@ -23,7 +23,7 @@ namespace {
         void undo(babelwires::Project& project) const override { m_eventTrace.emplace_back(Event::undone); }
 
         bool shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const override {
-            const auto* newCommand = subsequentCommand.asA<TestCommand>();
+            const auto* newCommand = subsequentCommand.as<TestCommand>();
             return (newCommand && newCommand->m_isSubsumable);
         }
 

--- a/Tests/BabelWires/connectionDescriptionTest.cpp
+++ b/Tests/BabelWires/connectionDescriptionTest.cpp
@@ -85,7 +85,7 @@ TEST(ConnectionDescriptionTest, getCommands) {
     }
 
     const libTestUtils::TestFeatureElement* targetElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(targetId));
+        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     context.m_project.process();

--- a/Tests/BabelWires/connectionDescriptionTest.cpp
+++ b/Tests/BabelWires/connectionDescriptionTest.cpp
@@ -85,7 +85,7 @@ TEST(ConnectionDescriptionTest, getCommands) {
     }
 
     const libTestUtils::TestFeatureElement* targetElement =
-        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(targetId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     context.m_project.process();
@@ -99,7 +99,7 @@ TEST(ConnectionDescriptionTest, getCommands) {
         if (isAdded) {
             ASSERT_NE(modifier, nullptr);
             const babelwires::ConnectionModifier* connection =
-                modifier->asA<babelwires::ConnectionModifier>();
+                modifier->as<babelwires::ConnectionModifier>();
             ASSERT_NE(connection, nullptr);
             EXPECT_EQ(connection->getModifierData().m_pathToFeature, connectionData.m_pathToFeature);
             EXPECT_EQ(connection->getModifierData().m_pathToSourceFeature, connectionData.m_pathToSourceFeature);

--- a/Tests/BabelWires/connectionDescriptionTest.cpp
+++ b/Tests/BabelWires/connectionDescriptionTest.cpp
@@ -99,7 +99,7 @@ TEST(ConnectionDescriptionTest, getCommands) {
         if (isAdded) {
             ASSERT_NE(modifier, nullptr);
             const babelwires::ConnectionModifier* connection =
-                dynamic_cast<const babelwires::ConnectionModifier*>(modifier);
+                modifier->asA<babelwires::ConnectionModifier>();
             ASSERT_NE(connection, nullptr);
             EXPECT_EQ(connection->getModifierData().m_pathToFeature, connectionData.m_pathToFeature);
             EXPECT_EQ(connection->getModifierData().m_pathToSourceFeature, connectionData.m_pathToSourceFeature);

--- a/Tests/BabelWires/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/deactivateOptionalCommandTest.cpp
@@ -23,14 +23,14 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     const babelwires::ElementId targetId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
-        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(targetId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        return element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     };
 
     ASSERT_NE(getInputFeature(), nullptr);
@@ -113,7 +113,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
         const babelwires::Modifier* modifier =
             element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(),
+        EXPECT_NE(modifier->getModifierData().as<babelwires::ActivateOptionalsModifierData>(),
                   nullptr);
     }
     checkModifiers(false);
@@ -164,7 +164,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+    const auto* element = context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     babelwires::FieldIdentifier opId("flerm");
@@ -182,11 +182,11 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+    const auto* element = context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::DeactivateOptionalCommand command(
@@ -202,11 +202,11 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+    const auto* element = context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::DeactivateOptionalCommand command(

--- a/Tests/BabelWires/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/deactivateOptionalCommandTest.cpp
@@ -23,8 +23,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     const babelwires::ElementId targetId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(
-            context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
         context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
@@ -165,8 +164,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(
-        context.m_project.getFeatureElement(elementId));
+    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     babelwires::FieldIdentifier opId("flerm");
@@ -184,8 +182,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(
-        context.m_project.getFeatureElement(elementId));
+    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
@@ -205,8 +202,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
     const babelwires::ElementId elementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
 
-    const auto* element = dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(
-        context.m_project.getFeatureElement(elementId));
+    const auto* element = context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =

--- a/Tests/BabelWires/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/deactivateOptionalCommandTest.cpp
@@ -27,7 +27,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
             context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(targetId));
+        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {

--- a/Tests/BabelWires/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/deactivateOptionalCommandTest.cpp
@@ -31,7 +31,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        return element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     };
 
     ASSERT_NE(getInputFeature(), nullptr);
@@ -189,7 +189,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::DeactivateOptionalCommand command(
@@ -210,7 +210,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const libTestUtils::TestFeatureWithOptionals* inputFeature =
-        dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
 
     babelwires::DeactivateOptionalCommand command(

--- a/Tests/BabelWires/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWires/deactivateOptionalCommandTest.cpp
@@ -114,7 +114,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
         const babelwires::Modifier* modifier =
             element->getEdits().findModifier(libTestUtils::TestFeatureWithOptionals::s_pathToSubrecord);
         EXPECT_NE(modifier, nullptr);
-        EXPECT_NE(dynamic_cast<const babelwires::ActivateOptionalsModifierData*>(&modifier->getModifierData()),
+        EXPECT_NE(modifier->getModifierData().asA<babelwires::ActivateOptionalsModifierData>(),
                   nullptr);
     }
     checkModifiers(false);

--- a/Tests/BabelWires/editTreeTest.cpp
+++ b/Tests/BabelWires/editTreeTest.cpp
@@ -87,12 +87,12 @@ TEST(EditTreeTest, severalModifier) {
     ASSERT_TRUE(tree.findModifier(path5));
     ASSERT_TRUE(tree.findModifier(path6));
 
-    ASSERT_TRUE(tree.findModifier(path1)->getModifierData().asA<babelwires::IntValueAssignmentData>());
-    ASSERT_TRUE(tree.findModifier(path2)->getModifierData().asA<babelwires::IntValueAssignmentData>());
-    ASSERT_TRUE(tree.findModifier(path3)->getModifierData().asA<babelwires::IntValueAssignmentData>());
-    ASSERT_TRUE(tree.findModifier(path4)->getModifierData().asA<babelwires::IntValueAssignmentData>());
-    ASSERT_TRUE(tree.findModifier(path5)->getModifierData().asA<babelwires::IntValueAssignmentData>());
-    ASSERT_TRUE(tree.findModifier(path6)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path1)->getModifierData().as<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path2)->getModifierData().as<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path3)->getModifierData().as<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path4)->getModifierData().as<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path5)->getModifierData().as<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path6)->getModifierData().as<babelwires::IntValueAssignmentData>());
 
     EXPECT_EQ(
         static_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path1)->getModifierData())->m_value,

--- a/Tests/BabelWires/editTreeTest.cpp
+++ b/Tests/BabelWires/editTreeTest.cpp
@@ -87,12 +87,12 @@ TEST(EditTreeTest, severalModifier) {
     ASSERT_TRUE(tree.findModifier(path5));
     ASSERT_TRUE(tree.findModifier(path6));
 
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path1)->getModifierData()));
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path2)->getModifierData()));
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path3)->getModifierData()));
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path4)->getModifierData()));
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path5)->getModifierData()));
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path6)->getModifierData()));
+    ASSERT_TRUE(tree.findModifier(path1)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path2)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path3)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path4)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path5)->getModifierData().asA<babelwires::IntValueAssignmentData>());
+    ASSERT_TRUE(tree.findModifier(path6)->getModifierData().asA<babelwires::IntValueAssignmentData>());
 
     EXPECT_EQ(
         static_cast<const babelwires::IntValueAssignmentData*>(&tree.findModifier(path1)->getModifierData())->m_value,

--- a/Tests/BabelWires/elementDataTest.cpp
+++ b/Tests/BabelWires/elementDataTest.cpp
@@ -144,7 +144,7 @@ TEST(ElementDataTest, sourceFileDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(dynamic_cast<const babelwires::SourceFileElement*>(featureElement.get()));
+    EXPECT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
     EXPECT_TRUE(featureElement->getOutputFeature());
     EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
@@ -240,7 +240,7 @@ TEST(ElementDataTest, targetFileDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(dynamic_cast<const babelwires::TargetFileElement*>(featureElement.get()));
+    EXPECT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
     EXPECT_TRUE(featureElement->getInputFeature());
     EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
@@ -329,7 +329,7 @@ TEST(ElementDataTest, processorDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(dynamic_cast<const babelwires::ProcessorElement*>(featureElement.get()));
+    EXPECT_TRUE(featureElement->asA<babelwires::ProcessorElement>());
     EXPECT_TRUE(featureElement->getInputFeature());
     EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);

--- a/Tests/BabelWires/elementDataTest.cpp
+++ b/Tests/BabelWires/elementDataTest.cpp
@@ -146,7 +146,7 @@ TEST(ElementDataTest, sourceFileDataCreateElement) {
     ASSERT_FALSE(featureElement->isFailed());
     EXPECT_TRUE(dynamic_cast<const babelwires::SourceFileElement*>(featureElement.get()));
     EXPECT_TRUE(featureElement->getOutputFeature());
-    EXPECT_TRUE(dynamic_cast<const libTestUtils::TestFileFeature*>(featureElement->getOutputFeature()));
+    EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
     EXPECT_TRUE(dynamic_cast<const babelwires::SourceFileElementData*>(&featureElement->getElementData()));
@@ -242,7 +242,7 @@ TEST(ElementDataTest, targetFileDataCreateElement) {
     ASSERT_FALSE(featureElement->isFailed());
     EXPECT_TRUE(dynamic_cast<const babelwires::TargetFileElement*>(featureElement.get()));
     EXPECT_TRUE(featureElement->getInputFeature());
-    EXPECT_TRUE(dynamic_cast<const libTestUtils::TestFileFeature*>(featureElement->getInputFeature()));
+    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
     EXPECT_TRUE(dynamic_cast<const babelwires::TargetFileElementData*>(&featureElement->getElementData()));
@@ -331,7 +331,7 @@ TEST(ElementDataTest, processorDataCreateElement) {
     ASSERT_FALSE(featureElement->isFailed());
     EXPECT_TRUE(dynamic_cast<const babelwires::ProcessorElement*>(featureElement.get()));
     EXPECT_TRUE(featureElement->getInputFeature());
-    EXPECT_TRUE(dynamic_cast<const libTestUtils::TestRecordFeature*>(featureElement->getInputFeature()));
+    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
     EXPECT_TRUE(dynamic_cast<const babelwires::ProcessorElementData*>(&featureElement->getElementData()));

--- a/Tests/BabelWires/elementDataTest.cpp
+++ b/Tests/BabelWires/elementDataTest.cpp
@@ -54,7 +54,7 @@ namespace {
 
     void checkModifiers(const babelwires::ElementData& data, const char* pathStep) {
         EXPECT_EQ(data.m_modifiers.size(), 1);
-        EXPECT_NE(dynamic_cast<const babelwires::IntValueAssignmentData*>(data.m_modifiers[0].get()), nullptr);
+        EXPECT_NE(data.m_modifiers[0]->asA<babelwires::IntValueAssignmentData>(), nullptr);
         const auto& mod = static_cast<const babelwires::IntValueAssignmentData&>(*data.m_modifiers[0]);
         EXPECT_EQ(mod.m_pathToFeature, babelwires::FeaturePath::deserializeFromString(pathStep));
         EXPECT_EQ(mod.m_value, 12);

--- a/Tests/BabelWires/elementDataTest.cpp
+++ b/Tests/BabelWires/elementDataTest.cpp
@@ -149,7 +149,7 @@ TEST(ElementDataTest, sourceFileDataCreateElement) {
     EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(dynamic_cast<const babelwires::SourceFileElementData*>(&featureElement->getElementData()));
+    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::SourceFileElementData>());
     EXPECT_EQ(static_cast<const babelwires::SourceFileElementData&>(featureElement->getElementData()).m_filePath,
               data.m_filePath);
 
@@ -245,7 +245,7 @@ TEST(ElementDataTest, targetFileDataCreateElement) {
     EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(dynamic_cast<const babelwires::TargetFileElementData*>(&featureElement->getElementData()));
+    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::TargetFileElementData>());
     EXPECT_EQ(static_cast<const babelwires::TargetFileElementData&>(featureElement->getElementData()).m_filePath,
               data.m_filePath);
 
@@ -334,7 +334,7 @@ TEST(ElementDataTest, processorDataCreateElement) {
     EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(dynamic_cast<const babelwires::ProcessorElementData*>(&featureElement->getElementData()));
+    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::ProcessorElementData>());
 
     const libTestUtils::TestRecordFeature* inputFeature =
         static_cast<const libTestUtils::TestRecordFeature*>(featureElement->getInputFeature());

--- a/Tests/BabelWires/elementDataTest.cpp
+++ b/Tests/BabelWires/elementDataTest.cpp
@@ -54,7 +54,7 @@ namespace {
 
     void checkModifiers(const babelwires::ElementData& data, const char* pathStep) {
         EXPECT_EQ(data.m_modifiers.size(), 1);
-        EXPECT_NE(data.m_modifiers[0]->asA<babelwires::IntValueAssignmentData>(), nullptr);
+        EXPECT_NE(data.m_modifiers[0]->as<babelwires::IntValueAssignmentData>(), nullptr);
         const auto& mod = static_cast<const babelwires::IntValueAssignmentData&>(*data.m_modifiers[0]);
         EXPECT_EQ(mod.m_pathToFeature, babelwires::FeaturePath::deserializeFromString(pathStep));
         EXPECT_EQ(mod.m_value, 12);
@@ -144,12 +144,12 @@ TEST(ElementDataTest, sourceFileDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
+    EXPECT_TRUE(featureElement->as<babelwires::SourceFileElement>());
     EXPECT_TRUE(featureElement->getOutputFeature());
-    EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>());
+    EXPECT_TRUE(featureElement->getOutputFeature()->as<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::SourceFileElementData>());
+    EXPECT_TRUE(featureElement->getElementData().as<babelwires::SourceFileElementData>());
     EXPECT_EQ(static_cast<const babelwires::SourceFileElementData&>(featureElement->getElementData()).m_filePath,
               data.m_filePath);
 
@@ -240,12 +240,12 @@ TEST(ElementDataTest, targetFileDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
+    EXPECT_TRUE(featureElement->as<babelwires::TargetFileElement>());
     EXPECT_TRUE(featureElement->getInputFeature());
-    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>());
+    EXPECT_TRUE(featureElement->getInputFeature()->as<const libTestUtils::TestFileFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::TargetFileElementData>());
+    EXPECT_TRUE(featureElement->getElementData().as<babelwires::TargetFileElementData>());
     EXPECT_EQ(static_cast<const babelwires::TargetFileElementData&>(featureElement->getElementData()).m_filePath,
               data.m_filePath);
 
@@ -329,12 +329,12 @@ TEST(ElementDataTest, processorDataCreateElement) {
 
     EXPECT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    EXPECT_TRUE(featureElement->asA<babelwires::ProcessorElement>());
+    EXPECT_TRUE(featureElement->as<babelwires::ProcessorElement>());
     EXPECT_TRUE(featureElement->getInputFeature());
-    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
+    EXPECT_TRUE(featureElement->getInputFeature()->as<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementData().m_factoryIdentifier, data.m_factoryIdentifier);
     EXPECT_EQ(featureElement->getElementData().m_factoryVersion, data.m_factoryVersion);
-    EXPECT_TRUE(featureElement->getElementData().asA<babelwires::ProcessorElementData>());
+    EXPECT_TRUE(featureElement->getElementData().as<babelwires::ProcessorElementData>());
 
     const libTestUtils::TestRecordFeature* inputFeature =
         static_cast<const libTestUtils::TestRecordFeature*>(featureElement->getInputFeature());

--- a/Tests/BabelWires/featureElementConnectionTest.cpp
+++ b/Tests/BabelWires/featureElementConnectionTest.cpp
@@ -20,7 +20,7 @@ struct FeatureElementConnectionTest : ::testing::Test {
 
         auto featureElement = featureElementData.createFeatureElement(m_context.m_projectContext, m_context.m_log, 66);
         m_featureElement = std::unique_ptr<libTestUtils::TestFeatureElement>(
-            featureElement.release()->asA<libTestUtils::TestFeatureElement>());
+            featureElement.release()->as<libTestUtils::TestFeatureElement>());
         ASSERT_TRUE(m_featureElement);
         m_featureElement->clearChanges();
 
@@ -37,7 +37,7 @@ struct FeatureElementConnectionTest : ::testing::Test {
         sourceElementData.m_intValueLimit = 1000;
         m_sourceId = m_context.m_project.addFeatureElement(sourceElementData);
         m_sourceElement =
-            m_context.m_project.getFeatureElement(m_sourceId)->asA<libTestUtils::TestFeatureElement>();
+            m_context.m_project.getFeatureElement(m_sourceId)->as<libTestUtils::TestFeatureElement>();
         ASSERT_TRUE(m_sourceElement);
 
         m_arrayInitData.m_pathToFeature = m_arrayPath;

--- a/Tests/BabelWires/featureElementConnectionTest.cpp
+++ b/Tests/BabelWires/featureElementConnectionTest.cpp
@@ -20,7 +20,7 @@ struct FeatureElementConnectionTest : ::testing::Test {
 
         auto featureElement = featureElementData.createFeatureElement(m_context.m_projectContext, m_context.m_log, 66);
         m_featureElement = std::unique_ptr<libTestUtils::TestFeatureElement>(
-            dynamic_cast<libTestUtils::TestFeatureElement*>(featureElement.release()));
+            featureElement.release()->asA<libTestUtils::TestFeatureElement>());
         ASSERT_TRUE(m_featureElement);
         m_featureElement->clearChanges();
 
@@ -37,7 +37,7 @@ struct FeatureElementConnectionTest : ::testing::Test {
         sourceElementData.m_intValueLimit = 1000;
         m_sourceId = m_context.m_project.addFeatureElement(sourceElementData);
         m_sourceElement =
-            dynamic_cast<libTestUtils::TestFeatureElement*>(m_context.m_project.getFeatureElement(m_sourceId));
+            m_context.m_project.getFeatureElement(m_sourceId)->asA<libTestUtils::TestFeatureElement>();
         ASSERT_TRUE(m_sourceElement);
 
         m_arrayInitData.m_pathToFeature = m_arrayPath;

--- a/Tests/BabelWires/featureElementTest.cpp
+++ b/Tests/BabelWires/featureElementTest.cpp
@@ -370,7 +370,7 @@ TEST(FeatureElementTest, failure) {
     auto featureElement = featureElementData.createFeatureElement(context.m_projectContext, context.m_log, 66);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<libTestUtils::TestFeatureElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
     libTestUtils::TestFeatureElement* testFeatureElement =
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get());
 
@@ -473,7 +473,7 @@ TEST(FeatureElementTest, simpleChanges) {
     }
     {
         featureElement->clearChanges();
-        ASSERT_TRUE(dynamic_cast<libTestUtils::TestFeatureElement*>(featureElement.get()));
+        ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get())->simulateFailure();
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureElementFailed));
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureStructureChanged));
@@ -481,7 +481,7 @@ TEST(FeatureElementTest, simpleChanges) {
     }
     {
         featureElement->clearChanges();
-        ASSERT_TRUE(dynamic_cast<libTestUtils::TestFeatureElement*>(featureElement.get()));
+        ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get())->simulateRecovery();
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureElementRecovered));
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureStructureChanged));
@@ -497,7 +497,7 @@ TEST(FeatureElementTest, isInDependencyLoop) {
     auto featureElement = featureElementData.createFeatureElement(context.m_projectContext, context.m_log, 66);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<libTestUtils::TestFeatureElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
 
     featureElement->clearChanges();
     featureElement->setInDependencyLoop(true);

--- a/Tests/BabelWires/featureElementTest.cpp
+++ b/Tests/BabelWires/featureElementTest.cpp
@@ -99,7 +99,7 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* arrayInitData = featureElement->findModifier(arrayPath);
         ASSERT_TRUE(arrayInitData);
         EXPECT_FALSE(arrayInitData->isFailed());
-        ASSERT_TRUE(dynamic_cast<const babelwires::ArraySizeModifierData*>(&arrayInitData->getModifierData()));
+        ASSERT_TRUE(arrayInitData->getModifierData().asA<babelwires::ArraySizeModifierData>());
         EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData*>(&arrayInitData->getModifierData())->m_size,
                   5);
     }
@@ -283,7 +283,7 @@ TEST(FeatureElementTest, extractElementData) {
     ASSERT_EQ(extractedData->m_modifiers.size(), 3);
     // We assume extracted data is sorted, though that assumption is not part of the guarantee.
     EXPECT_EQ(extractedData->m_modifiers[0]->m_pathToFeature, arrayPath);
-    EXPECT_TRUE(dynamic_cast<const babelwires::ArraySizeModifierData*>(extractedData->m_modifiers[0].get()));
+    EXPECT_TRUE(extractedData->m_modifiers[0].get()->asA<babelwires::ArraySizeModifierData>());
     EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData*>(extractedData->m_modifiers[0].get())->m_size, 5);
     EXPECT_EQ(extractedData->m_modifiers[1]->m_pathToFeature, arrayElemPath2);
     EXPECT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[1].get()));

--- a/Tests/BabelWires/featureElementTest.cpp
+++ b/Tests/BabelWires/featureElementTest.cpp
@@ -24,8 +24,8 @@ TEST(FeatureElementTest, basicAccessors) {
     EXPECT_FALSE(featureElement->isFailed());
     EXPECT_TRUE(featureElement->getInputFeature());
     EXPECT_TRUE(featureElement->getOutputFeature());
-    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
-    EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestRecordFeature>());
+    EXPECT_TRUE(featureElement->getInputFeature()->as<const libTestUtils::TestRecordFeature>());
+    EXPECT_TRUE(featureElement->getOutputFeature()->as<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementId(), 54);
 }
 
@@ -99,7 +99,7 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* arrayInitData = featureElement->findModifier(arrayPath);
         ASSERT_TRUE(arrayInitData);
         EXPECT_FALSE(arrayInitData->isFailed());
-        ASSERT_TRUE(arrayInitData->getModifierData().asA<babelwires::ArraySizeModifierData>());
+        ASSERT_TRUE(arrayInitData->getModifierData().as<babelwires::ArraySizeModifierData>());
         EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData*>(&arrayInitData->getModifierData())->m_size,
                   5);
     }
@@ -107,7 +107,7 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* arrayElemData = featureElement->findModifier(arrayElemPath);
         ASSERT_TRUE(arrayElemData);
         EXPECT_FALSE(arrayElemData->isFailed());
-        ASSERT_TRUE(arrayElemData->getModifierData().asA<babelwires::IntValueAssignmentData>());
+        ASSERT_TRUE(arrayElemData->getModifierData().as<babelwires::IntValueAssignmentData>());
         EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&arrayElemData->getModifierData())->m_value,
                   16);
     }
@@ -115,17 +115,17 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* failedModifier = featureElement->findModifier(failedPath);
         ASSERT_TRUE(failedModifier);
         EXPECT_TRUE(failedModifier->isFailed());
-        ASSERT_TRUE(failedModifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
+        ASSERT_TRUE(failedModifier->getModifierData().as<babelwires::IntValueAssignmentData>());
         EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&failedModifier->getModifierData())->m_value,
                   71);
     }
     const babelwires::RecordFeature* const recordFeature = featureElement->getInputFeature();
     ASSERT_TRUE(recordFeature);
     const libTestUtils::TestRecordFeature* const testRecordFeature =
-        recordFeature->asA<const libTestUtils::TestRecordFeature>();
+        recordFeature->as<const libTestUtils::TestRecordFeature>();
     ASSERT_TRUE(testRecordFeature);
     EXPECT_EQ(testRecordFeature->m_arrayFeature->getNumFeatures(), 5);
-    ASSERT_TRUE(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3)->asA<const babelwires::IntFeature>());
+    ASSERT_TRUE(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3)->as<const babelwires::IntFeature>());
     EXPECT_EQ(
         static_cast<const babelwires::IntFeature*>(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3))->get(),
         16);
@@ -283,14 +283,14 @@ TEST(FeatureElementTest, extractElementData) {
     ASSERT_EQ(extractedData->m_modifiers.size(), 3);
     // We assume extracted data is sorted, though that assumption is not part of the guarantee.
     EXPECT_EQ(extractedData->m_modifiers[0]->m_pathToFeature, arrayPath);
-    EXPECT_TRUE(extractedData->m_modifiers[0].get()->asA<babelwires::ArraySizeModifierData>());
+    EXPECT_TRUE(extractedData->m_modifiers[0].get()->as<babelwires::ArraySizeModifierData>());
     EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData*>(extractedData->m_modifiers[0].get())->m_size, 5);
     EXPECT_EQ(extractedData->m_modifiers[1]->m_pathToFeature, arrayElemPath2);
-    EXPECT_TRUE(extractedData->m_modifiers[1]->asA<babelwires::IntValueAssignmentData>());
+    EXPECT_TRUE(extractedData->m_modifiers[1]->as<babelwires::IntValueAssignmentData>());
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[1].get())->m_value, 12);
     // Even though this modifier is currently failed, its data is still important.
     EXPECT_EQ(extractedData->m_modifiers[2]->m_pathToFeature, failedPath);
-    EXPECT_TRUE(extractedData->m_modifiers[2]->asA<babelwires::IntValueAssignmentData>());
+    EXPECT_TRUE(extractedData->m_modifiers[2]->as<babelwires::IntValueAssignmentData>());
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[2].get())->m_value, 71);
 
     // The failed path is not included.
@@ -346,13 +346,13 @@ TEST(FeatureElementTest, removedModifiers) {
     for (const auto modifier : featureElement->getRemovedModifiers()) {
         ++numMods;
         if (modifier->getModifierData().m_pathToFeature == arrayElemPath) {
-            ASSERT_TRUE(modifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
+            ASSERT_TRUE(modifier->getModifierData().as<babelwires::IntValueAssignmentData>());
             EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData())->m_value,
                       16);
             ++numCorrectMods;
         }
         if (modifier->getModifierData().m_pathToFeature == failedPath) {
-            ASSERT_TRUE(modifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
+            ASSERT_TRUE(modifier->getModifierData().as<babelwires::IntValueAssignmentData>());
             EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData())->m_value,
                       71);
             ++numCorrectMods;
@@ -370,7 +370,7 @@ TEST(FeatureElementTest, failure) {
     auto featureElement = featureElementData.createFeatureElement(context.m_projectContext, context.m_log, 66);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
+    ASSERT_TRUE(featureElement->as<libTestUtils::TestFeatureElement>());
     libTestUtils::TestFeatureElement* testFeatureElement =
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get());
 
@@ -473,7 +473,7 @@ TEST(FeatureElementTest, simpleChanges) {
     }
     {
         featureElement->clearChanges();
-        ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
+        ASSERT_TRUE(featureElement->as<libTestUtils::TestFeatureElement>());
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get())->simulateFailure();
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureElementFailed));
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureStructureChanged));
@@ -481,7 +481,7 @@ TEST(FeatureElementTest, simpleChanges) {
     }
     {
         featureElement->clearChanges();
-        ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
+        ASSERT_TRUE(featureElement->as<libTestUtils::TestFeatureElement>());
         static_cast<libTestUtils::TestFeatureElement*>(featureElement.get())->simulateRecovery();
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureElementRecovered));
         EXPECT_TRUE(featureElement->isChanged(babelwires::FeatureElement::Changes::FeatureStructureChanged));
@@ -497,7 +497,7 @@ TEST(FeatureElementTest, isInDependencyLoop) {
     auto featureElement = featureElementData.createFeatureElement(context.m_projectContext, context.m_log, 66);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<libTestUtils::TestFeatureElement>());
+    ASSERT_TRUE(featureElement->as<libTestUtils::TestFeatureElement>());
 
     featureElement->clearChanges();
     featureElement->setInDependencyLoop(true);

--- a/Tests/BabelWires/featureElementTest.cpp
+++ b/Tests/BabelWires/featureElementTest.cpp
@@ -24,8 +24,8 @@ TEST(FeatureElementTest, basicAccessors) {
     EXPECT_FALSE(featureElement->isFailed());
     EXPECT_TRUE(featureElement->getInputFeature());
     EXPECT_TRUE(featureElement->getOutputFeature());
-    EXPECT_TRUE(dynamic_cast<const libTestUtils::TestRecordFeature*>(featureElement->getInputFeature()));
-    EXPECT_TRUE(dynamic_cast<const libTestUtils::TestRecordFeature*>(featureElement->getOutputFeature()));
+    EXPECT_TRUE(featureElement->getInputFeature()->asA<const libTestUtils::TestRecordFeature>());
+    EXPECT_TRUE(featureElement->getOutputFeature()->asA<const libTestUtils::TestRecordFeature>());
     EXPECT_EQ(featureElement->getElementId(), 54);
 }
 
@@ -122,10 +122,10 @@ TEST(FeatureElementTest, modifiers) {
     const babelwires::RecordFeature* const recordFeature = featureElement->getInputFeature();
     ASSERT_TRUE(recordFeature);
     const libTestUtils::TestRecordFeature* const testRecordFeature =
-        dynamic_cast<const libTestUtils::TestRecordFeature*>(recordFeature);
+        recordFeature->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_TRUE(testRecordFeature);
     EXPECT_EQ(testRecordFeature->m_arrayFeature->getNumFeatures(), 5);
-    ASSERT_TRUE(dynamic_cast<const babelwires::IntFeature*>(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3)));
+    ASSERT_TRUE(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3)->asA<const babelwires::IntFeature>());
     EXPECT_EQ(
         static_cast<const babelwires::IntFeature*>(testRecordFeature->m_arrayFeature->tryGetChildFromStep(3))->get(),
         16);

--- a/Tests/BabelWires/featureElementTest.cpp
+++ b/Tests/BabelWires/featureElementTest.cpp
@@ -107,7 +107,7 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* arrayElemData = featureElement->findModifier(arrayElemPath);
         ASSERT_TRUE(arrayElemData);
         EXPECT_FALSE(arrayElemData->isFailed());
-        ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&arrayElemData->getModifierData()));
+        ASSERT_TRUE(arrayElemData->getModifierData().asA<babelwires::IntValueAssignmentData>());
         EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&arrayElemData->getModifierData())->m_value,
                   16);
     }
@@ -115,7 +115,7 @@ TEST(FeatureElementTest, modifiers) {
         const babelwires::Modifier* failedModifier = featureElement->findModifier(failedPath);
         ASSERT_TRUE(failedModifier);
         EXPECT_TRUE(failedModifier->isFailed());
-        ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&failedModifier->getModifierData()));
+        ASSERT_TRUE(failedModifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
         EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&failedModifier->getModifierData())->m_value,
                   71);
     }
@@ -286,11 +286,11 @@ TEST(FeatureElementTest, extractElementData) {
     EXPECT_TRUE(extractedData->m_modifiers[0].get()->asA<babelwires::ArraySizeModifierData>());
     EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData*>(extractedData->m_modifiers[0].get())->m_size, 5);
     EXPECT_EQ(extractedData->m_modifiers[1]->m_pathToFeature, arrayElemPath2);
-    EXPECT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[1].get()));
+    EXPECT_TRUE(extractedData->m_modifiers[1]->asA<babelwires::IntValueAssignmentData>());
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[1].get())->m_value, 12);
     // Even though this modifier is currently failed, its data is still important.
     EXPECT_EQ(extractedData->m_modifiers[2]->m_pathToFeature, failedPath);
-    EXPECT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[2].get()));
+    EXPECT_TRUE(extractedData->m_modifiers[2]->asA<babelwires::IntValueAssignmentData>());
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(extractedData->m_modifiers[2].get())->m_value, 71);
 
     // The failed path is not included.
@@ -346,13 +346,13 @@ TEST(FeatureElementTest, removedModifiers) {
     for (const auto modifier : featureElement->getRemovedModifiers()) {
         ++numMods;
         if (modifier->getModifierData().m_pathToFeature == arrayElemPath) {
-            ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData()));
+            ASSERT_TRUE(modifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
             EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData())->m_value,
                       16);
             ++numCorrectMods;
         }
         if (modifier->getModifierData().m_pathToFeature == failedPath) {
-            ASSERT_TRUE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData()));
+            ASSERT_TRUE(modifier->getModifierData().asA<babelwires::IntValueAssignmentData>());
             EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData*>(&modifier->getModifierData())->m_value,
                       71);
             ++numCorrectMods;

--- a/Tests/BabelWires/featureTest.cpp
+++ b/Tests/BabelWires/featureTest.cpp
@@ -340,7 +340,7 @@ TEST(FeatureTest, arrayFeature) {
 
     babelwires::Feature* entry = arrayFeature.addEntry();
     EXPECT_NE(entry, nullptr);
-    babelwires::IntFeature* firstEntry = entry->asA<babelwires::IntFeature>();
+    babelwires::IntFeature* firstEntry = entry->as<babelwires::IntFeature>();
     EXPECT_NE(firstEntry, nullptr);
 
     EXPECT_EQ(arrayFeature.getNumFeatures(), 1);

--- a/Tests/BabelWires/featureTest.cpp
+++ b/Tests/BabelWires/featureTest.cpp
@@ -340,7 +340,7 @@ TEST(FeatureTest, arrayFeature) {
 
     babelwires::Feature* entry = arrayFeature.addEntry();
     EXPECT_NE(entry, nullptr);
-    babelwires::IntFeature* firstEntry = dynamic_cast<babelwires::IntFeature*>(entry);
+    babelwires::IntFeature* firstEntry = entry->asA<babelwires::IntFeature>();
     EXPECT_NE(firstEntry, nullptr);
 
     EXPECT_EQ(arrayFeature.getNumFeatures(), 1);

--- a/Tests/BabelWires/modifierDataTest.cpp
+++ b/Tests/BabelWires/modifierDataTest.cpp
@@ -277,26 +277,26 @@ TEST(ModifierDataTest, createModifierMethods) {
     {
         babelwires::ArraySizeModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(dynamic_cast<babelwires::ArraySizeModifier*>(data.createModifier().get()), nullptr);
+        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::ArraySizeModifier>();
     }
     {
         babelwires::IntValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(dynamic_cast<babelwires::LocalModifier*>(data.createModifier().get()), nullptr);
+        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
     }
     {
         babelwires::RationalValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(dynamic_cast<babelwires::LocalModifier*>(data.createModifier().get()), nullptr);
+        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
     }
     {
         babelwires::StringValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(dynamic_cast<babelwires::LocalModifier*>(data.createModifier().get()), nullptr);
+        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
     }
     {
         babelwires::ConnectionModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(dynamic_cast<babelwires::ConnectionModifier*>(data.createModifier().get()), nullptr);
+        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::ConnectionModifier>();
     }
 }

--- a/Tests/BabelWires/modifierDataTest.cpp
+++ b/Tests/BabelWires/modifierDataTest.cpp
@@ -277,26 +277,26 @@ TEST(ModifierDataTest, createModifierMethods) {
     {
         babelwires::ArraySizeModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier()->asA<babelwires::ArraySizeModifier>(), nullptr);
+        EXPECT_NE(data.createModifier()->as<babelwires::ArraySizeModifier>(), nullptr);
     }
     {
         babelwires::IntValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
+        EXPECT_NE(data.createModifier()->as<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::RationalValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
+        EXPECT_NE(data.createModifier()->as<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::StringValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
+        EXPECT_NE(data.createModifier()->as<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::ConnectionModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier()->asA<babelwires::ConnectionModifier>(), nullptr);
+        EXPECT_NE(data.createModifier()->as<babelwires::ConnectionModifier>(), nullptr);
     }
 }

--- a/Tests/BabelWires/modifierDataTest.cpp
+++ b/Tests/BabelWires/modifierDataTest.cpp
@@ -277,26 +277,26 @@ TEST(ModifierDataTest, createModifierMethods) {
     {
         babelwires::ArraySizeModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::ArraySizeModifier>();
+        EXPECT_NE(data.createModifier()->asA<babelwires::ArraySizeModifier>(), nullptr);
     }
     {
         babelwires::IntValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
+        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::RationalValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
+        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::StringValueAssignmentData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::LocalModifier>();
+        EXPECT_NE(data.createModifier()->asA<babelwires::LocalModifier>(), nullptr);
     }
     {
         babelwires::ConnectionModifierData data;
         ASSERT_NE(data.createModifier(), nullptr);
-        EXPECT_NE(data.createModifier().get()), nullptr->asA<babelwires::ConnectionModifier>();
+        EXPECT_NE(data.createModifier()->asA<babelwires::ConnectionModifier>(), nullptr);
     }
 }

--- a/Tests/BabelWires/modifierTest.cpp
+++ b/Tests/BabelWires/modifierTest.cpp
@@ -186,25 +186,25 @@ TEST(ModifierTest, arraySizeModifierSuccess) {
     EXPECT_EQ(arrayMod.getState(), babelwires::Modifier::State::Success);
     EXPECT_EQ(arrayFeature->getNumFeatures(), 3);
 
-    dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(0)).set(10);
-    dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(1)).set(11);
-    dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(2)).set(12);
+    arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->set(10);
+    arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->set(11);
+    arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->set(12);
 
     EXPECT_TRUE(arrayMod.addArrayEntries(testLog, &recordFeature, 1, 2));
 
     EXPECT_EQ(arrayFeature->getNumFeatures(), 5);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(0)).get(), 10);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(1)).get(), 0);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(2)).get(), 0);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(3)).get(), 11);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(4)).get(), 12);
+    EXPECT_EQ(arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->get(), 10);
+    EXPECT_EQ(arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(3)->asA<babelwires::IntFeature>()->get(), 11);
+    EXPECT_EQ(arrayFeature->getFeature(4)->asA<babelwires::IntFeature>()->get(), 12);
 
     EXPECT_TRUE(arrayMod.removeArrayEntries(testLog, &recordFeature, 2, 2));
 
     EXPECT_EQ(arrayFeature->getNumFeatures(), 3);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(0)).get(), 10);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(1)).get(), 0);
-    EXPECT_EQ(dynamic_cast<babelwires::IntFeature&>(*arrayFeature->getFeature(2)).get(), 12);
+    EXPECT_EQ(arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->get(), 10);
+    EXPECT_EQ(arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->get(), 12);
 }
 
 TEST(ModifierTest, arraySizeModifierFailure) {

--- a/Tests/BabelWires/modifierTest.cpp
+++ b/Tests/BabelWires/modifierTest.cpp
@@ -38,7 +38,7 @@ TEST(ModifierTest, basicStuff) {
     EXPECT_EQ(intMod.asConnectionModifier(), nullptr);
     EXPECT_EQ(intMod.getModifierData().m_pathToFeature, path);
     EXPECT_EQ(intMod.getPathToFeature(), path);
-    EXPECT_NE(intMod.getModifierData().asA<babelwires::IntValueAssignmentData>(), nullptr);
+    EXPECT_NE(intMod.getModifierData().as<babelwires::IntValueAssignmentData>(), nullptr);
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData&>(intMod.getModifierData()).m_value, 198);
 
     EXPECT_EQ(const_cast<const babelwires::LocalModifier&>(intMod).getOwner(), nullptr);
@@ -59,7 +59,7 @@ TEST(ModifierTest, clone) {
     auto clone = intMod.clone();
     ASSERT_NE(clone, nullptr);
     EXPECT_EQ(clone->getModifierData().m_pathToFeature, path);
-    EXPECT_NE(clone->getModifierData().asA<babelwires::IntValueAssignmentData>(), nullptr);
+    EXPECT_NE(clone->getModifierData().as<babelwires::IntValueAssignmentData>(), nullptr);
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData&>(clone->getModifierData()).m_value, 198);
 }
 
@@ -186,25 +186,25 @@ TEST(ModifierTest, arraySizeModifierSuccess) {
     EXPECT_EQ(arrayMod.getState(), babelwires::Modifier::State::Success);
     EXPECT_EQ(arrayFeature->getNumFeatures(), 3);
 
-    arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->set(10);
-    arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->set(11);
-    arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->set(12);
+    arrayFeature->getFeature(0)->as<babelwires::IntFeature>()->set(10);
+    arrayFeature->getFeature(1)->as<babelwires::IntFeature>()->set(11);
+    arrayFeature->getFeature(2)->as<babelwires::IntFeature>()->set(12);
 
     EXPECT_TRUE(arrayMod.addArrayEntries(testLog, &recordFeature, 1, 2));
 
     EXPECT_EQ(arrayFeature->getNumFeatures(), 5);
-    EXPECT_EQ(arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->get(), 10);
-    EXPECT_EQ(arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->get(), 0);
-    EXPECT_EQ(arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->get(), 0);
-    EXPECT_EQ(arrayFeature->getFeature(3)->asA<babelwires::IntFeature>()->get(), 11);
-    EXPECT_EQ(arrayFeature->getFeature(4)->asA<babelwires::IntFeature>()->get(), 12);
+    EXPECT_EQ(arrayFeature->getFeature(0)->as<babelwires::IntFeature>()->get(), 10);
+    EXPECT_EQ(arrayFeature->getFeature(1)->as<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(2)->as<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(3)->as<babelwires::IntFeature>()->get(), 11);
+    EXPECT_EQ(arrayFeature->getFeature(4)->as<babelwires::IntFeature>()->get(), 12);
 
     EXPECT_TRUE(arrayMod.removeArrayEntries(testLog, &recordFeature, 2, 2));
 
     EXPECT_EQ(arrayFeature->getNumFeatures(), 3);
-    EXPECT_EQ(arrayFeature->getFeature(0)->asA<babelwires::IntFeature>()->get(), 10);
-    EXPECT_EQ(arrayFeature->getFeature(1)->asA<babelwires::IntFeature>()->get(), 0);
-    EXPECT_EQ(arrayFeature->getFeature(2)->asA<babelwires::IntFeature>()->get(), 12);
+    EXPECT_EQ(arrayFeature->getFeature(0)->as<babelwires::IntFeature>()->get(), 10);
+    EXPECT_EQ(arrayFeature->getFeature(1)->as<babelwires::IntFeature>()->get(), 0);
+    EXPECT_EQ(arrayFeature->getFeature(2)->as<babelwires::IntFeature>()->get(), 12);
 }
 
 TEST(ModifierTest, arraySizeModifierFailure) {

--- a/Tests/BabelWires/modifierTest.cpp
+++ b/Tests/BabelWires/modifierTest.cpp
@@ -38,7 +38,7 @@ TEST(ModifierTest, basicStuff) {
     EXPECT_EQ(intMod.asConnectionModifier(), nullptr);
     EXPECT_EQ(intMod.getModifierData().m_pathToFeature, path);
     EXPECT_EQ(intMod.getPathToFeature(), path);
-    EXPECT_NE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&intMod.getModifierData()), nullptr);
+    EXPECT_NE(intMod.getModifierData().asA<babelwires::IntValueAssignmentData>(), nullptr);
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData&>(intMod.getModifierData()).m_value, 198);
 
     EXPECT_EQ(const_cast<const babelwires::LocalModifier&>(intMod).getOwner(), nullptr);
@@ -59,7 +59,7 @@ TEST(ModifierTest, clone) {
     auto clone = intMod.clone();
     ASSERT_NE(clone, nullptr);
     EXPECT_EQ(clone->getModifierData().m_pathToFeature, path);
-    EXPECT_NE(dynamic_cast<const babelwires::IntValueAssignmentData*>(&clone->getModifierData()), nullptr);
+    EXPECT_NE(clone->getModifierData().asA<babelwires::IntValueAssignmentData>(), nullptr);
     EXPECT_EQ(static_cast<const babelwires::IntValueAssignmentData&>(clone->getModifierData()).m_value, 198);
 }
 

--- a/Tests/BabelWires/moveElementCommandTest.cpp
+++ b/Tests/BabelWires/moveElementCommandTest.cpp
@@ -18,7 +18,7 @@ TEST(MoveElementCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);
@@ -66,7 +66,7 @@ TEST(MoveElementCommandTest, subsumeMoves) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);
@@ -104,7 +104,7 @@ TEST(MoveElementCommandTest, subsumeMovesDelay) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);

--- a/Tests/BabelWires/moveElementCommandTest.cpp
+++ b/Tests/BabelWires/moveElementCommandTest.cpp
@@ -18,7 +18,7 @@ TEST(MoveElementCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);
@@ -66,7 +66,7 @@ TEST(MoveElementCommandTest, subsumeMoves) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);
@@ -104,7 +104,7 @@ TEST(MoveElementCommandTest, subsumeMovesDelay) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, -14);
     EXPECT_EQ(element->getUiPosition().m_y, -15);

--- a/Tests/BabelWires/pasteElementsCommandTest.cpp
+++ b/Tests/BabelWires/pasteElementsCommandTest.cpp
@@ -164,7 +164,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
             ASSERT_NE(modifier, nullptr);
             EXPECT_FALSE(modifier->isFailed());
             const babelwires::ConnectionModifierData* modData =
-                dynamic_cast<const babelwires::ConnectionModifierData*>(&modifier->getModifierData());
+                modifier->getModifierData().asA<babelwires::ConnectionModifierData>();
             ASSERT_NE(modData, nullptr);
             EXPECT_EQ(modData->m_sourceId, newSourceElement->getElementId());
         } else {

--- a/Tests/BabelWires/pasteElementsCommandTest.cpp
+++ b/Tests/BabelWires/pasteElementsCommandTest.cpp
@@ -123,7 +123,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
         const babelwires::FeatureElement* newTargetElement = nullptr;
 
         for (const auto& pair : context.m_project.getElements()) {
-            if (pair.second->asA<babelwires::SourceFileElement>()) {
+            if (pair.second->as<babelwires::SourceFileElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_sourceElementId) {
                     EXPECT_EQ(originalSourceElement, nullptr);
                     originalSourceElement = pair.second.get();
@@ -131,7 +131,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
                     EXPECT_EQ(newSourceElement, nullptr);
                     newSourceElement = pair.second.get();
                 }
-            } else if (pair.second->asA<babelwires::ProcessorElement>()) {
+            } else if (pair.second->as<babelwires::ProcessorElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_processorId) {
                     EXPECT_EQ(originalProcessor, nullptr);
                     originalProcessor = pair.second.get();
@@ -139,7 +139,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
                     EXPECT_EQ(newProcessor, nullptr);
                     newProcessor = pair.second.get();
                 }
-            } else if (pair.second->asA<babelwires::TargetFileElement>()) {
+            } else if (pair.second->as<babelwires::TargetFileElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_targetElementId) {
                     EXPECT_EQ(originalTargetElement, nullptr);
                     originalTargetElement = pair.second.get();
@@ -164,7 +164,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
             ASSERT_NE(modifier, nullptr);
             EXPECT_FALSE(modifier->isFailed());
             const babelwires::ConnectionModifierData* modData =
-                modifier->getModifierData().asA<babelwires::ConnectionModifierData>();
+                modifier->getModifierData().as<babelwires::ConnectionModifierData>();
             ASSERT_NE(modData, nullptr);
             EXPECT_EQ(modData->m_sourceId, newSourceElement->getElementId());
         } else {

--- a/Tests/BabelWires/pasteElementsCommandTest.cpp
+++ b/Tests/BabelWires/pasteElementsCommandTest.cpp
@@ -123,7 +123,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
         const babelwires::FeatureElement* newTargetElement = nullptr;
 
         for (const auto& pair : context.m_project.getElements()) {
-            if (dynamic_cast<const babelwires::SourceFileElement*>(pair.second.get())) {
+            if (pair.second->asA<babelwires::SourceFileElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_sourceElementId) {
                     EXPECT_EQ(originalSourceElement, nullptr);
                     originalSourceElement = pair.second.get();
@@ -131,7 +131,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
                     EXPECT_EQ(newSourceElement, nullptr);
                     newSourceElement = pair.second.get();
                 }
-            } else if (dynamic_cast<const babelwires::ProcessorElement*>(pair.second.get())) {
+            } else if (pair.second->asA<babelwires::ProcessorElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_processorId) {
                     EXPECT_EQ(originalProcessor, nullptr);
                     originalProcessor = pair.second.get();
@@ -139,7 +139,7 @@ TEST(PasteElementsCommandTest, executeAndUndoDuplicateData) {
                     EXPECT_EQ(newProcessor, nullptr);
                     newProcessor = pair.second.get();
                 }
-            } else if (dynamic_cast<const babelwires::TargetFileElement*>(pair.second.get())) {
+            } else if (pair.second->asA<babelwires::TargetFileElement>()) {
                 if (pair.first == libTestUtils::TestProjectData::c_targetElementId) {
                     EXPECT_EQ(originalTargetElement, nullptr);
                     originalTargetElement = pair.second.get();

--- a/Tests/BabelWires/processorElementTest.cpp
+++ b/Tests/BabelWires/processorElementTest.cpp
@@ -24,11 +24,11 @@ TEST(ProcessorElementTest, sourceFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<babelwires::ProcessorElement>());
+    ASSERT_TRUE(featureElement->as<babelwires::ProcessorElement>());
     babelwires::ProcessorElement* processorElement = static_cast<babelwires::ProcessorElement*>(featureElement.get());
 
     const babelwires::RecordFeature* outputFeature = processorElement->getOutputFeature();
-    ASSERT_TRUE(outputFeature->asA<const libTestUtils::TestRecordFeature>());
+    ASSERT_TRUE(outputFeature->as<const libTestUtils::TestRecordFeature>());
     const libTestUtils::TestRecordFeature* outputTestRecordFeature =
         static_cast<const libTestUtils::TestRecordFeature*>(outputFeature);
     EXPECT_EQ(outputTestRecordFeature->m_arrayFeature->getNumFeatures(), 2);

--- a/Tests/BabelWires/processorElementTest.cpp
+++ b/Tests/BabelWires/processorElementTest.cpp
@@ -24,7 +24,7 @@ TEST(ProcessorElementTest, sourceFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<babelwires::ProcessorElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<babelwires::ProcessorElement>());
     babelwires::ProcessorElement* processorElement = static_cast<babelwires::ProcessorElement*>(featureElement.get());
 
     const babelwires::RecordFeature* outputFeature = processorElement->getOutputFeature();

--- a/Tests/BabelWires/processorElementTest.cpp
+++ b/Tests/BabelWires/processorElementTest.cpp
@@ -28,7 +28,7 @@ TEST(ProcessorElementTest, sourceFileDataCreateElement) {
     babelwires::ProcessorElement* processorElement = static_cast<babelwires::ProcessorElement*>(featureElement.get());
 
     const babelwires::RecordFeature* outputFeature = processorElement->getOutputFeature();
-    ASSERT_TRUE(dynamic_cast<const libTestUtils::TestRecordFeature*>(outputFeature));
+    ASSERT_TRUE(outputFeature->asA<const libTestUtils::TestRecordFeature>());
     const libTestUtils::TestRecordFeature* outputTestRecordFeature =
         static_cast<const libTestUtils::TestRecordFeature*>(outputFeature);
     EXPECT_EQ(outputTestRecordFeature->m_arrayFeature->getNumFeatures(), 2);

--- a/Tests/BabelWires/projectBundleTest.cpp
+++ b/Tests/BabelWires/projectBundleTest.cpp
@@ -296,12 +296,12 @@ TEST(ProjectBundleTest, filePathResolution) {
         
         ASSERT_EQ(projectData.m_elements.size(), 2);
         {
-            auto elementData = dynamic_cast<const babelwires::SourceFileElementData*>(projectData.m_elements[0].get());
+            auto elementData = projectData.m_elements[0].get()->asA<babelwires::SourceFileElementData>();
             ASSERT_NE(elementData, nullptr);
             EXPECT_EQ(elementData->m_filePath, scenario.m_expectedResolvedPath);
         }
         {
-            auto elementData = dynamic_cast<const babelwires::TargetFileElementData*>(projectData.m_elements[1].get());
+            auto elementData = projectData.m_elements[1].get()->asA<babelwires::TargetFileElementData>();
             ASSERT_NE(elementData, nullptr);
             EXPECT_EQ(elementData->m_filePath, scenario.m_expectedResolvedPath);
         }

--- a/Tests/BabelWires/projectBundleTest.cpp
+++ b/Tests/BabelWires/projectBundleTest.cpp
@@ -296,12 +296,12 @@ TEST(ProjectBundleTest, filePathResolution) {
         
         ASSERT_EQ(projectData.m_elements.size(), 2);
         {
-            auto elementData = projectData.m_elements[0].get()->asA<babelwires::SourceFileElementData>();
+            auto elementData = projectData.m_elements[0].get()->as<babelwires::SourceFileElementData>();
             ASSERT_NE(elementData, nullptr);
             EXPECT_EQ(elementData->m_filePath, scenario.m_expectedResolvedPath);
         }
         {
-            auto elementData = projectData.m_elements[1].get()->asA<babelwires::TargetFileElementData>();
+            auto elementData = projectData.m_elements[1].get()->as<babelwires::TargetFileElementData>();
             ASSERT_NE(elementData, nullptr);
             EXPECT_EQ(elementData->m_filePath, scenario.m_expectedResolvedPath);
         }

--- a/Tests/BabelWires/projectDataTest.cpp
+++ b/Tests/BabelWires/projectDataTest.cpp
@@ -39,7 +39,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 45);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestTargetFileFormat::getThisIdentifier());
-        const babelwires::TargetFileElementData* targetData = dynamic_cast<const babelwires::TargetFileElementData*>(data);
+        const babelwires::TargetFileElementData* targetData = data->asA<babelwires::TargetFileElementData>();
         ASSERT_TRUE(targetData);
         ASSERT_EQ(targetData->m_filePath, libTestUtils::TestProjectData().m_targetFilePath);
     }
@@ -48,7 +48,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 6);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestProcessorFactory::getThisIdentifier());
-        const babelwires::ProcessorElementData* processorData = dynamic_cast<const babelwires::ProcessorElementData*>(data);
+        const babelwires::ProcessorElementData* processorData = data->asA<babelwires::ProcessorElementData>();
         ASSERT_TRUE(processorData);
     }
     {
@@ -56,7 +56,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 12);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestSourceFileFormat::getThisIdentifier());
-        const babelwires::SourceFileElementData* sourceData = dynamic_cast<const babelwires::SourceFileElementData*>(data);
+        const babelwires::SourceFileElementData* sourceData = data->asA<babelwires::SourceFileElementData>();
         ASSERT_TRUE(sourceData);
         ASSERT_EQ(sourceData->m_filePath, babelwires::FilePath(libTestUtils::TestProjectData().m_sourceFilePath));
     }

--- a/Tests/BabelWires/projectDataTest.cpp
+++ b/Tests/BabelWires/projectDataTest.cpp
@@ -39,7 +39,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 45);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestTargetFileFormat::getThisIdentifier());
-        const babelwires::TargetFileElementData* targetData = data->asA<babelwires::TargetFileElementData>();
+        const babelwires::TargetFileElementData* targetData = data->as<babelwires::TargetFileElementData>();
         ASSERT_TRUE(targetData);
         ASSERT_EQ(targetData->m_filePath, libTestUtils::TestProjectData().m_targetFilePath);
     }
@@ -48,7 +48,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 6);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestProcessorFactory::getThisIdentifier());
-        const babelwires::ProcessorElementData* processorData = data->asA<babelwires::ProcessorElementData>();
+        const babelwires::ProcessorElementData* processorData = data->as<babelwires::ProcessorElementData>();
         ASSERT_TRUE(processorData);
     }
     {
@@ -56,7 +56,7 @@ TEST(ProjectDataTest, serialization) {
         ASSERT_TRUE(data);
         EXPECT_EQ(data->m_id, 12);
         EXPECT_EQ(data->m_factoryIdentifier, libTestUtils::TestSourceFileFormat::getThisIdentifier());
-        const babelwires::SourceFileElementData* sourceData = data->asA<babelwires::SourceFileElementData>();
+        const babelwires::SourceFileElementData* sourceData = data->as<babelwires::SourceFileElementData>();
         ASSERT_TRUE(sourceData);
         ASSERT_EQ(sourceData->m_filePath, babelwires::FilePath(libTestUtils::TestProjectData().m_sourceFilePath));
     }

--- a/Tests/BabelWires/projectTest.cpp
+++ b/Tests/BabelWires/projectTest.cpp
@@ -181,7 +181,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        EXPECT_EQ(dynamic_cast<const babelwires::ArraySizeModifierData&>(modifier->getModifierData()).m_size, 6);
+        EXPECT_EQ(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>()->m_size, 6);
     }
 
     context.m_project.process();
@@ -189,7 +189,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        EXPECT_EQ(dynamic_cast<const babelwires::ArraySizeModifierData&>(modifier->getModifierData()).m_size, 4);
+        EXPECT_EQ(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>()->m_size, 4);
     }
 
     context.m_project.process();
@@ -272,8 +272,8 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSource) {
         modData.m_pathToSourceFeature = libTestUtils::TestRecordFeature::s_pathToArray_1;
         context.m_project.addModifier(targetElementId, modData);
     }
-    const babelwires::ConnectionModifierData& connectionData = dynamic_cast<const babelwires::ConnectionModifierData&>(
-        targetElement->findModifier(pathToTargetFeature)->getModifierData());
+    const babelwires::ConnectionModifierData& connectionData = 
+        *targetElement->findModifier(pathToTargetFeature)->getModifierData().asA<babelwires::ConnectionModifierData>();
 
     context.m_project.process();
 

--- a/Tests/BabelWires/projectTest.cpp
+++ b/Tests/BabelWires/projectTest.cpp
@@ -172,7 +172,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        ASSERT_TRUE(dynamic_cast<const babelwires::ArraySizeModifierData*>(&modifier->getModifierData()));
+        ASSERT_TRUE(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>());
         EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData&>(modifier->getModifierData()).m_size, 4);
     }
 

--- a/Tests/BabelWires/projectTest.cpp
+++ b/Tests/BabelWires/projectTest.cpp
@@ -70,7 +70,7 @@ TEST(ProjectTest, addGetAndRemoveElement) {
 
     const babelwires::FeatureElement* element = context.m_project.getFeatureElement(elementId);
     EXPECT_NE(element, nullptr);
-    EXPECT_NE(element->asA<libTestUtils::TestFeatureElement>(), nullptr);
+    EXPECT_NE(element->as<libTestUtils::TestFeatureElement>(), nullptr);
     EXPECT_TRUE(element->isChanged(babelwires::FeatureElement::Changes::FeatureElementIsNew));
 
     context.m_project.removeElement(elementId);
@@ -98,7 +98,7 @@ TEST(ProjectTest, addAndRemoveLocalModifier) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const babelwires::FeaturePath pathToFeature = libTestUtils::TestRecordFeature::s_pathToArray_1;
@@ -125,13 +125,13 @@ TEST(ProjectTest, addAndRemoveConnectionModifier) {
     const babelwires::ElementId sourceElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* sourceElement =
-        context.m_project.getFeatureElement(sourceElementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(sourceElementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(sourceElement, nullptr);
 
     const babelwires::ElementId targetElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* targetElement =
-        context.m_project.getFeatureElement(targetElementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(targetElementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     const babelwires::FeaturePath pathToTargetFeature = libTestUtils::TestRecordFeature::s_pathToArray_1;
@@ -160,7 +160,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const babelwires::FeaturePath pathToArray = libTestUtils::TestRecordFeature::s_pathToArray;
@@ -172,7 +172,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        ASSERT_TRUE(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>());
+        ASSERT_TRUE(modifier->getModifierData().as<babelwires::ArraySizeModifierData>());
         EXPECT_EQ(static_cast<const babelwires::ArraySizeModifierData&>(modifier->getModifierData()).m_size, 4);
     }
 
@@ -181,7 +181,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        EXPECT_EQ(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>()->m_size, 6);
+        EXPECT_EQ(modifier->getModifierData().as<babelwires::ArraySizeModifierData>()->m_size, 6);
     }
 
     context.m_project.process();
@@ -189,7 +189,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     {
         const babelwires::Modifier* const modifier = element->findModifier(pathToArray);
         ASSERT_NE(modifier, nullptr);
-        EXPECT_EQ(modifier->getModifierData().asA<babelwires::ArraySizeModifierData>()->m_size, 4);
+        EXPECT_EQ(modifier->getModifierData().as<babelwires::ArraySizeModifierData>()->m_size, 4);
     }
 
     context.m_project.process();
@@ -205,7 +205,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesModifier) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::IntValueAssignmentData modData;
@@ -251,13 +251,13 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSource) {
     const babelwires::ElementId sourceElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* sourceElement =
-        context.m_project.getFeatureElement(sourceElementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(sourceElementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(sourceElement, nullptr);
 
     const babelwires::ElementId targetElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* targetElement =
-        context.m_project.getFeatureElement(targetElementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(targetElementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     const babelwires::FeaturePath pathToTargetFeature = libTestUtils::TestRecordFeature::s_pathToInt;
@@ -273,7 +273,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSource) {
         context.m_project.addModifier(targetElementId, modData);
     }
     const babelwires::ConnectionModifierData& connectionData = 
-        *targetElement->findModifier(pathToTargetFeature)->getModifierData().asA<babelwires::ConnectionModifierData>();
+        *targetElement->findModifier(pathToTargetFeature)->getModifierData().as<babelwires::ConnectionModifierData>();
 
     context.m_project.process();
 
@@ -314,7 +314,7 @@ TEST(ProjectTest, uiProperties) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(testFeatureData);
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     EXPECT_EQ(element->getUiPosition().m_x, 8);
@@ -342,7 +342,7 @@ TEST(ProjectTest, elementIds) {
     ASSERT_NE(elementId, 3);
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     libTestUtils::TestFeatureElementData elementData;
@@ -352,7 +352,7 @@ TEST(ProjectTest, elementIds) {
     EXPECT_EQ(elementId1, 3);
 
     const libTestUtils::TestFeatureElement* element1 =
-        context.m_project.getFeatureElement(elementId1)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId1)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element1, nullptr);
     EXPECT_EQ(element1->getElementData().m_id, elementId1);
     EXPECT_NE(element, element1);
@@ -362,7 +362,7 @@ TEST(ProjectTest, elementIds) {
     EXPECT_NE(elementId2, elementId1);
 
     const libTestUtils::TestFeatureElement* element2 =
-        context.m_project.getFeatureElement(elementId2)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId2)->as<libTestUtils::TestFeatureElement>();
     EXPECT_NE(element2, nullptr);
     EXPECT_NE(element1, element2);
 }
@@ -381,10 +381,10 @@ TEST(ProjectTest, reloadSource) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(sourceFileData);
     const babelwires::FeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<babelwires::FeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<babelwires::FeatureElement>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getOutputFeature(), nullptr);
-    ASSERT_NE(element->getOutputFeature()->asA<const libTestUtils::TestFileFeature>(), nullptr);
+    ASSERT_NE(element->getOutputFeature()->as<const libTestUtils::TestFileFeature>(), nullptr);
     EXPECT_EQ(static_cast<const libTestUtils::TestFileFeature*>(element->getOutputFeature())->m_intChildFeature->get(),
               14);
 
@@ -420,10 +420,10 @@ TEST(ProjectTest, saveTarget) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(targetFileData);
     babelwires::FeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<babelwires::FeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<babelwires::FeatureElement>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getInputFeature(), nullptr);
-    auto* inputFeature = element->getInputFeature()->asA<libTestUtils::TestFileFeature>();
+    auto* inputFeature = element->getInputFeature()->as<libTestUtils::TestFileFeature>();
     ASSERT_NE(inputFeature, nullptr);
 
     inputFeature->m_intChildFeature->set(47);
@@ -466,24 +466,24 @@ TEST(ProjectTest, process) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_sourceElementId);
     ASSERT_NE(sourceElement, nullptr);
     const libTestUtils::TestFileFeature* sourceOutput =
-        sourceElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
+        sourceElement->getOutputFeature()->as<const libTestUtils::TestFileFeature>();
     ASSERT_NE(sourceOutput, nullptr);
 
     const babelwires::FeatureElement* processor =
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_processorId);
     ASSERT_NE(processor, nullptr);
     const libTestUtils::TestRecordFeature* processorInput =
-        processor->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        processor->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(processorInput, nullptr);
     const libTestUtils::TestRecordFeature* processorOutput =
-        processor->getOutputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        processor->getOutputFeature()->as<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(processorOutput, nullptr);
 
     const babelwires::FeatureElement* targetElement =
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_targetElementId);
     ASSERT_NE(targetElement, nullptr);
     const libTestUtils::TestFileFeature* targetInput =
-        targetElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>();
+        targetElement->getInputFeature()->as<const libTestUtils::TestFileFeature>();
     ASSERT_NE(targetInput, nullptr);
 
     // 4rd array entry, where they count up from the input value (3).
@@ -666,8 +666,8 @@ TEST(ProjectTest, dependencyLoopAndProcessing) {
     EXPECT_FALSE(element3->isInDependencyLoop());
     EXPECT_FALSE(element4->isInDependencyLoop());
 
-    ASSERT_NE(element3->getOutputFeature()->asA<libTestUtils::TestRecordFeature>(), nullptr);
-    EXPECT_EQ(element3->getOutputFeature()->asA<libTestUtils::TestRecordFeature>()->m_intFeature2->get(), 16);              
+    ASSERT_NE(element3->getOutputFeature()->as<libTestUtils::TestRecordFeature>(), nullptr);
+    EXPECT_EQ(element3->getOutputFeature()->as<libTestUtils::TestRecordFeature>()->m_intFeature2->get(), 16);              
 
     context.m_project.removeModifier(elementId2, libTestUtils::TestRecordFeature::s_pathToInt2);
     context.m_project.process();
@@ -750,7 +750,7 @@ TEST(ProjectTest, processWithFailure) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_sourceElementId);
     ASSERT_NE(sourceElement, nullptr);
     const libTestUtils::TestFileFeature* sourceOutput =
-        sourceElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
+        sourceElement->getOutputFeature()->as<const libTestUtils::TestFileFeature>();
     ASSERT_NE(sourceOutput, nullptr);
 
     const babelwires::FeatureElement* processor =
@@ -762,6 +762,6 @@ TEST(ProjectTest, processWithFailure) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_targetElementId);
     ASSERT_NE(targetElement, nullptr);
     const libTestUtils::TestFileFeature* targetInput =
-        targetElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>();
+        targetElement->getInputFeature()->as<const libTestUtils::TestFileFeature>();
     ASSERT_NE(targetInput, nullptr);
 }

--- a/Tests/BabelWires/projectTest.cpp
+++ b/Tests/BabelWires/projectTest.cpp
@@ -70,7 +70,7 @@ TEST(ProjectTest, addGetAndRemoveElement) {
 
     const babelwires::FeatureElement* element = context.m_project.getFeatureElement(elementId);
     EXPECT_NE(element, nullptr);
-    EXPECT_NE(dynamic_cast<const libTestUtils::TestFeatureElement*>(element), nullptr);
+    EXPECT_NE(element->asA<libTestUtils::TestFeatureElement>(), nullptr);
     EXPECT_TRUE(element->isChanged(babelwires::FeatureElement::Changes::FeatureElementIsNew));
 
     context.m_project.removeElement(elementId);
@@ -98,7 +98,7 @@ TEST(ProjectTest, addAndRemoveLocalModifier) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const babelwires::FeaturePath pathToFeature = libTestUtils::TestRecordFeature::s_pathToArray_1;
@@ -125,13 +125,13 @@ TEST(ProjectTest, addAndRemoveConnectionModifier) {
     const babelwires::ElementId sourceElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* sourceElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(sourceElementId));
+        context.m_project.getFeatureElement(sourceElementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(sourceElement, nullptr);
 
     const babelwires::ElementId targetElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* targetElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(targetElementId));
+        context.m_project.getFeatureElement(targetElementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     const babelwires::FeaturePath pathToTargetFeature = libTestUtils::TestRecordFeature::s_pathToArray_1;
@@ -160,7 +160,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSimple) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const babelwires::FeaturePath pathToArray = libTestUtils::TestRecordFeature::s_pathToArray;
@@ -205,7 +205,7 @@ TEST(ProjectTest, addAndRemoveArrayEntriesModifier) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::IntValueAssignmentData modData;
@@ -251,13 +251,13 @@ TEST(ProjectTest, addAndRemoveArrayEntriesSource) {
     const babelwires::ElementId sourceElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* sourceElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(sourceElementId));
+        context.m_project.getFeatureElement(sourceElementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(sourceElement, nullptr);
 
     const babelwires::ElementId targetElementId =
         context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
     const libTestUtils::TestFeatureElement* targetElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(targetElementId));
+        context.m_project.getFeatureElement(targetElementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(targetElement, nullptr);
 
     const babelwires::FeaturePath pathToTargetFeature = libTestUtils::TestRecordFeature::s_pathToInt;
@@ -314,7 +314,7 @@ TEST(ProjectTest, uiProperties) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(testFeatureData);
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     EXPECT_EQ(element->getUiPosition().m_x, 8);
@@ -342,7 +342,7 @@ TEST(ProjectTest, elementIds) {
     ASSERT_NE(elementId, 3);
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     libTestUtils::TestFeatureElementData elementData;
@@ -352,7 +352,7 @@ TEST(ProjectTest, elementIds) {
     EXPECT_EQ(elementId1, 3);
 
     const libTestUtils::TestFeatureElement* element1 =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId1));
+        context.m_project.getFeatureElement(elementId1)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element1, nullptr);
     EXPECT_EQ(element1->getElementData().m_id, elementId1);
     EXPECT_NE(element, element1);
@@ -362,7 +362,7 @@ TEST(ProjectTest, elementIds) {
     EXPECT_NE(elementId2, elementId1);
 
     const libTestUtils::TestFeatureElement* element2 =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId2));
+        context.m_project.getFeatureElement(elementId2)->asA<libTestUtils::TestFeatureElement>();
     EXPECT_NE(element2, nullptr);
     EXPECT_NE(element1, element2);
 }
@@ -381,7 +381,7 @@ TEST(ProjectTest, reloadSource) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(sourceFileData);
     const babelwires::FeatureElement* element =
-        dynamic_cast<const babelwires::FeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<babelwires::FeatureElement>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getOutputFeature(), nullptr);
     ASSERT_NE(element->getOutputFeature()->asA<const libTestUtils::TestFileFeature>(), nullptr);
@@ -420,7 +420,7 @@ TEST(ProjectTest, saveTarget) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(targetFileData);
     babelwires::FeatureElement* element =
-        dynamic_cast<babelwires::FeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<babelwires::FeatureElement>();
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getInputFeature(), nullptr);
     auto* inputFeature = element->getInputFeature()->asA<libTestUtils::TestFileFeature>();

--- a/Tests/BabelWires/projectTest.cpp
+++ b/Tests/BabelWires/projectTest.cpp
@@ -384,7 +384,7 @@ TEST(ProjectTest, reloadSource) {
         dynamic_cast<const babelwires::FeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getOutputFeature(), nullptr);
-    ASSERT_NE(dynamic_cast<const libTestUtils::TestFileFeature*>(element->getOutputFeature()), nullptr);
+    ASSERT_NE(element->getOutputFeature()->asA<const libTestUtils::TestFileFeature>(), nullptr);
     EXPECT_EQ(static_cast<const libTestUtils::TestFileFeature*>(element->getOutputFeature())->m_intChildFeature->get(),
               14);
 
@@ -423,7 +423,7 @@ TEST(ProjectTest, saveTarget) {
         dynamic_cast<babelwires::FeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
     ASSERT_NE(element->getInputFeature(), nullptr);
-    auto* inputFeature = dynamic_cast<libTestUtils::TestFileFeature*>(element->getInputFeature());
+    auto* inputFeature = element->getInputFeature()->asA<libTestUtils::TestFileFeature>();
     ASSERT_NE(inputFeature, nullptr);
 
     inputFeature->m_intChildFeature->set(47);
@@ -466,24 +466,24 @@ TEST(ProjectTest, process) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_sourceElementId);
     ASSERT_NE(sourceElement, nullptr);
     const libTestUtils::TestFileFeature* sourceOutput =
-        dynamic_cast<const libTestUtils::TestFileFeature*>(sourceElement->getOutputFeature());
+        sourceElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
     ASSERT_NE(sourceOutput, nullptr);
 
     const babelwires::FeatureElement* processor =
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_processorId);
     ASSERT_NE(processor, nullptr);
     const libTestUtils::TestRecordFeature* processorInput =
-        dynamic_cast<const libTestUtils::TestRecordFeature*>(processor->getInputFeature());
+        processor->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(processorInput, nullptr);
     const libTestUtils::TestRecordFeature* processorOutput =
-        dynamic_cast<const libTestUtils::TestRecordFeature*>(processor->getOutputFeature());
+        processor->getOutputFeature()->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(processorOutput, nullptr);
 
     const babelwires::FeatureElement* targetElement =
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_targetElementId);
     ASSERT_NE(targetElement, nullptr);
     const libTestUtils::TestFileFeature* targetInput =
-        dynamic_cast<const libTestUtils::TestFileFeature*>(targetElement->getInputFeature());
+        targetElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>();
     ASSERT_NE(targetInput, nullptr);
 
     // 4rd array entry, where they count up from the input value (3).
@@ -666,9 +666,8 @@ TEST(ProjectTest, dependencyLoopAndProcessing) {
     EXPECT_FALSE(element3->isInDependencyLoop());
     EXPECT_FALSE(element4->isInDependencyLoop());
 
-    ASSERT_NE(dynamic_cast<const libTestUtils::TestRecordFeature*>(element3->getOutputFeature()), nullptr);
-    EXPECT_EQ(dynamic_cast<const libTestUtils::TestRecordFeature*>(element3->getOutputFeature())->m_intFeature2->get(),
-              16);
+    ASSERT_NE(element3->getOutputFeature()->asA<libTestUtils::TestRecordFeature>(), nullptr);
+    EXPECT_EQ(element3->getOutputFeature()->asA<libTestUtils::TestRecordFeature>()->m_intFeature2->get(), 16);              
 
     context.m_project.removeModifier(elementId2, libTestUtils::TestRecordFeature::s_pathToInt2);
     context.m_project.process();
@@ -751,7 +750,7 @@ TEST(ProjectTest, processWithFailure) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_sourceElementId);
     ASSERT_NE(sourceElement, nullptr);
     const libTestUtils::TestFileFeature* sourceOutput =
-        dynamic_cast<const libTestUtils::TestFileFeature*>(sourceElement->getOutputFeature());
+        sourceElement->getOutputFeature()->asA<const libTestUtils::TestFileFeature>();
     ASSERT_NE(sourceOutput, nullptr);
 
     const babelwires::FeatureElement* processor =
@@ -763,6 +762,6 @@ TEST(ProjectTest, processWithFailure) {
         context.m_project.getFeatureElement(libTestUtils::TestProjectData::c_targetElementId);
     ASSERT_NE(targetElement, nullptr);
     const libTestUtils::TestFileFeature* targetInput =
-        dynamic_cast<const libTestUtils::TestFileFeature*>(targetElement->getInputFeature());
+        targetElement->getInputFeature()->asA<const libTestUtils::TestFileFeature>();
     ASSERT_NE(targetInput, nullptr);
 }

--- a/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
+++ b/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
@@ -51,7 +51,7 @@ TEST(RemoveEntryFromArrayCommandTest, executeAndUndoNonDefaultArray) {
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     };
 
     const auto checkModifiers = [&context, element, targetElement](bool isCommandExecuted) {
@@ -146,7 +146,7 @@ TEST(RemoveEntryFromArrayCommandTest, failSafelyOutOfRange) {
         dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
     ASSERT_NE(element, nullptr);
 
-    const auto* inputFeature = dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+    const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
 

--- a/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
+++ b/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
@@ -44,14 +44,14 @@ TEST(RemoveEntryFromArrayCommandTest, executeAndUndoNonDefaultArray) {
     context.m_project.process();
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
-        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(targetId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        return element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     };
 
     const auto checkModifiers = [&context, element, targetElement](bool isCommandExecuted) {
@@ -143,10 +143,10 @@ TEST(RemoveEntryFromArrayCommandTest, failSafelyOutOfRange) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
-    const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+    const auto* inputFeature = element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     ASSERT_NE(inputFeature, nullptr);
     EXPECT_EQ(inputFeature->m_arrayFeature->getNumFeatures(), 2);
 

--- a/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
+++ b/Tests/BabelWires/removeEntryFromArrayCommandTest.cpp
@@ -44,10 +44,10 @@ TEST(RemoveEntryFromArrayCommandTest, executeAndUndoNonDefaultArray) {
     context.m_project.process();
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(targetId));
+        context.m_project.getFeatureElement(targetId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
@@ -143,7 +143,7 @@ TEST(RemoveEntryFromArrayCommandTest, failSafelyOutOfRange) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto* inputFeature = element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();

--- a/Tests/BabelWires/removeFailedModifiersCommandTest.cpp
+++ b/Tests/BabelWires/removeFailedModifiersCommandTest.cpp
@@ -45,7 +45,7 @@ namespace {
         context.m_project.process();
 
         const auto* element =
-            context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+            context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
         ASSERT_NE(element, nullptr);
 
         const auto checkModifiers = [&context, element, isWholeRecord](bool isCommandExecuted) {

--- a/Tests/BabelWires/removeFailedModifiersCommandTest.cpp
+++ b/Tests/BabelWires/removeFailedModifiersCommandTest.cpp
@@ -45,7 +45,7 @@ namespace {
         context.m_project.process();
 
         const auto* element =
-            dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+            context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
         ASSERT_NE(element, nullptr);
 
         const auto checkModifiers = [&context, element, isWholeRecord](bool isCommandExecuted) {

--- a/Tests/BabelWires/removeModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeModifierCommandTest.cpp
@@ -51,7 +51,7 @@ TEST(RemoveModifierCommandTest, executeAndUndoArray) {
     context.m_project.process();
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {

--- a/Tests/BabelWires/removeModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeModifierCommandTest.cpp
@@ -55,7 +55,7 @@ TEST(RemoveModifierCommandTest, executeAndUndoArray) {
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestRecordFeature*>(element->getInputFeature());
+        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
     };
     const auto checkModifiers = [&context, element](bool isCommandExecuted) {
         const babelwires::Modifier* arrayInitialization =

--- a/Tests/BabelWires/removeModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeModifierCommandTest.cpp
@@ -117,11 +117,11 @@ TEST(RemoveModifierCommandTest, executeAndUndoOptionals)
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        dynamic_cast<const libTestUtils::TestFeatureElementWithOptionals*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return dynamic_cast<const libTestUtils::TestFeatureWithOptionals*>(element->getInputFeature());
+        return element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
     };
 
     ASSERT_NE(getInputFeature(), nullptr);

--- a/Tests/BabelWires/removeModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeModifierCommandTest.cpp
@@ -51,11 +51,11 @@ TEST(RemoveModifierCommandTest, executeAndUndoArray) {
     context.m_project.process();
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<const libTestUtils::TestRecordFeature>();
+        return element->getInputFeature()->as<const libTestUtils::TestRecordFeature>();
     };
     const auto checkModifiers = [&context, element](bool isCommandExecuted) {
         const babelwires::Modifier* arrayInitialization =
@@ -117,11 +117,11 @@ TEST(RemoveModifierCommandTest, executeAndUndoOptionals)
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementWithOptionalsData());
     const libTestUtils::TestFeatureElementWithOptionals* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElementWithOptionals>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
     const auto getInputFeature = [element]() {
-        return element->getInputFeature()->asA<libTestUtils::TestFeatureWithOptionals>();
+        return element->getInputFeature()->as<libTestUtils::TestFeatureWithOptionals>();
     };
 
     ASSERT_NE(getInputFeature(), nullptr);

--- a/Tests/BabelWires/removeSimpleModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeSimpleModifierCommandTest.cpp
@@ -26,7 +26,7 @@ TEST(RemoveSimpleModifierCommandTest, executeAndUndo) {
     context.m_project.process();
 
     const auto* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto checkModifiers = [&context, element](bool isCommandExecuted) {

--- a/Tests/BabelWires/removeSimpleModifierCommandTest.cpp
+++ b/Tests/BabelWires/removeSimpleModifierCommandTest.cpp
@@ -26,7 +26,7 @@ TEST(RemoveSimpleModifierCommandTest, executeAndUndo) {
     context.m_project.process();
 
     const auto* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     const auto checkModifiers = [&context, element](bool isCommandExecuted) {

--- a/Tests/BabelWires/resizeElementCommandTest.cpp
+++ b/Tests/BabelWires/resizeElementCommandTest.cpp
@@ -18,7 +18,7 @@ TEST(ResizeElementCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 
@@ -62,7 +62,7 @@ TEST(ResizeElementCommandTest, subsumeMoves) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 
@@ -96,7 +96,7 @@ TEST(ResizeElementCommandTest, subsumeMovesDelay) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 

--- a/Tests/BabelWires/resizeElementCommandTest.cpp
+++ b/Tests/BabelWires/resizeElementCommandTest.cpp
@@ -18,7 +18,7 @@ TEST(ResizeElementCommandTest, executeAndUndo) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 
@@ -62,7 +62,7 @@ TEST(ResizeElementCommandTest, subsumeMoves) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 
@@ -96,7 +96,7 @@ TEST(ResizeElementCommandTest, subsumeMovesDelay) {
 
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiSize().m_width, 77);
 

--- a/Tests/BabelWires/setExpandedCommandTest.cpp
+++ b/Tests/BabelWires/setExpandedCommandTest.cpp
@@ -16,7 +16,7 @@ TEST(SetExpandedCommandTest, executeAndUndoTrue) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::SetExpandedCommand command("Test command", elementId, libTestUtils::TestRecordFeature::s_pathToArray,
@@ -50,7 +50,7 @@ TEST(SetExpandedCommandTest, executeAndUndoFalse) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
 
     const libTestUtils::TestFeatureElement* element =
-        dynamic_cast<const libTestUtils::TestFeatureElement*>(context.m_project.getFeatureElement(elementId));
+        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::SetExpandedCommand command("Test command", elementId, libTestUtils::TestRecordFeature::s_pathToArray,

--- a/Tests/BabelWires/setExpandedCommandTest.cpp
+++ b/Tests/BabelWires/setExpandedCommandTest.cpp
@@ -16,7 +16,7 @@ TEST(SetExpandedCommandTest, executeAndUndoTrue) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(libTestUtils::TestFeatureElementData());
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::SetExpandedCommand command("Test command", elementId, libTestUtils::TestRecordFeature::s_pathToArray,
@@ -50,7 +50,7 @@ TEST(SetExpandedCommandTest, executeAndUndoFalse) {
     const babelwires::ElementId elementId = context.m_project.addFeatureElement(elementData);
 
     const libTestUtils::TestFeatureElement* element =
-        context.m_project.getFeatureElement(elementId)->asA<libTestUtils::TestFeatureElement>();
+        context.m_project.getFeatureElement(elementId)->as<libTestUtils::TestFeatureElement>();
     ASSERT_NE(element, nullptr);
 
     babelwires::SetExpandedCommand command("Test command", elementId, libTestUtils::TestRecordFeature::s_pathToArray,

--- a/Tests/BabelWires/sourceFileElementTest.cpp
+++ b/Tests/BabelWires/sourceFileElementTest.cpp
@@ -45,7 +45,7 @@ TEST(SourceFileElementTest, sourceFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<babelwires::SourceFileElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
     babelwires::SourceFileElement* sourceFileElement =
         static_cast<babelwires::SourceFileElement*>(featureElement.get());
 
@@ -110,7 +110,7 @@ TEST(SourceFileElementTest, changeFile) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<babelwires::SourceFileElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
     babelwires::SourceFileElement* sourceFileElement =
         static_cast<babelwires::SourceFileElement*>(featureElement.get());
 

--- a/Tests/BabelWires/sourceFileElementTest.cpp
+++ b/Tests/BabelWires/sourceFileElementTest.cpp
@@ -45,7 +45,7 @@ TEST(SourceFileElementTest, sourceFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
+    ASSERT_TRUE(featureElement->as<babelwires::SourceFileElement>());
     babelwires::SourceFileElement* sourceFileElement =
         static_cast<babelwires::SourceFileElement*>(featureElement.get());
 
@@ -110,7 +110,7 @@ TEST(SourceFileElementTest, changeFile) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<babelwires::SourceFileElement>());
+    ASSERT_TRUE(featureElement->as<babelwires::SourceFileElement>());
     babelwires::SourceFileElement* sourceFileElement =
         static_cast<babelwires::SourceFileElement*>(featureElement.get());
 

--- a/Tests/BabelWires/targetFileElementTest.cpp
+++ b/Tests/BabelWires/targetFileElementTest.cpp
@@ -34,7 +34,7 @@ TEST(TargetFileElementTest, targetFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
+    ASSERT_TRUE(featureElement->as<babelwires::TargetFileElement>());
     babelwires::TargetFileElement* targetFileElement =
         static_cast<babelwires::TargetFileElement*>(featureElement.get());
 
@@ -95,7 +95,7 @@ TEST(TargetFileElementTest, changeFile) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
+    ASSERT_TRUE(featureElement->as<babelwires::TargetFileElement>());
     babelwires::TargetFileElement* targetFileElement =
         static_cast<babelwires::TargetFileElement*>(featureElement.get());
 

--- a/Tests/BabelWires/targetFileElementTest.cpp
+++ b/Tests/BabelWires/targetFileElementTest.cpp
@@ -34,7 +34,7 @@ TEST(TargetFileElementTest, targetFileDataCreateElement) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<babelwires::TargetFileElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
     babelwires::TargetFileElement* targetFileElement =
         static_cast<babelwires::TargetFileElement*>(featureElement.get());
 
@@ -95,7 +95,7 @@ TEST(TargetFileElementTest, changeFile) {
     auto featureElement = data.createFeatureElement(context.m_projectContext, context.m_log, 10);
     ASSERT_TRUE(featureElement);
     ASSERT_FALSE(featureElement->isFailed());
-    ASSERT_TRUE(dynamic_cast<babelwires::TargetFileElement*>(featureElement.get()));
+    ASSERT_TRUE(featureElement->asA<babelwires::TargetFileElement>());
     babelwires::TargetFileElement* targetFileElement =
         static_cast<babelwires::TargetFileElement*>(featureElement.get());
 

--- a/Tests/Common/blockStreamTest.cpp
+++ b/Tests/Common/blockStreamTest.cpp
@@ -49,7 +49,7 @@ TEST(BlockStream, BlocksAndAlignment) {
     int count = 0;
     for (const auto& event : stream) {
         if (count % 2) {
-            EXPECT_NE(event.asA<TestEvent>(), nullptr);
+            EXPECT_NE(event.as<TestEvent>(), nullptr);
             const TestEvent& e = static_cast<const TestEvent&>(event);
             EXPECT_EQ(e.m_big[2], (count / 2));
         }
@@ -131,7 +131,7 @@ TEST(BlockStream, CopyTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
+                    EXPECT_NE(event.as<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -172,7 +172,7 @@ TEST(BlockStream, MoveTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
+                    EXPECT_NE(event.as<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -223,7 +223,7 @@ TEST(BlockStream, CopyAssignTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
+                    EXPECT_NE(event.as<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -274,7 +274,7 @@ TEST(BlockStream, MoveAssignTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
+                    EXPECT_NE(event.as<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }

--- a/Tests/Common/blockStreamTest.cpp
+++ b/Tests/Common/blockStreamTest.cpp
@@ -49,7 +49,7 @@ TEST(BlockStream, BlocksAndAlignment) {
     int count = 0;
     for (const auto& event : stream) {
         if (count % 2) {
-            EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+            EXPECT_NE(event.asA<TestEvent>(), nullptr);
             const TestEvent& e = static_cast<const TestEvent&>(event);
             EXPECT_EQ(e.m_big[2], (count / 2));
         }
@@ -131,7 +131,7 @@ TEST(BlockStream, CopyTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -172,7 +172,7 @@ TEST(BlockStream, MoveTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -223,7 +223,7 @@ TEST(BlockStream, CopyAssignTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }
@@ -274,7 +274,7 @@ TEST(BlockStream, MoveAssignTest) {
             int count = 0;
             for (const auto& event : stream2) {
                 if (count % 3 == 2) {
-                    EXPECT_NE(dynamic_cast<const TestEvent*>(&event), nullptr);
+                    EXPECT_NE(event.asA<TestEvent>(), nullptr);
                     const TestEvent& e = static_cast<const TestEvent&>(event);
                     EXPECT_EQ(e.m_big[2], (count / 3));
                 }

--- a/Tests/Common/streamEventHolderTest.cpp
+++ b/Tests/Common/streamEventHolderTest.cpp
@@ -62,16 +62,16 @@ TEST(StreamEventHolder, Alignment) {
     EXPECT_TRUE(holder.hasEvent());
     EXPECT_EQ((*holder).m_value, 10);
     EXPECT_EQ(holder->m_value, 10);
-    ASSERT_NE(dynamic_cast<BigAlignedEvent*>(&*holder), nullptr);
-    EXPECT_EQ(dynamic_cast<BigAlignedEvent&>(*holder).m_value, 10);
+    ASSERT_NE(holder->asA<BigAlignedEvent>(), nullptr);
+    EXPECT_EQ(holder->asA<BigAlignedEvent>()->m_value, 10);
 
     BigAlignedEvent event2(14);
     holder = event2;
     EXPECT_TRUE(holder.hasEvent());
     EXPECT_EQ((*holder).m_value, 14);
     EXPECT_EQ(holder->m_value, 14);
-    ASSERT_NE(dynamic_cast<BigAlignedEvent*>(&*holder), nullptr);
-    EXPECT_EQ(dynamic_cast<BigAlignedEvent&>(*holder).m_value, 14);
+    ASSERT_NE(holder->asA<BigAlignedEvent>(), nullptr);
+    EXPECT_EQ(holder->asA<BigAlignedEvent>()->m_value, 14);
 }
 
 namespace {

--- a/Tests/Common/streamEventHolderTest.cpp
+++ b/Tests/Common/streamEventHolderTest.cpp
@@ -62,16 +62,16 @@ TEST(StreamEventHolder, Alignment) {
     EXPECT_TRUE(holder.hasEvent());
     EXPECT_EQ((*holder).m_value, 10);
     EXPECT_EQ(holder->m_value, 10);
-    ASSERT_NE(holder->asA<BigAlignedEvent>(), nullptr);
-    EXPECT_EQ(holder->asA<BigAlignedEvent>()->m_value, 10);
+    ASSERT_NE(holder->as<BigAlignedEvent>(), nullptr);
+    EXPECT_EQ(holder->as<BigAlignedEvent>()->m_value, 10);
 
     BigAlignedEvent event2(14);
     holder = event2;
     EXPECT_TRUE(holder.hasEvent());
     EXPECT_EQ((*holder).m_value, 14);
     EXPECT_EQ(holder->m_value, 14);
-    ASSERT_NE(holder->asA<BigAlignedEvent>(), nullptr);
-    EXPECT_EQ(holder->asA<BigAlignedEvent>()->m_value, 14);
+    ASSERT_NE(holder->as<BigAlignedEvent>(), nullptr);
+    EXPECT_EQ(holder->as<BigAlignedEvent>()->m_value, 14);
 }
 
 namespace {


### PR DESCRIPTION
Downcasting is needed in several hierarchies. Try to formalize the way client code does downcasting by adding a foo.as<BAR>() method in those hierarchies. While the underlying mechanism is still dynamic_cast, this should help if it gets refactored in future.