### PR TITLE
No need for typename in SERIALIZABLE_ABSTRACT

### DIFF
--- a/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
@@ -52,7 +52,7 @@ namespace babelwires {
     struct ElementData : Cloneable, CustomCloneable<ShallowCloneContext>, Serializable, ProjectVisitable {
         CLONEABLE_ABSTRACT(ElementData);
         CUSTOM_CLONEABLE_ABSTRACT(ElementData);
-        SERIALIZABLE_ABSTRACT(ElementData, "ElementData", void);
+        SERIALIZABLE_ABSTRACT(ElementData, void);
         DOWNCASTABLE_TYPE_HIERARCHY(ElementData);
 
         ElementData() = default;

--- a/BabelWiresLib/Project/Modifiers/modifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/modifierData.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
     /// ModifierData carry the data sufficient to reconstruct a Modifier.
     struct ModifierData : Cloneable, Serializable, ProjectVisitable {
         CLONEABLE_ABSTRACT(ModifierData);
-        SERIALIZABLE_ABSTRACT(ModifierData, "ModifierData", void);
+        SERIALIZABLE_ABSTRACT(ModifierData, void);
         DOWNCASTABLE_TYPE_HIERARCHY(ModifierData);
 
         /// Identifies the feature being modified.
@@ -49,7 +49,7 @@ namespace babelwires {
     /// Base class for ModifierData which construct LocalModifiers.
     struct LocalModifierData : ModifierData {
         CLONEABLE_ABSTRACT(LocalModifierData);
-        SERIALIZABLE_ABSTRACT(LocalModifierData, "LocalModifierData", ModifierData);
+        SERIALIZABLE_ABSTRACT(LocalModifierData, ModifierData);
 
         /// Perform the modification on the target feature, or throw.
         virtual void apply(Feature* targetFeature) const = 0;

--- a/BabelWiresLib/Serialization/dataBundle.hpp
+++ b/BabelWiresLib/Serialization/dataBundle.hpp
@@ -27,7 +27,7 @@ namespace babelwires {
       public:
         using Data = DATA;
 
-        SERIALIZABLE_ABSTRACT(DataBundle, "dataBundle", void);
+        SERIALIZABLE_ABSTRACT(DataBundle, void);
         DataBundle() = default;
         DataBundle(const DataBundle&) = delete;
         DataBundle(DataBundle&&) = default;

--- a/Common/Serialization/serializable.hpp
+++ b/Common/Serialization/serializable.hpp
@@ -2,7 +2,7 @@
  * An interface for classes which support serialization/deserialization.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -37,17 +37,17 @@ namespace babelwires {
     };
 
 /// For abstract classes whose subtypes can be serialized.
-#define SERIALIZABLE_ABSTRACT(T, TYPENAME, PARENT)                                                                     \
+#define SERIALIZABLE_ABSTRACT(T, PARENT)                                                                               \
     using SerializableParent = PARENT;                                                                                 \
-    static constexpr char serializationType[] = TYPENAME;                                                              \
-    static constexpr void* getSerializationTag() { return babelwires::Detail::getSerializationTag<T>(); }              \
-    std::string_view getSerializationType() const override { return serializationType; }
+    static constexpr void* getSerializationTag() { return babelwires::Detail::getSerializationTag<T>(); }
 
 /// For concrete classes which can be serialized and deserialized.
 /// A class must provide implementations of serializeContents and deserializeContents.
 // TODO Macro tricks to make PARENT and VERSION optional.
 #define SERIALIZABLE(T, TYPENAME, PARENT, VERSION)                                                                     \
-    SERIALIZABLE_ABSTRACT(T, TYPENAME, PARENT);                                                                        \
+    SERIALIZABLE_ABSTRACT(T, PARENT);                                                                        \
+    std::string_view getSerializationType() const override { return serializationType; }                               \
+    static constexpr char serializationType[] = TYPENAME;                                                              \
     static constexpr int serializationVersion = VERSION;                                                               \
     static_assert(VERSION != 0, "Version must be greater than 0");                                                     \
     babelwires::VersionNumber getSerializationVersion() const override {                                               \

--- a/Tests/Common/serializationTest.cpp
+++ b/Tests/Common/serializationTest.cpp
@@ -233,7 +233,7 @@ TEST(SerializationTest, versioningCurrent) {
 
 namespace {
     struct Base : babelwires::Serializable {
-        SERIALIZABLE_ABSTRACT(Base, "Base", void);
+        SERIALIZABLE_ABSTRACT(Base, void);
     };
 
     struct Concrete0 : Base {
@@ -247,7 +247,7 @@ namespace {
     };
 
     struct Intermediate : Base {
-        SERIALIZABLE_ABSTRACT(Intermediate, "Intermediate", Base);
+        SERIALIZABLE_ABSTRACT(Intermediate, Base);
     };
 
     struct Intermediate2 : Intermediate {};


### PR DESCRIPTION
Abstract types are never found in serialized data, so there's no need for them to have an associated name.