### PR TITLE
Generalize serialization with project metadata

### DIFF
--- a/BabelWiresLib/Serialization/dataBundle.hpp
+++ b/BabelWiresLib/Serialization/dataBundle.hpp
@@ -19,11 +19,10 @@
 
 namespace babelwires {
     /// A DataBundle carries data which is independent of the current system, and carries metadata sufficient
-    /// to version it (i.e. load it into a system which has changed since the data was saved).
-    /// Some virtual methods are provided so subclasses can carry additional metadata. To give control over the
-    /// file structure, this additional metadata can optionally be serialized outside instead of inside the data
-    /// payload. The subclass must implement the ProjectVisitable implementation so the data and possibly the
-    /// additional metadata get visited.
+    /// to load it into a system which may not be identical to the system in which it was saved.
+    /// This base class handles metadata for identifiers and paths, although the subclass must implement the
+    /// ProjectVisitable interface so the data (and possibly additional metadata) get visited.
+    /// Some virtual methods are provided so subclasses can provide support for additional metadata.
     template <typename DATA> class DataBundle : public Serializable, public ProjectVisitable {
       public:
         SERIALIZABLE_ABSTRACT(DataBundle, "dataBundle", void);
@@ -83,21 +82,22 @@ namespace babelwires {
         void resolveFilePathsAgainstCurrentProjectPath(const std::filesystem::path& pathToProjectFile,
                                                        UserLogger& userLogger);
 
+        /// Convert identifiers, relative to the sourceReg, to identifiers, relative to the targetReg.
         template <typename SOURCE_REG, typename TARGET_REG>
-        void convertData(SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
+        void convertIdentifiers(SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
                          babelwires::IdentifierRegistry::Authority authority);
 
       private:
-        /// The data.
+        /// The data payload.
         DATA m_data;
 
         /// Identifier metadata.
         IdentifierRegistry m_identifierRegistry;
 
-        /// Absolute path to the project, when saved.
+        /// Absolute path to the file when saved.
         /// FilePaths in the data are stored in relative form whenever possible.
         /// Having this allows us to reconstruct their absolute paths in case the relative path
-        /// from the project as loaded does not exist.
+        /// from the file as loaded does not exist.
         FilePath m_projectFilePath;
     };
 

--- a/BabelWiresLib/Serialization/dataBundle.hpp
+++ b/BabelWiresLib/Serialization/dataBundle.hpp
@@ -1,0 +1,92 @@
+/**
+ * A DataBundle carries DATA along with metadata sufficient to version it.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/Project/projectContext.hpp>
+#include <BabelWiresLib/FileFormat/filePath.hpp>
+
+#include <Common/Identifiers/identifierRegistry.hpp>
+#include <Common/Serialization/serializable.hpp>
+#include <Common/Log/userLogger.hpp>
+
+#include <filesystem>
+
+namespace babelwires {
+    /// A DataBundle carries data which is independent of the current system, and carries metadata sufficient
+    /// to version it (i.e. load it into a system which has changed since the data was saved).
+    /// Some virtual methods are provided so subclasses can carry additional metadata. To give control over the
+    /// file structure, this additional metadata can optionally be serialized outside instead of inside the data
+    /// payload.
+    template <typename DATA> class DataBundle : public Serializable {
+      public:
+        SERIALIZABLE_ABSTRACT(DataBundle, "dataBundle", void);
+        DataBundle() = default;
+        DataBundle(const DataBundle&) = delete;
+        DataBundle(DataBundle&&) = default;
+
+        DataBundle& operator=(const DataBundle&) = delete;
+        DataBundle& operator=(DataBundle&&) = default;
+
+        /// Construct a bundle from data.
+        /// The data is modified to make the bundle independent of the current system.
+        DataBundle(std::filesystem::path pathToProjectFile, DATA&& data);
+
+        /// Returns the contained data, modified so it corresponds the current system.
+        /// This object is invalidated after calling this.
+        DATA resolveAgainstCurrentContext(const ProjectContext& context, const std::filesystem::path& pathToProjectFile,
+                                          UserLogger& userLogger) &&;
+
+        void serializeContents(Serializer& serializer) const override;
+        void deserializeContents(Deserializer& deserializer) override;
+
+        const DATA& getData() const { return m_data; }
+        DATA& getData() { return m_data; }
+
+        const IdentifierRegistry& getIdentifierRegistry() const { return m_identifierRegistry; }
+
+      private:
+        /// Ensure the fields in the data refer to the context independent m_identifierRegistry.
+        void interpretIdentifiersInCurrentContext();
+
+        /// Ensure the filePaths in the data are made relative to the m_projectFilePath.
+        void interpretFilePathsInCurrentProjectPath();
+
+        /// Ensure the fields in the data refer to the global FileNameRegistry.
+        void resolveIdentifiersAgainstCurrentContext();
+
+        /// Update the filePaths in the data, in terms of the given pathToProjectFile.
+        void resolveFilePathsAgainstCurrentProjectPath(const std::filesystem::path& pathToProjectFile,
+                                                       UserLogger& userLogger);
+
+      protected:
+        /// If the subclass needs to do any additional resolution, it can do it here.
+        virtual void adaptDataToAdditionalMetadata(const ProjectContext& context, UserLogger& userLogger) {}
+
+        /// Allows the subclass to put additional metadata at the same level as the metadata handled by this class.
+        virtual void serializeAdditionalMetadata(Serializer& serializer) const {}
+
+        /// Allows the subclass to put additional metadata at the same level as the metadata handled by this class.
+        virtual void deserializeAdditionalMetadata(Deserializer& deserializer) {}
+
+      private:
+        /// The data.
+        DATA m_data;
+
+        /// Identifier metadata.
+        IdentifierRegistry m_identifierRegistry;
+
+        /// Absolute path to the project, when saved.
+        /// FilePaths in the data are stored in relative form whenever possible.
+        /// Having this allows us to reconstruct their absolute paths in case the relative path
+        /// from the project as loaded does not exist.
+        FilePath m_projectFilePath;
+    };
+
+} // namespace babelwires
+
+#include <BabelWiresLib/Serialization/dataBundle_inl.hpp>

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -1,0 +1,115 @@
+#include <BabelWiresLib/Project/projectVisitable.hpp>
+
+#include <Common/Serialization/deserializer.hpp>
+#include <Common/Serialization/serializer.hpp>
+
+namespace babelwires {
+    namespace Detail {
+
+        template <typename SOURCE_REG, typename TARGET_REG> struct IdentifierVisitor : babelwires::IdentifierVisitor {
+            IdentifierVisitor(const SOURCE_REG& sourceReg, TARGET_REG& targetReg,
+                              babelwires::IdentifierRegistry::Authority authority)
+                : m_sourceReg(sourceReg)
+                , m_targetReg(targetReg)
+                , m_authority(authority) {}
+
+            template <typename IDENTIFIER> void visit(IDENTIFIER& sourceId) {
+                if (sourceId.getDiscriminator() != 0) {
+                    IDENTIFIER newId = sourceId;
+                    newId.setDiscriminator(0);
+                    // This can throw, but an exception here is only meaningful in the loading case.
+                    // In the saving case, the exception is caught and triggers an assertion.
+                    const babelwires::IdentifierRegistry::ValueType fieldData =
+                        m_sourceReg->getDeserializedIdentifierData(sourceId);
+                    newId = m_targetReg->addIdentifierWithMetadata(newId, *std::get<1>(fieldData),
+                                                                   *std::get<2>(fieldData), m_authority);
+                    sourceId.setDiscriminator(newId.getDiscriminator());
+                }
+            }
+
+            void operator()(babelwires::Identifier& identifier) override { visit(identifier); }
+            void operator()(babelwires::LongIdentifier& identifier) override { visit(identifier); }
+
+            const SOURCE_REG& m_sourceReg;
+            TARGET_REG& m_targetReg;
+            babelwires::IdentifierRegistry::Authority m_authority;
+        };
+
+        template <typename DATA, typename SOURCE_REG, typename TARGET_REG>
+        void convertData(DATA& data, SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
+                         babelwires::IdentifierRegistry::Authority authority) {
+            IdentifierVisitor<SOURCE_REG, TARGET_REG> visitor(sourceReg, targetReg, authority);
+            data.visitIdentifiers(visitor);
+        }
+    } // namespace Detail
+} // namespace babelwires
+
+template <typename DATA>
+babelwires::DataBundle<DATA>::DataBundle(std::filesystem::path pathToProjectFile, DATA&& data)
+    : m_data(std::move(data))
+    , m_projectFilePath(pathToProjectFile) {
+    interpretIdentifiersInCurrentContext();
+    interpretFilePathsInCurrentProjectPath();
+}
+
+template <typename DATA>
+DATA babelwires::DataBundle<DATA>::resolveAgainstCurrentContext(const ProjectContext& context,
+                                                                      const std::filesystem::path& pathToProjectFile,
+                                                                      UserLogger& userLogger) && {
+    resolveIdentifiersAgainstCurrentContext();
+    resolveFilePathsAgainstCurrentProjectPath(pathToProjectFile, userLogger);
+    adaptDataToAdditionalMetadata(context, userLogger);
+    return std::move(m_data);
+}
+
+template <typename DATA> void babelwires::DataBundle<DATA>::interpretIdentifiersInCurrentContext() {
+    IdentifierRegistry::ReadAccess sourceRegistry = IdentifierRegistry::read();
+    try {
+        Detail::convertData(m_data, sourceRegistry, &m_identifierRegistry, IdentifierRegistry::Authority::isTemporary);
+    } catch (const ParseException&) {
+        assert(false && "A field with a discriminator did not resolve.");
+    }
+}
+
+template <typename DATA> void babelwires::DataBundle<DATA>::interpretFilePathsInCurrentProjectPath() {
+    if (!m_projectFilePath.empty()) {
+        const std::filesystem::path projectPath = m_projectFilePath;
+        babelwires::FilePathVisitor visitor = [&](FilePath& filePath) {
+            filePath.interpretRelativeTo(projectPath.parent_path());
+        };
+        m_data.visitFilePaths(visitor);
+    }
+}
+
+template <typename DATA> void babelwires::DataBundle<DATA>::resolveIdentifiersAgainstCurrentContext() {
+    IdentifierRegistry::WriteAccess targetRegistry = IdentifierRegistry::write();
+    Detail::convertData(m_data, &m_identifierRegistry, targetRegistry, IdentifierRegistry::Authority::isProvisional);
+}
+
+template <typename DATA>
+void babelwires::DataBundle<DATA>::resolveFilePathsAgainstCurrentProjectPath(const std::filesystem::path& pathToProjectFile,
+                                                                       UserLogger& userLogger) {
+    const std::filesystem::path newBase =
+        pathToProjectFile.empty() ? std::filesystem::path() : pathToProjectFile.parent_path();
+    const std::filesystem::path oldBase =
+        m_projectFilePath.empty() ? std::filesystem::path() : std::filesystem::path(m_projectFilePath).parent_path();
+    babelwires::FilePathVisitor visitor = [&](FilePath& filePath) {
+        filePath.resolveRelativeTo(newBase, oldBase, userLogger);
+    };
+    m_data.visitFilePaths(visitor);
+}
+
+template <typename DATA> void babelwires::DataBundle<DATA>::serializeContents(Serializer& serializer) const {
+    serializer.serializeValue("filePath", m_projectFilePath);
+    serializer.serializeObject(m_data);
+    serializeAdditionalMetadata(serializer);
+    serializer.serializeObject(m_identifierRegistry);
+}
+
+template <typename DATA> void babelwires::DataBundle<DATA>::deserializeContents(Deserializer& deserializer) {
+    deserializer.deserializeValue("filePath", m_projectFilePath, babelwires::Deserializer::IsOptional::Optional);
+    m_data = std::move(*deserializer.deserializeObject<DATA>(DATA::serializationType));
+    deserializeAdditionalMetadata(deserializer);
+    m_identifierRegistry =
+        std::move(*deserializer.deserializeObject<IdentifierRegistry>(IdentifierRegistry::serializationType));
+}

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -60,7 +60,7 @@ DATA babelwires::DataBundle<DATA>::resolveAgainstCurrentContext(const ProjectCon
 
 template <typename DATA>
 template <typename SOURCE_REG, typename TARGET_REG>
-void babelwires::DataBundle<DATA>::convertData(SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
+void babelwires::DataBundle<DATA>::convertIdentifiers(SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
                     babelwires::IdentifierRegistry::Authority authority) {
     Detail::IdentifierVisitor<SOURCE_REG, TARGET_REG> visitor(sourceReg, targetReg, authority);
     visitIdentifiers(visitor);
@@ -69,7 +69,7 @@ void babelwires::DataBundle<DATA>::convertData(SOURCE_REG&& sourceReg, TARGET_RE
 template <typename DATA> void babelwires::DataBundle<DATA>::interpretIdentifiersInCurrentContext() {
     IdentifierRegistry::ReadAccess sourceRegistry = IdentifierRegistry::read();
     try {
-        convertData(sourceRegistry, &m_identifierRegistry, IdentifierRegistry::Authority::isTemporary);
+        convertIdentifiers(sourceRegistry, &m_identifierRegistry, IdentifierRegistry::Authority::isTemporary);
     } catch (const ParseException&) {
         assert(false && "A field with a discriminator did not resolve.");
     }
@@ -87,7 +87,7 @@ template <typename DATA> void babelwires::DataBundle<DATA>::interpretFilePathsIn
 
 template <typename DATA> void babelwires::DataBundle<DATA>::resolveIdentifiersAgainstCurrentContext() {
     IdentifierRegistry::WriteAccess targetRegistry = IdentifierRegistry::write();
-    convertData(&m_identifierRegistry, targetRegistry, IdentifierRegistry::Authority::isProvisional);
+    convertIdentifiers(&m_identifierRegistry, targetRegistry, IdentifierRegistry::Authority::isProvisional);
 }
 
 template <typename DATA>

--- a/BabelWiresLib/Serialization/projectBundle.cpp
+++ b/BabelWiresLib/Serialization/projectBundle.cpp
@@ -12,87 +12,10 @@
 
 #include "Common/exceptions.hpp"
 
-#include "Common/Serialization/deserializer.hpp"
-#include "Common/Serialization/serializer.hpp"
-
-namespace {
-    template <typename SOURCE_REG, typename TARGET_REG> struct IdentifierVisitor : babelwires::IdentifierVisitor {
-        IdentifierVisitor(const SOURCE_REG& sourceReg, TARGET_REG& targetReg,
-                            babelwires::IdentifierRegistry::Authority authority)
-            : m_sourceReg(sourceReg)
-            , m_targetReg(targetReg)
-            , m_authority(authority) {}
-
-        template <typename IDENTIFIER> void visit(IDENTIFIER& sourceId) {
-            if (sourceId.getDiscriminator() != 0) {
-                IDENTIFIER newId = sourceId;
-                newId.setDiscriminator(0);
-                // This can throw, but an exception here is only meaningful in the loading case.
-                // In the saving case, the exception is caught and triggers an assertion.
-                const babelwires::IdentifierRegistry::ValueType fieldData =
-                    m_sourceReg->getDeserializedIdentifierData(sourceId);
-                newId = m_targetReg->addIdentifierWithMetadata(newId, *std::get<1>(fieldData), *std::get<2>(fieldData),
-                                                             m_authority);
-                sourceId.setDiscriminator(newId.getDiscriminator());
-            }
-        }
-
-        void operator()(babelwires::Identifier& identifier) override { visit(identifier); }
-        void operator()(babelwires::LongIdentifier& identifier) override { visit(identifier); }
-
-        const SOURCE_REG& m_sourceReg;
-        TARGET_REG& m_targetReg;
-        babelwires::IdentifierRegistry::Authority m_authority;
-    };
-
-    template <typename SOURCE_REG, typename TARGET_REG>
-    void convertProjectData(babelwires::ProjectData& projectData, SOURCE_REG&& sourceReg, TARGET_REG&& targetReg,
-                            babelwires::IdentifierRegistry::Authority authority) {
-        IdentifierVisitor<SOURCE_REG, TARGET_REG> visitor(sourceReg, targetReg, authority);
-        projectData.visitIdentifiers(visitor);
-    }
-} // namespace
-
-babelwires::ProjectBundle::ProjectBundle() = default;
-
 babelwires::ProjectBundle::ProjectBundle(std::filesystem::path pathToProjectFile, ProjectData&& projectData)
-    : m_projectData(std::move(projectData))
-    , m_projectFilePath(pathToProjectFile) {
-    interpretIdentifiersInCurrentContext();
-    interpretFilePathsInCurrentProjectPath();
-    captureCurrentFactoryMetadata();
-}
-
-babelwires::ProjectData babelwires::ProjectBundle::resolveAgainstCurrentContext(
-    const ProjectContext& context, const std::filesystem::path& pathToProjectFile, UserLogger& userLogger) && {
-    resolveIdentifiersAgainstCurrentContext();
-    resolveFilePathsAgainstCurrentProjectPath(pathToProjectFile, userLogger);
-    adaptDataToCurrentFactories(context, userLogger);
-    return std::move(m_projectData);
-}
-
-void babelwires::ProjectBundle::interpretIdentifiersInCurrentContext() {
-    IdentifierRegistry::ReadAccess sourceRegistry = IdentifierRegistry::read();
-    try {
-        convertProjectData(m_projectData, sourceRegistry, &m_identifierRegistry,
-                           IdentifierRegistry::Authority::isTemporary);
-    } catch (const ParseException&) {
-        assert(false && "A field with a discriminator did not resolve.");
-    }
-}
-
-void babelwires::ProjectBundle::interpretFilePathsInCurrentProjectPath() {
-    if (!m_projectFilePath.empty()) {
-        const std::filesystem::path projectPath = m_projectFilePath;
-        babelwires::FilePathVisitor visitor = [&](FilePath& filePath) {
-            filePath.interpretRelativeTo(projectPath.parent_path());
-        };
-        m_projectData.visitFilePaths(visitor);
-    }
-}
-
-void babelwires::ProjectBundle::captureCurrentFactoryMetadata() {
-    for (const auto& element : m_projectData.m_elements) {
+    : DataBundle(std::move(pathToProjectFile), std::move(projectData)) {
+    // Capture current factory metadata
+    for (const auto& element : getData().m_elements) {
         VersionNumber& storedVersion = m_factoryMetadata[element->m_factoryIdentifier];
         assert(((storedVersion == 0) || (storedVersion == element->m_factoryVersion)) &&
                "Inconsistent factory versions in ProjectData");
@@ -100,30 +23,12 @@ void babelwires::ProjectBundle::captureCurrentFactoryMetadata() {
     }
 }
 
-void babelwires::ProjectBundle::resolveIdentifiersAgainstCurrentContext() {
-    IdentifierRegistry::WriteAccess targetRegistry = IdentifierRegistry::write();
-    convertProjectData(m_projectData, &m_identifierRegistry, targetRegistry,
-                       IdentifierRegistry::Authority::isProvisional);
-}
-
-void babelwires::ProjectBundle::resolveFilePathsAgainstCurrentProjectPath(
-    const std::filesystem::path& pathToProjectFile, UserLogger& userLogger) {
-    const std::filesystem::path newBase =
-        pathToProjectFile.empty() ? std::filesystem::path() : pathToProjectFile.parent_path();
-    const std::filesystem::path oldBase =
-        m_projectFilePath.empty() ? std::filesystem::path() : std::filesystem::path(m_projectFilePath).parent_path();
-    babelwires::FilePathVisitor visitor = [&](FilePath& filePath) {
-        filePath.resolveRelativeTo(newBase, oldBase, userLogger);
-    };
-    m_projectData.visitFilePaths(visitor);
-}
-
-void babelwires::ProjectBundle::adaptDataToCurrentFactories(const ProjectContext& context, UserLogger& userLogger) {
-    for (auto& element : m_projectData.m_elements) {
+void babelwires::ProjectBundle::adaptDataToAdditionalMetadata(const ProjectContext& context, UserLogger& userLogger) {
+    for (auto& element : getData().m_elements) {
         element->m_factoryVersion = m_factoryMetadata[element->m_factoryIdentifier];
     }
 
-    for (auto& element : m_projectData.m_elements) {
+    for (auto& element : getData().m_elements) {
         // Can log the same message multiple times.
         element->checkFactoryVersion(context, userLogger);
     }
@@ -146,9 +51,7 @@ namespace {
     };
 } // namespace
 
-void babelwires::ProjectBundle::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("filePath", m_projectFilePath);
-    serializer.serializeObject(m_projectData);
+void babelwires::ProjectBundle::serializeAdditionalMetadata(Serializer& serializer) const {
     std::vector<FactoryInfoPair> factoryMetadata;
     for (const auto& [k, v] : m_factoryMetadata) {
         FactoryInfoPair metadata;
@@ -157,16 +60,11 @@ void babelwires::ProjectBundle::serializeContents(Serializer& serializer) const 
         factoryMetadata.emplace_back(metadata);
     }
     serializer.serializeArray("factoryMetadata", factoryMetadata);
-    serializer.serializeObject(m_identifierRegistry);
 }
 
-void babelwires::ProjectBundle::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("filePath", m_projectFilePath, babelwires::Deserializer::IsOptional::Optional);
-    m_projectData = std::move(*deserializer.deserializeObject<ProjectData>(ProjectData::serializationType));
+void babelwires::ProjectBundle::deserializeAdditionalMetadata(Deserializer& deserializer) {
     for (auto it = deserializer.deserializeArray<FactoryInfoPair>("factoryMetadata"); it.isValid(); ++it) {
         auto fm = it.getObject();
         m_factoryMetadata.insert(std::make_pair(std::move(fm->m_factoryIdentifier), fm->m_factoryVersion));
     }
-    m_identifierRegistry =
-        std::move(*deserializer.deserializeObject<IdentifierRegistry>(IdentifierRegistry::serializationType));
 }

--- a/BabelWiresLib/Serialization/projectBundle.hpp
+++ b/BabelWiresLib/Serialization/projectBundle.hpp
@@ -33,6 +33,7 @@ namespace babelwires {
         const FactoryMetadata& getFactoryMetadata() const { return m_factoryMetadata; }
 
       protected:
+        /// Populate the factoryMetadata.
         void interpretAdditionalMetadataInCurrentContext() override;
 
         /// The versions of the factories in the stored ProjectData from the factory meta-data are updated.

--- a/BabelWiresLib/Serialization/projectBundle.hpp
+++ b/BabelWiresLib/Serialization/projectBundle.hpp
@@ -7,87 +7,42 @@
  **/
 #pragma once
 
-#include "Common/Identifiers/identifierRegistry.hpp"
-#include "BabelWiresLib/FileFormat/filePath.hpp"
+#include "BabelWiresLib/Serialization/dataBundle.hpp"
 #include "BabelWiresLib/Project/projectData.hpp"
-
-#include "Common/Serialization/serializable.hpp"
 
 #include <map>
 
 namespace babelwires {
     /// A ProjectBundle carries ProjectData which is independent of the current system, and carries metadata sufficient
     /// to version it (i.e. load it into a system which has changed since the data was saved).
-    class ProjectBundle : public Serializable {
+    class ProjectBundle : public DataBundle<ProjectData> {
       public:
         SERIALIZABLE(ProjectBundle, "project", void, 1);
-        ProjectBundle();
-        ProjectBundle(const ProjectBundle&) = delete;
+        ProjectBundle() = default;
         ProjectBundle(ProjectBundle&&) = default;
-
-        ProjectBundle& operator=(const ProjectBundle&) = delete;
         ProjectBundle& operator=(ProjectBundle&&) = default;
 
         /// Construct a bundle from projectData.
         /// The projectData is modified to make the bundle independent of the current system.
         ProjectBundle(std::filesystem::path pathToProjectFile, ProjectData&& projectData);
 
-        /// Returns the contained projectData, modified so it corresponds the current system.
-        /// This object is invalidated after calling this.
-        ProjectData resolveAgainstCurrentContext(const ProjectContext& context, const std::filesystem::path& pathToProjectFile,
-                                                       UserLogger& userLogger) &&;
-
-        void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
-
-      private:
-        /// Ensure the fields in the projectData refer to the context independent m_identifierRegistry.
-        void interpretIdentifiersInCurrentContext();
-
-        /// Ensure the filePaths in the projectData are made relative to the m_projectFilePath.
-        void interpretFilePathsInCurrentProjectPath();
-
-        /// Record the metadata of factories used by the projectData.
-        void captureCurrentFactoryMetadata();
-
-        /// Ensure the fields in the projectData refer to the global FileNameRegistry.
-        void resolveIdentifiersAgainstCurrentContext();
-
-        /// Update the filePaths in the projectData, in terms of the given pathToProjectFile.
-        void resolveFilePathsAgainstCurrentProjectPath(const std::filesystem::path& pathToProjectFile,
-                                                       UserLogger& userLogger);
-
-        /// The versions of the factories in the stored ProjectData from the factory meta-data are updated.
-        /// NOTE: Right now, no versioning is done! All that happens is that warnings and errors are issued.
-        void adaptDataToCurrentFactories(const ProjectContext& context, UserLogger& userLogger);
-
       public:
-        // Used by tests.
-
-        const IdentifierRegistry& getIdentifierRegistry() const { return m_identifierRegistry; }
-
-        const ProjectData& getProjectData() const { return m_projectData; }
-
         /// Information about the factories used by the projectData.
         using FactoryMetadata = std::map<LongIdentifier, VersionNumber>;
 
         const FactoryMetadata& getFactoryMetadata() const { return m_factoryMetadata; }
 
-      private:
-        /// The data.
-        ProjectData m_projectData;
+      protected:
+        /// The versions of the factories in the stored ProjectData from the factory meta-data are updated.
+        /// NOTE: Right now, no versioning is done! All that happens is that warnings and errors are issued.
+        void adaptDataToAdditionalMetadata(const ProjectContext& context, UserLogger& userLogger) override;
 
+        void serializeAdditionalMetadata(Serializer& serializer) const override;
+        void deserializeAdditionalMetadata(Deserializer& deserializer) override;
+
+      private:
         /// Information about the factories.
         FactoryMetadata m_factoryMetadata;
-
-        /// Identifier metadata.
-        IdentifierRegistry m_identifierRegistry;
-
-        /// Absolute path to the project, when saved.
-        /// FilePaths in the projectData are stored in relative form whenever possible.
-        /// Having this allows us to reconstruct their absolute paths in case the relative path
-        /// from the project as loaded does not exist.
-        FilePath m_projectFilePath;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Serialization/projectBundle.hpp
+++ b/BabelWiresLib/Serialization/projectBundle.hpp
@@ -33,12 +33,16 @@ namespace babelwires {
         const FactoryMetadata& getFactoryMetadata() const { return m_factoryMetadata; }
 
       protected:
+        void interpretAdditionalMetadataInCurrentContext() override;
+
         /// The versions of the factories in the stored ProjectData from the factory meta-data are updated.
         /// NOTE: Right now, no versioning is done! All that happens is that warnings and errors are issued.
         void adaptDataToAdditionalMetadata(const ProjectContext& context, UserLogger& userLogger) override;
 
         void serializeAdditionalMetadata(Serializer& serializer) const override;
         void deserializeAdditionalMetadata(Deserializer& deserializer) override;
+        void visitIdentifiers(IdentifierVisitor& visitor) override;
+        void visitFilePaths(FilePathVisitor& visitor) override;
 
       private:
         /// Information about the factories.

--- a/BabelWiresLib/Serialization/projectSerialization.cpp
+++ b/BabelWiresLib/Serialization/projectSerialization.cpp
@@ -58,6 +58,7 @@ babelwires::ProjectData babelwires::ProjectSerialization::loadFromString(const s
 void babelwires::ProjectSerialization::internal::saveToStream(std::ostream& os, const std::filesystem::path& pathToProjectFile, ProjectData projectData) {
     XmlSerializer serializer;
     ProjectBundle bundle(pathToProjectFile, std::move(projectData));
+    bundle.interpretInCurrentContext();
     serializer.serializeObject(bundle);
     serializer.write(os);
 }

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -144,7 +144,7 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
             EXPECT_NE(recordInt2Disciminator, fileIntChildDiscriminator);
 
             libTestUtils::TestProjectData::testProjectDataAndDisciminators(
-                bundle2.getProjectData(), recordIntDiscriminator, recordArrayDiscriminator, recordRecordDiscriminator,
+                bundle2.getData(), recordIntDiscriminator, recordArrayDiscriminator, recordRecordDiscriminator,
                 recordInt2Disciminator, fileIntChildDiscriminator);
         }
         bundle = std::move(bundle2);
@@ -342,7 +342,7 @@ TEST(ProjectBundleTest, factoryIdentifiers) {
 
     babelwires::ProjectBundle bundle(std::filesystem::current_path(), std::move(projectData));
    
-    EXPECT_EQ(bundle.getProjectData().m_elements[0]->m_factoryIdentifier.getDiscriminator(), 1);
-    EXPECT_EQ(bundle.getProjectData().m_elements[1]->m_factoryIdentifier.getDiscriminator(), 1);
-    EXPECT_EQ(bundle.getProjectData().m_elements[2]->m_factoryIdentifier.getDiscriminator(), 1);
+    EXPECT_EQ(bundle.getData().m_elements[0]->m_factoryIdentifier.getDiscriminator(), 1);
+    EXPECT_EQ(bundle.getData().m_elements[1]->m_factoryIdentifier.getDiscriminator(), 1);
+    EXPECT_EQ(bundle.getData().m_elements[2]->m_factoryIdentifier.getDiscriminator(), 1);
 }

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -89,6 +89,7 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
 
         // Test the construction of a bundle from a projectData.
         babelwires::ProjectBundle bundle2(std::filesystem::current_path(), std::move(projectData));
+        bundle2.interpretInCurrentContext();
 
         {
             // Bit of a hack, but this lets us iterate through the registry.
@@ -211,6 +212,7 @@ TEST(ProjectBundleTest, factoryMetadata) {
     projectData.m_elements[2]->m_factoryVersion = 3;
 
     babelwires::ProjectBundle bundle(std::filesystem::current_path(), std::move(projectData));
+    bundle.interpretInCurrentContext();
 
     ASSERT_EQ(bundle.getFactoryMetadata().size(), 3);
     EXPECT_EQ(bundle.getFactoryMetadata().find(libTestUtils::TestTargetFileFormat::getThisIdentifier())->second, 1);
@@ -341,6 +343,7 @@ TEST(ProjectBundleTest, factoryIdentifiers) {
     EXPECT_EQ(projectData.m_elements[2]->m_factoryIdentifier.getDiscriminator(), 2);
 
     babelwires::ProjectBundle bundle(std::filesystem::current_path(), std::move(projectData));
+    bundle.interpretInCurrentContext();
    
     EXPECT_EQ(bundle.getData().m_elements[0]->m_factoryIdentifier.getDiscriminator(), 1);
     EXPECT_EQ(bundle.getData().m_elements[1]->m_factoryIdentifier.getDiscriminator(), 1);


### PR DESCRIPTION
I want to be able to serialize other types with the same support for metadata as the project. I will want this, for example, for maps which are being developed in the mapValue branch. This breaks out the generic metadata handling in ProjectBundle and moves it to a base class called DataBundle. The handling of factory metadata (which is projectData specific) is left in ProjectBundle.