### PR TITLE
Use Constructor instead of deserializeContents

### DIFF
--- a/BabelWiresLib/Project/FeatureElements/featureElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData.cpp
@@ -27,7 +27,7 @@ void babelwires::UiData::serializeContents(Serializer& serializer) const {
     serializer.serializeValue("width", m_uiSize.m_width);
 }
 
-void babelwires::UiData::deserializeContents(Deserializer& deserializer) {
+babelwires::UiData::UiData(Deserializer& deserializer) {
     deserializer.deserializeValue("x", m_uiPosition.m_x);
     deserializer.deserializeValue("y", m_uiPosition.m_y);
     deserializer.deserializeValue("width", m_uiSize.m_width);
@@ -62,7 +62,8 @@ void babelwires::ElementData::addCommonKeyValuePairs(Serializer& serializer) con
     // Factory versions are handled by the projectBundle.
 }
 
-void babelwires::ElementData::getCommonKeyValuePairs(Deserializer& deserializer) {
+babelwires::ElementData::ElementData(Deserializer& deserializer)
+{
     deserializer.deserializeValue("id", m_id);
     deserializer.deserializeValue("factory", m_factoryIdentifier);
     // Factory versions are handled by the projectBundle.

--- a/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
@@ -37,7 +37,8 @@ namespace babelwires {
     struct UiData : Serializable {
         SERIALIZABLE(UiData, "uiData", void, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        UiData() = default;
+        UiData(Deserializer& deserializer);
 
         /// The position this element is at in the UI.
         UiPosition m_uiPosition;
@@ -105,7 +106,7 @@ namespace babelwires {
 
         /// For use when serializing subclasses.
         void addCommonKeyValuePairs(Serializer& serializer) const;
-        void getCommonKeyValuePairs(Deserializer& deserializer);
+        ElementData(Deserializer& deserializer);
 
         /// For use when serializing subclasses.
         void serializeModifiers(Serializer& serializer) const;

--- a/BabelWiresLib/Project/FeatureElements/processorElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/processorElementData.cpp
@@ -2,17 +2,17 @@
  * ProcessorElementData describes the construction of a SourceFileFeature.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "BabelWiresLib/Project/FeatureElements/processorElementData.hpp"
 
+#include "BabelWiresLib/Features/rootFeature.hpp"
 #include "BabelWiresLib/Processors/processor.hpp"
 #include "BabelWiresLib/Processors/processorFactory.hpp"
 #include "BabelWiresLib/Processors/processorFactoryRegistry.hpp"
 #include "BabelWiresLib/Project/FeatureElements/processorElement.hpp"
 #include "BabelWiresLib/Project/projectContext.hpp"
-#include "BabelWiresLib/Features/rootFeature.hpp"
 
 #include "Common/Log/userLogger.hpp"
 #include "Common/Serialization/deserializer.hpp"
@@ -28,7 +28,7 @@ bool babelwires::ProcessorElementData::checkFactoryVersion(const ProjectContext&
 
 std::unique_ptr<babelwires::FeatureElement>
 babelwires::ProcessorElementData::doCreateFeatureElement(const ProjectContext& context, UserLogger& userLogger,
-                                                  ElementId newId) const {
+                                                         ElementId newId) const {
     return std::make_unique<ProcessorElement>(context, userLogger, *this, newId);
 }
 
@@ -38,8 +38,8 @@ void babelwires::ProcessorElementData::serializeContents(Serializer& serializer)
     serializeUiData(serializer);
 }
 
-void babelwires::ProcessorElementData::deserializeContents(Deserializer& deserializer) {
-    getCommonKeyValuePairs(deserializer);
+babelwires::ProcessorElementData::ProcessorElementData(Deserializer& deserializer)
+    : ElementData(deserializer) {
     deserializeModifiers(deserializer);
     deserializeUiData(deserializer);
 }

--- a/BabelWiresLib/Project/FeatureElements/processorElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/processorElementData.hpp
@@ -22,7 +22,7 @@ namespace babelwires {
         bool checkFactoryVersion(const ProjectContext& context, UserLogger& userLogger) override;
 
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        ProcessorElementData(Deserializer& deserializer);
 
       protected:
         std::unique_ptr<FeatureElement> doCreateFeatureElement(const ProjectContext& context, UserLogger& userLogger,

--- a/BabelWiresLib/Project/FeatureElements/sourceFileElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/sourceFileElementData.cpp
@@ -38,8 +38,8 @@ void babelwires::SourceFileElementData::serializeContents(Serializer& serializer
     serializeUiData(serializer);
 }
 
-void babelwires::SourceFileElementData::deserializeContents(Deserializer& deserializer) {
-    getCommonKeyValuePairs(deserializer);
+babelwires::SourceFileElementData::SourceFileElementData(Deserializer& deserializer)
+ : ElementData(deserializer) {
     deserializer.deserializeValue("filePath", m_filePath);
     deserializeModifiers(deserializer);
     deserializeUiData(deserializer);

--- a/BabelWiresLib/Project/FeatureElements/sourceFileElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/sourceFileElementData.hpp
@@ -28,7 +28,7 @@ namespace babelwires {
         bool checkFactoryVersion(const ProjectContext& context, UserLogger& userLogger) override;
 
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        SourceFileElementData(Deserializer& deserializer);
         void visitFilePaths(FilePathVisitor& visitor) override;
 
         /// The file containing the data.

--- a/BabelWiresLib/Project/FeatureElements/targetFileElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/targetFileElementData.cpp
@@ -39,8 +39,7 @@ void babelwires::TargetFileElementData::serializeContents(Serializer& serializer
     serializeUiData(serializer);
 }
 
-void babelwires::TargetFileElementData::deserializeContents(Deserializer& deserializer) {
-    getCommonKeyValuePairs(deserializer);
+babelwires::TargetFileElementData::TargetFileElementData(Deserializer& deserializer) : ElementData(deserializer) {
     deserializer.deserializeValue("filePath", m_filePath);
     deserializeModifiers(deserializer);
     deserializeUiData(deserializer);

--- a/BabelWiresLib/Project/FeatureElements/targetFileElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/targetFileElementData.hpp
@@ -29,7 +29,7 @@ namespace babelwires {
         bool checkFactoryVersion(const ProjectContext& context, UserLogger& userLogger) override;
 
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        TargetFileElementData(Deserializer& deserializer);
         void visitFilePaths(FilePathVisitor& visitor) override;
 
         /// The file containing the data.

--- a/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.cpp
@@ -11,7 +11,7 @@ void babelwires::ActivateOptionalsModifierData::serializeContents(Serializer& se
     serializer.serializeValueArray("optionals", m_selectedOptionals, "activate");
 }
 
-void babelwires::ActivateOptionalsModifierData::deserializeContents(Deserializer& deserializer) {
+babelwires::ActivateOptionalsModifierData::ActivateOptionalsModifierData(Deserializer& deserializer) {
     deserializer.deserializeValue("path", m_pathToFeature);
     for (auto it = deserializer.deserializeValueArray<Identifier>("optionals", Deserializer::IsOptional::Optional,
                                                                    "activate");

--- a/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp
@@ -16,7 +16,8 @@ namespace babelwires {
         CLONEABLE(ActivateOptionalsModifierData);
         SERIALIZABLE(ActivateOptionalsModifierData, "activatedOptionals", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        ActivateOptionalsModifierData() = default;
+        ActivateOptionalsModifierData(Deserializer& deserializer);
         void visitIdentifiers(IdentifierVisitor& visitor) override;
 
         std::vector<Identifier> m_selectedOptionals;

--- a/BabelWiresLib/Project/Modifiers/arraySizeModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/arraySizeModifierData.cpp
@@ -29,12 +29,11 @@ std::unique_ptr<babelwires::Modifier> babelwires::ArraySizeModifierData::createM
 }
 
 void babelwires::ArraySizeModifierData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    ModifierData::serializeContents(serializer);
     serializer.serializeValue("size", m_size);
 }
 
-void babelwires::ArraySizeModifierData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::ArraySizeModifierData::ArraySizeModifierData(Deserializer& deserializer) : LocalModifierData(deserializer) {
     deserializer.deserializeValue("size", m_size);
 }
 

--- a/BabelWiresLib/Project/Modifiers/arraySizeModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/arraySizeModifierData.hpp
@@ -21,7 +21,8 @@ namespace babelwires {
 
         SERIALIZABLE(ArraySizeModifierData, "arraySize", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        ArraySizeModifierData() = default;
+        ArraySizeModifierData(Deserializer& deserializer);
 
         int m_size = 0;
     };

--- a/BabelWiresLib/Project/Modifiers/connectionModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/connectionModifierData.cpp
@@ -2,19 +2,19 @@
  * ConnectionModifierData used to assign a ValueFeature within a container to a value from another element.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "BabelWiresLib/Project/Modifiers/connectionModifierData.hpp"
 
 #include "BabelWiresLib/Features/Utilities/modelUtilities.hpp"
+#include "BabelWiresLib/Features/modelExceptions.hpp"
+#include "BabelWiresLib/Features/recordFeature.hpp"
 #include "BabelWiresLib/Features/rootFeature.hpp"
 #include "BabelWiresLib/Project/FeatureElements/featureElement.hpp"
 #include "BabelWiresLib/Project/Modifiers/connectionModifier.hpp"
 #include "BabelWiresLib/Project/Modifiers/localModifier.hpp"
 #include "BabelWiresLib/Project/project.hpp"
-#include "BabelWiresLib/Features/modelExceptions.hpp"
-#include "BabelWiresLib/Features/recordFeature.hpp"
 
 #include "Common/Serialization/deserializer.hpp"
 #include "Common/Serialization/serializer.hpp"
@@ -49,7 +49,7 @@ const babelwires::Feature* babelwires::ConnectionModifierData::getSourceFeature(
 }
 
 void babelwires::ConnectionModifierData::apply(const Feature* sourceFeature, Feature* targetFeature,
-                                              bool applyEvenIfSourceUnchanged) const {
+                                               bool applyEvenIfSourceUnchanged) const {
     if (!(applyEvenIfSourceUnchanged || sourceFeature->isChanged(Feature::Changes::ValueChanged))) {
         return;
     }
@@ -69,13 +69,13 @@ void babelwires::ConnectionModifierData::apply(const Feature* sourceFeature, Fea
 }
 
 void babelwires::ConnectionModifierData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    ModifierData::serializeContents(serializer);
     serializer.serializeValue("sourceId", m_sourceId);
     serializer.serializeValue("sourcePath", m_pathToSourceFeature);
 }
 
-void babelwires::ConnectionModifierData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::ConnectionModifierData::ConnectionModifierData(Deserializer& deserializer)
+    : ModifierData(deserializer) {
     deserializer.deserializeValue("sourceId", m_sourceId);
     deserializer.deserializeValue("sourcePath", m_pathToSourceFeature);
 }

--- a/BabelWiresLib/Project/Modifiers/connectionModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/connectionModifierData.hpp
@@ -23,7 +23,8 @@ namespace babelwires {
         CLONEABLE(ConnectionModifierData);
         SERIALIZABLE(ConnectionModifierData, "assignFrom", ModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        ConnectionModifierData() = default;
+        ConnectionModifierData(Deserializer& deserializer);
         void visitIdentifiers(IdentifierVisitor& visitor) override;
 
         ElementId m_sourceId;

--- a/BabelWiresLib/Project/Modifiers/modifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/modifierData.cpp
@@ -2,15 +2,15 @@
  * ModifierDatas carry the data sufficient to reconstruct a Modifier.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include "BabelWiresLib/Project/Modifiers/modifierData.hpp"
 
 #include "BabelWiresLib/Features/Utilities/modelUtilities.hpp"
+#include "BabelWiresLib/Features/enumFeature.hpp"
 #include "BabelWiresLib/Features/numericFeature.hpp"
 #include "BabelWiresLib/Features/stringFeature.hpp"
-#include "BabelWiresLib/Features/enumFeature.hpp"
 #include "BabelWiresLib/FileFormat/fileFeature.hpp"
 #include "BabelWiresLib/Project/FeatureElements/featureElement.hpp"
 #include "BabelWiresLib/Project/Modifiers/connectionModifier.hpp"
@@ -24,6 +24,14 @@ babelwires::Feature* babelwires::ModifierData::getTargetFeature(Feature* contain
     return &m_pathToFeature.follow(*container);
 }
 
+void babelwires::ModifierData::serializeContents(Serializer& serializer) const {
+    serializer.serializeValue("path", m_pathToFeature);
+}
+
+babelwires::ModifierData::ModifierData(Deserializer& deserializer) {
+    deserializer.deserializeValue("path", m_pathToFeature);
+}
+
 void babelwires::ModifierData::visitIdentifiers(IdentifierVisitor& visitor) {
     for (auto& s : m_pathToFeature) {
         if (s.isField()) {
@@ -32,8 +40,10 @@ void babelwires::ModifierData::visitIdentifiers(IdentifierVisitor& visitor) {
     }
 }
 
-void babelwires::ModifierData::visitFilePaths(FilePathVisitor& visitor) {
-}
+void babelwires::ModifierData::visitFilePaths(FilePathVisitor& visitor) {}
+
+babelwires::LocalModifierData::LocalModifierData(Deserializer& deserializer)
+    : ModifierData(deserializer) {}
 
 std::unique_ptr<babelwires::Modifier> babelwires::LocalModifierData::createModifier() const {
     return std::make_unique<babelwires::LocalModifier>(clone());
@@ -48,12 +58,11 @@ void babelwires::IntValueAssignmentData::apply(Feature* targetFeature) const {
 }
 
 void babelwires::IntValueAssignmentData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    LocalModifierData::serializeContents(serializer);
     serializer.serializeValue("value", m_value);
 }
 
-void babelwires::IntValueAssignmentData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::IntValueAssignmentData::IntValueAssignmentData(Deserializer& deserializer) : LocalModifierData(deserializer) {
     deserializer.deserializeValue("value", m_value);
 }
 
@@ -66,12 +75,11 @@ void babelwires::RationalValueAssignmentData::apply(Feature* targetFeature) cons
 }
 
 void babelwires::RationalValueAssignmentData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    LocalModifierData::serializeContents(serializer);
     serializer.serializeValue("value", m_value);
 }
 
-void babelwires::RationalValueAssignmentData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::RationalValueAssignmentData::RationalValueAssignmentData(Deserializer& deserializer) : LocalModifierData(deserializer) {
     deserializer.deserializeValue("value", m_value);
 }
 
@@ -84,12 +92,11 @@ void babelwires::StringValueAssignmentData::apply(Feature* targetFeature) const 
 }
 
 void babelwires::StringValueAssignmentData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    LocalModifierData::serializeContents(serializer);
     serializer.serializeValue("value", m_value);
 }
 
-void babelwires::StringValueAssignmentData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::StringValueAssignmentData::StringValueAssignmentData(Deserializer& deserializer) : LocalModifierData(deserializer) {
     deserializer.deserializeValue("value", m_value);
 }
 
@@ -102,12 +109,11 @@ void babelwires::EnumValueAssignmentData::apply(Feature* targetFeature) const {
 }
 
 void babelwires::EnumValueAssignmentData::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("path", m_pathToFeature);
+    LocalModifierData::serializeContents(serializer);
     serializer.serializeValue("value", m_value);
 }
 
-void babelwires::EnumValueAssignmentData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("path", m_pathToFeature);
+babelwires::EnumValueAssignmentData::EnumValueAssignmentData(Deserializer& deserializer) : LocalModifierData(deserializer) {
     deserializer.deserializeValue("value", m_value);
 }
 

--- a/BabelWiresLib/Project/Modifiers/modifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/modifierData.hpp
@@ -2,7 +2,7 @@
  * ModifierDatas carry the data sufficient to reconstruct a Modifier.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -26,6 +26,8 @@ namespace babelwires {
         CLONEABLE_ABSTRACT(ModifierData);
         SERIALIZABLE_ABSTRACT(ModifierData, void);
         DOWNCASTABLE_TYPE_HIERARCHY(ModifierData);
+        ModifierData() = default;
+        ModifierData(Deserializer& deserializer);
 
         /// Identifies the feature being modified.
         FeaturePath m_pathToFeature;
@@ -44,12 +46,16 @@ namespace babelwires {
         /// (There is currently no scenario where a modifier references a filepath, but
         /// this is just here for future proofing.)
         void visitFilePaths(FilePathVisitor& visitor) override;
+
+        void serializeContents(Serializer& serializer) const override;
     };
 
     /// Base class for ModifierData which construct LocalModifiers.
     struct LocalModifierData : ModifierData {
         CLONEABLE_ABSTRACT(LocalModifierData);
         SERIALIZABLE_ABSTRACT(LocalModifierData, ModifierData);
+        LocalModifierData() = default;
+        LocalModifierData(Deserializer& deserializer);
 
         /// Perform the modification on the target feature, or throw.
         virtual void apply(Feature* targetFeature) const = 0;
@@ -63,7 +69,8 @@ namespace babelwires {
         CLONEABLE(IntValueAssignmentData);
         SERIALIZABLE(IntValueAssignmentData, "assignInt", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        IntValueAssignmentData() = default;
+        IntValueAssignmentData(Deserializer& deserializer);
 
         int m_value = 0;
     };
@@ -74,7 +81,8 @@ namespace babelwires {
         CLONEABLE(RationalValueAssignmentData);
         SERIALIZABLE(RationalValueAssignmentData, "assignRational", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        RationalValueAssignmentData() = default;
+        RationalValueAssignmentData(Deserializer& deserializer);
 
         Rational m_value = 0;
     };
@@ -85,7 +93,8 @@ namespace babelwires {
         CLONEABLE(StringValueAssignmentData);
         SERIALIZABLE(StringValueAssignmentData, "assignString", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        StringValueAssignmentData() = default;
+        StringValueAssignmentData(Deserializer& deserializer);
 
         std::string m_value;
     };
@@ -96,9 +105,10 @@ namespace babelwires {
         CLONEABLE(EnumValueAssignmentData);
         SERIALIZABLE(EnumValueAssignmentData, "assignEnum", LocalModifierData, 1);
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        EnumValueAssignmentData() = default;
+        EnumValueAssignmentData(Deserializer& deserializer);
         void visitIdentifiers(IdentifierVisitor& visitor) override;
-        
+
         Identifier m_value = "Fixme";
     };
 } // namespace babelwires

--- a/BabelWiresLib/Project/projectData.cpp
+++ b/BabelWiresLib/Project/projectData.cpp
@@ -17,7 +17,7 @@ void babelwires::ProjectData::serializeContents(Serializer& serializer) const {
     serializer.serializeArray("elements", m_elements);
 }
 
-void babelwires::ProjectData::deserializeContents(Deserializer& deserializer) {
+babelwires::ProjectData::ProjectData(Deserializer& deserializer) {
     deserializer.deserializeValue("id", m_projectId, Deserializer::IsOptional::Optional);
     auto it = deserializer.deserializeArray<ElementData>("elements");
     while (it.isValid()) {

--- a/BabelWiresLib/Project/projectData.hpp
+++ b/BabelWiresLib/Project/projectData.hpp
@@ -29,7 +29,7 @@ namespace babelwires {
 
         // Serialization.
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        ProjectData(Deserializer& deserializer);
 
         /// Call the visitor on all the FieldIdentifiers in the element.
         void visitIdentifiers(IdentifierVisitor& visitor) override;

--- a/BabelWiresLib/Serialization/dataBundle.hpp
+++ b/BabelWiresLib/Serialization/dataBundle.hpp
@@ -49,7 +49,7 @@ namespace babelwires {
                                           UserLogger& userLogger) &&;
 
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        DataBundle(Deserializer& deserializer);
 
         const DATA& getData() const { return m_data; }
         DATA& getData() { return m_data; }
@@ -66,9 +66,6 @@ namespace babelwires {
 
         /// Allows the subclass to put additional metadata at the same level as the metadata handled by this class.
         virtual void serializeAdditionalMetadata(Serializer& serializer) const {}
-
-        /// Allows the subclass to put additional metadata at the same level as the metadata handled by this class.
-        virtual void deserializeAdditionalMetadata(Deserializer& deserializer) {}
 
       private:
         /// Ensure the identifiers in the data refer to the context independent m_identifierRegistry.

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -110,10 +110,9 @@ template <typename DATA> void babelwires::DataBundle<DATA>::serializeContents(Se
     serializer.serializeObject(m_identifierRegistry);
 }
 
-template <typename DATA> void babelwires::DataBundle<DATA>::deserializeContents(Deserializer& deserializer) {
+template <typename DATA> babelwires::DataBundle<DATA>::DataBundle(Deserializer& deserializer) {
     deserializer.deserializeValue("filePath", m_projectFilePath, babelwires::Deserializer::IsOptional::Optional);
     m_data = std::move(*deserializer.deserializeObject<DATA>(DATA::serializationType));
-    deserializeAdditionalMetadata(deserializer);
     m_identifierRegistry =
         std::move(*deserializer.deserializeObject<IdentifierRegistry>(IdentifierRegistry::serializationType));
 }

--- a/BabelWiresLib/Serialization/projectBundle.cpp
+++ b/BabelWiresLib/Serialization/projectBundle.cpp
@@ -47,7 +47,8 @@ namespace {
             serializer.serializeValue("id", m_factoryIdentifier);
             serializer.serializeValue("version", m_factoryVersion);
         }
-        void deserializeContents(babelwires::Deserializer& deserializer) override {
+        FactoryInfoPair() = default;
+        FactoryInfoPair(babelwires::Deserializer& deserializer) {
             deserializer.deserializeValue("id", m_factoryIdentifier);
             deserializer.deserializeValue("version", m_factoryVersion);
         }
@@ -65,7 +66,7 @@ void babelwires::ProjectBundle::serializeAdditionalMetadata(Serializer& serializ
     serializer.serializeArray("factoryMetadata", factoryMetadata);
 }
 
-void babelwires::ProjectBundle::deserializeAdditionalMetadata(Deserializer& deserializer) {
+babelwires::ProjectBundle::ProjectBundle(Deserializer& deserializer) : DataBundle(deserializer) {
     for (auto it = deserializer.deserializeArray<FactoryInfoPair>("factoryMetadata"); it.isValid(); ++it) {
         auto fm = it.getObject();
         m_factoryMetadata.insert(std::make_pair(std::move(fm->m_factoryIdentifier), fm->m_factoryVersion));

--- a/BabelWiresLib/Serialization/projectBundle.hpp
+++ b/BabelWiresLib/Serialization/projectBundle.hpp
@@ -26,6 +26,8 @@ namespace babelwires {
         /// The projectData is modified to make the bundle independent of the current system.
         ProjectBundle(std::filesystem::path pathToProjectFile, ProjectData&& projectData);
 
+        ProjectBundle(Deserializer& deserializer);
+
       public:
         /// Information about the factories used by the projectData.
         using FactoryMetadata = std::map<LongIdentifier, VersionNumber>;
@@ -41,7 +43,6 @@ namespace babelwires {
         void adaptDataToAdditionalMetadata(const ProjectContext& context, UserLogger& userLogger) override;
 
         void serializeAdditionalMetadata(Serializer& serializer) const override;
-        void deserializeAdditionalMetadata(Deserializer& deserializer) override;
         void visitIdentifiers(IdentifierVisitor& visitor) override;
         void visitFilePaths(FilePathVisitor& visitor) override;
 

--- a/Common/Identifiers/identifierRegistry.cpp
+++ b/Common/Identifiers/identifierRegistry.cpp
@@ -34,8 +34,8 @@ void babelwires::IdentifierRegistry::InstanceData::serializeContents(Serializer&
     serializer.serializeValue("uuid", m_uuid);
 }
 
-void babelwires::IdentifierRegistry::InstanceData::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("id", m_identifier);
+babelwires::IdentifierRegistry::InstanceData::InstanceData(Deserializer& deserializer)
+    : m_identifier(deserializer.deserializeValue<LongIdentifier>("id")) {
     deserializer.deserializeValue("name", m_fieldName);
     deserializer.deserializeValue("uuid", m_uuid);
     m_authority = Authority::isProvisional;
@@ -225,7 +225,7 @@ void babelwires::IdentifierRegistry::serializeContents(Serializer& serializer) c
     serializer.serializeArray("identifiers", contents);
 }
 
-void babelwires::IdentifierRegistry::deserializeContents(Deserializer& deserializer) {
+babelwires::IdentifierRegistry::IdentifierRegistry(Deserializer& deserializer) {
     for (auto it = deserializer.deserializeArray<InstanceData>("identifiers", Deserializer::IsOptional::Optional);
          it.isValid(); ++it) {
         std::unique_ptr<InstanceData> instanceDataPtr = it.getObject();

--- a/Common/Identifiers/identifierRegistry.hpp
+++ b/Common/Identifiers/identifierRegistry.hpp
@@ -68,7 +68,7 @@ namespace babelwires {
         // For use during serialization/deserialization:
 
         void serializeContents(Serializer& serializer) const override;
-        void deserializeContents(Deserializer& deserializer) override;
+        IdentifierRegistry(Deserializer& deserializer);
 
         /// Information stored about an identifier.
         using ValueType = std::tuple<LongIdentifier, const std::string*, const Uuid*>;
@@ -130,7 +130,7 @@ namespace babelwires {
             InstanceData(std::string fieldName, Uuid uuid, LongIdentifier identifier, Authority authority);
 
             void serializeContents(Serializer& serializer) const override;
-            void deserializeContents(Deserializer& deserializer) override;
+            InstanceData(Deserializer& deserializer);
 
             std::string m_fieldName;
             Uuid m_uuid;

--- a/Common/Serialization/deserializer.hpp
+++ b/Common/Serialization/deserializer.hpp
@@ -1,8 +1,9 @@
 /**
- * The Deserializer supports the loading of serialized data, where the particular representation (e.g. XML) of data is abstracted.
+ * The Deserializer supports the loading of serialized data, where the particular representation (e.g. XML) of data is
+ *abstracted.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -18,7 +19,6 @@
 #include <string_view>
 
 namespace babelwires {
-
 
     class Deserializer : public SerializerDeserializerCommon {
       public:
@@ -64,6 +64,24 @@ namespace babelwires {
                 value = V::deserializeFromString(asString);
             }
             return ret;
+        }
+
+        /// An alternative form for values which cannot be default constructed.
+        template <typename V>
+        std::enable_if_t<IsSerializableValue<V>::value, V>
+        deserializeValue(std::string_view key) {
+            std::string asString;
+            deserializeValue(key, asString);
+            return V::deserializeFromString(asString);
+        }
+
+        /// The same shape is available for the standard types, for convenience.
+        template <typename V>
+        std::enable_if_t<std::is_default_constructible<V>::value, V>
+        deserializeValue(std::string_view key) {
+            V v;
+            deserializedValue(key, v);
+            return v;
         }
 
         /// Deserialize a child object of type T.

--- a/Common/Serialization/serializerDeserializerCommon.cpp
+++ b/Common/Serialization/serializerDeserializerCommon.cpp
@@ -45,7 +45,7 @@ namespace {
             serializer.serializeValue("version", m_version);
         }
 
-        void deserializeContents(babelwires::Deserializer& deserializer) override {
+        SerializationMetadata(babelwires::Deserializer& deserializer) {
             deserializer.deserializeValue("type", m_type);
             deserializer.deserializeValue("version", m_version);
         }

--- a/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<babelwires::FeatureElement> testUtils::TestFeatureElementData::d
 
 void testUtils::TestFeatureElementData::serializeContents(babelwires::Serializer& serializer) const {}
 
-void testUtils::TestFeatureElementData::deserializeContents(babelwires::Deserializer& deserializer) {}
+testUtils::TestFeatureElementData::TestFeatureElementData(babelwires::Deserializer& deserializer) {}
 
 testUtils::TestFeatureElement::TestFeatureElement(const babelwires::ProjectContext& context)
     : TestFeatureElement(context, TestFeatureElementData(), 10) {}

--- a/Tests/BabelWiresLib/TestUtils/testFeatureElement.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureElement.hpp
@@ -24,7 +24,7 @@ namespace testUtils {
 
         // Dummy implementations.
         void serializeContents(babelwires::Serializer& serializer) const override;
-        void deserializeContents(babelwires::Deserializer& deserializer) override;
+        TestFeatureElementData(babelwires::Deserializer& deserializer);
         bool checkFactoryVersion(const babelwires::ProjectContext& context,
                                  babelwires::UserLogger& userLogger) override;
 

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<babelwires::FeatureElement> testUtils::TestFeatureElementWithOpt
 
 void testUtils::TestFeatureElementWithOptionalsData::serializeContents(babelwires::Serializer& serializer) const {}
 
-void testUtils::TestFeatureElementWithOptionalsData::deserializeContents(babelwires::Deserializer& deserializer) {}
+testUtils::TestFeatureElementWithOptionalsData::TestFeatureElementWithOptionalsData(babelwires::Deserializer& deserializer) {}
 
 testUtils::TestFeatureElementWithOptionals::TestFeatureElementWithOptionals(const babelwires::ProjectContext& context)
     : TestFeatureElementWithOptionals(context, TestFeatureElementWithOptionalsData(), 10) {}

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.hpp
@@ -69,7 +69,7 @@ namespace testUtils {
 
         // Dummy implementations.
         void serializeContents(babelwires::Serializer& serializer) const override;
-        void deserializeContents(babelwires::Deserializer& deserializer) override;
+        TestFeatureElementWithOptionalsData(babelwires::Deserializer& deserializer);
         bool checkFactoryVersion(const babelwires::ProjectContext& context,
                                  babelwires::UserLogger& userLogger) override;
 

--- a/Tests/Common/serializationTest.cpp
+++ b/Tests/Common/serializationTest.cpp
@@ -18,7 +18,8 @@ namespace {
             serializer.serializeValueArray("array", m_array);
         }
 
-        void deserializeContents(Deserializer& deserializer) override {
+        A() = default;
+        A(Deserializer& deserializer) {
             deserializer.deserializeValue("x", m_x);
             for (auto it = deserializer.deserializeValueArray<std::string>("array", Deserializer::IsOptional::Optional);
                  it.isValid(); ++it) {
@@ -69,7 +70,8 @@ namespace {
             serializer.serializeArray("arrayOfAs", m_arrayOfAs);
         }
 
-        void deserializeContents(Deserializer& deserializer) override {
+        B() = default;
+        B(Deserializer& deserializer) {
             if (std::unique_ptr<A> a = deserializer.deserializeObject<A>()) {
                 m_a = std::move(*a);
             }
@@ -131,7 +133,8 @@ namespace {
 
             void serializeContents(Serializer& serializer) const override { serializer.serializeValue("x", m_x); }
 
-            void deserializeContents(Deserializer& deserializer) override { deserializer.deserializeValue("x", m_x); }
+            C() = default;
+            C(Deserializer& deserializer) { deserializer.deserializeValue("x", m_x); }
 
             // A refactor will split this into a sign and an unsigened int.
             int m_x = 0;
@@ -149,7 +152,8 @@ namespace {
                 serializer.serializeValue("x", m_x);
             }
 
-            void deserializeContents(Deserializer& deserializer) override {
+            C() = default;
+            C(Deserializer& deserializer) {
                 const int version = deserializer.getTypeVersion("C");
                 if (version == 1) {
                     int oldInt = 0;
@@ -241,7 +245,8 @@ namespace {
 
         void serializeContents(Serializer& serializer) const override { serializer.serializeValue("x", m_x); }
 
-        void deserializeContents(Deserializer& deserializer) override { deserializer.deserializeValue("x", m_x); }
+        Concrete0() = default;
+        Concrete0(Deserializer& deserializer) { deserializer.deserializeValue("x", m_x); }
 
         int m_x = 0;
     };
@@ -257,7 +262,8 @@ namespace {
 
         void serializeContents(Serializer& serializer) const override { serializer.serializeValue("s", m_s); }
 
-        void deserializeContents(Deserializer& deserializer) override { deserializer.deserializeValue("s", m_s); }
+        Concrete1() = default;
+        Concrete1(Deserializer& deserializer) { deserializer.deserializeValue("s", m_s); }
 
         std::string m_s;
     };
@@ -269,8 +275,8 @@ namespace {
             serializer.serializeValue("u32", m_u32);
         }
 
-        void deserializeContents(Deserializer& deserializer) override {
-            Concrete1::deserializeContents(deserializer);
+        Concrete2() = default;
+        Concrete2(Deserializer& deserializer) : Concrete1(deserializer) {
             deserializer.deserializeValue("u32", m_u32);
         }
 
@@ -299,7 +305,8 @@ namespace {
             serializer.serializeArray("objects", m_objects);
         }
 
-        void deserializeContents(Deserializer& deserializer) override {
+        Main() = default;
+        Main(Deserializer& deserializer) {
             m_base = deserializer.deserializeObject<Base>("base", babelwires::Deserializer::IsOptional::Optional);
             m_concrete0 =
                 deserializer.deserializeObject<Concrete0>("concrete0", babelwires::Deserializer::IsOptional::Optional);


### PR DESCRIPTION
Using a virtual deserializeContents method meant that every deserializable object had to have a default constructor. This makes it difficult to have serializable objects with complex invariants.

Instead, deserializing using a constructor of the form T(Deserializer&) removes that requirement.

There are probably many structs and classes which could be tidied up as a result of this change, but I'm currently busy with the mapValue work, so such tidying will have to wait.