### PR TITLE
Add UnionFeature for records with alternative sets of features

### DIFF
--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -21,6 +21,7 @@ SET( BABELWIRESLIB_SRCS
 	Project/Modifiers/connectionModifierData.cpp
 	Project/Modifiers/activateOptionalsModifierData.cpp
 	Project/Modifiers/mapValueAssignmentData.cpp
+	Project/Modifiers/selectUnionBranchModifierData.cpp
 	Project/uiPosition.cpp
 	Project/projectData.cpp
 	ProjectExtra/projectObserver.cpp
@@ -85,6 +86,7 @@ SET( BABELWIRESLIB_SRCS
 	Project/Commands/removeAllEditsCommand.cpp
 	Project/Commands/removeFailedModifiersCommand.cpp
 	Project/Commands/resizeElementCommand.cpp
+	Project/Commands/selectUnionBranchCommand.cpp
 	Project/Commands/setArraySizeCommand.cpp
 	ValueNames/valueNames.cpp
 	ValueNames/sparseValueNamesImpl.cpp

--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -68,6 +68,7 @@ SET( BABELWIRESLIB_SRCS
 	Features/Path/pathStep.cpp
 	Features/Utilities/featureXml.cpp
 	Features/rootFeature.cpp
+	Features/unionFeature.cpp
 	Serialization/projectBundle.cpp
 	Project/Commands/activateOptionalCommand.cpp
 	Project/Commands/addElementCommand.cpp

--- a/BabelWiresLib/Features/recordFeature.cpp
+++ b/BabelWiresLib/Features/recordFeature.cpp
@@ -21,8 +21,7 @@ void babelwires::RecordFeature::doSetToDefault() {
     setSubfeaturesToDefault();
 }
 
-void babelwires::RecordFeature::doSetToDefaultNonRecursive() {
-}
+void babelwires::RecordFeature::doSetToDefaultNonRecursive() {}
 
 babelwires::Feature* babelwires::RecordFeature::doGetFeature(int i) {
     return m_fields.at(i).m_feature.get();
@@ -83,7 +82,8 @@ int babelwires::RecordFeature::getChildIndexFromStep(const Identifier& identifie
 
 void babelwires::RecordFeature::addFieldInternal(Field f, int index) {
     assert((f.m_identifier.getDiscriminator() != 0) && "Only registered identfiers can be used as field identifiers");
-    assert((tryGetChildFromStep(PathStep(f.m_identifier)) == nullptr) && "There's an alredy a field with that field identifier");
+    assert((tryGetChildFromStep(PathStep(f.m_identifier)) == nullptr) &&
+           "There's an alredy a field with that field identifier");
     f.m_feature->setOwner(this);
     if (index == -1) {
         m_fields.emplace_back(std::move(f));
@@ -116,8 +116,8 @@ babelwires::RecordFeature::FieldAndIndex babelwires::RecordFeature::removeField(
 std::size_t babelwires::RecordFeature::doGetHash() const {
     std::size_t hash = hash::mixtureOf(static_cast<const char*>("Record"));
     for (const auto& f : m_fields) {
-        // Records can change their set of active fields (see RecordWithOptionalsFeature), so we mix in the
-        // field's identifier as well as its hash.
+        // Records can change their set of active fields (see RecordWithOptionalsFeature and UnionFeature), so we mix in
+        // the field's identifier as well as its hash.
         hash::mixInto(hash, f.m_identifier);
         hash::mixInto(hash, f.m_feature->getHash());
     }

--- a/BabelWiresLib/Features/recordFeature.cpp
+++ b/BabelWiresLib/Features/recordFeature.cpp
@@ -93,6 +93,11 @@ void babelwires::RecordFeature::addFieldInternal(Field f, int index) {
     setChanged(Changes::StructureChanged);
 }
 
+void babelwires::RecordFeature::addFieldAndIndexInternal(FieldAndIndex fieldAndIndex) {
+    const int targetIndex = fieldAndIndex.m_index;
+    addFieldInternal(std::move(fieldAndIndex), targetIndex);
+}
+
 babelwires::RecordFeature::FieldAndIndex babelwires::RecordFeature::removeField(Identifier identifier) {
     int i;
     for (i = 0; i < m_fields.size(); ++i) {

--- a/BabelWiresLib/Features/recordFeature.hpp
+++ b/BabelWiresLib/Features/recordFeature.hpp
@@ -53,6 +53,9 @@ namespace babelwires {
             int m_index = -1;
         };
 
+        /// Convenience method which calls the addFieldInternal.
+        void addFieldAndIndexInternal(FieldAndIndex fieldAndIndex);
+
         FieldAndIndex removeField(Identifier identifier);
 
       protected:

--- a/BabelWiresLib/Features/recordWithOptionalsFeature.cpp
+++ b/BabelWiresLib/Features/recordWithOptionalsFeature.cpp
@@ -23,7 +23,7 @@ void babelwires::RecordWithOptionalsFeature::activateField(Identifier identifier
         throw ModelException() << "The field " << identifier << " is not an inactive optional field, so it cannot be activated";
     }
     std::for_each(it + 1, m_inactiveFields.end(), [](FieldAndIndex& f) { ++f.m_index; });
-    addFieldInternal(std::move(*it), it->m_index);
+    addFieldAndIndexInternal(std::move(*it));
     m_inactiveFields.erase(it);
 }
 

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -113,6 +113,6 @@ unsigned int babelwires::UnionFeature::getIndexOfTag(Identifier tag) const {
     return it - m_tags.begin();
 }
 
-const std::vector<babelwires::Identifier> babelwires::UnionFeature::getFieldsOfSelectedBranch() const {
+const std::vector<babelwires::Identifier>& babelwires::UnionFeature::getFieldsOfSelectedBranch() const {
     return m_selectedBranch.m_activeFields;
 }

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -14,6 +14,9 @@ babelwires::UnionFeature::UnionFeature(TagValues tags, unsigned int defaultTagIn
     , m_defaultTagIndex(defaultTagIndex)
 {
     assert((m_defaultTagIndex < m_tags.size()) && "defaultTagIndex is out of range");
+    for (const auto& tag : m_tags) {
+        m_unselectedBranches.emplace(tag, UnselectedBranch());
+    }
 }
 
 void babelwires::UnionFeature::addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex) {
@@ -79,7 +82,7 @@ bool babelwires::UnionFeature::isTag(Identifier tag) const {
 bool babelwires::UnionFeature::isSelectedTag(Identifier tag) const {
     assert(isTag(tag) && "isSelectedTag can only be called with an actual tag");
     const bool isGivenTag = (m_selectedTag == tag);
-    assert(isGivenTag == (m_unselectedBranches.find(tag) != m_unselectedBranches.end()) && "Inconsistency between m_selectedTag and m_unselectedBranches");
+    assert(isGivenTag == (m_unselectedBranches.find(tag) == m_unselectedBranches.end()) && "Inconsistency between m_selectedTag and m_unselectedBranches");
     return isGivenTag;
 }
 

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -108,3 +108,7 @@ unsigned int babelwires::UnionFeature::getIndexOfTag(Identifier tag) const {
     assert((it != m_tags.end()) && "The given tag is not a valid tag of this union");
     return it - m_tags.begin();
 }
+
+const std::vector<babelwires::Identifier> babelwires::UnionFeature::getFieldsOfSelectedBranch() const {
+    return m_selectedBranch.m_activeFields;
+}

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -97,3 +97,8 @@ void babelwires::UnionFeature::doSetToDefaultNonRecursive() {
     }
     selectTag(m_tags[m_defaultTagIndex]);
 }
+
+babelwires::Identifier babelwires::UnionFeature::getSelectedTag() const {
+    assert(m_selectedTag.has_value() && "Cannot call getSelectedTag until the union has been set to default");
+    return *m_selectedTag;
+}

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -64,7 +64,7 @@ void babelwires::UnionFeature::selectTagByIndex(unsigned int index) {
 
     // Activate the fields in the unselectedBranch.
 
-    typeof(UnselectedBranch::m_inactiveFields) oldUnselectedFields;
+    decltype(UnselectedBranch::m_inactiveFields) oldUnselectedFields;
     oldUnselectedFields.swap(m_unselectedBranches[index].m_inactiveFields);
 
     for (auto& fieldAndIndex : oldUnselectedFields) {

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -1,0 +1,99 @@
+/**
+ * A UnionFeature is a Record feature with alternative sets of features.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresLib/Features/unionFeature.hpp>
+
+#include <BabelWiresLib/Features/modelExceptions.hpp>
+
+babelwires::UnionFeature::UnionFeature(TagValues tags, unsigned int defaultTagIndex) 
+    : m_tags(std::move(tags))
+    , m_defaultTagIndex(defaultTagIndex)
+{
+    assert((m_defaultTagIndex < m_tags.size()) && "defaultTagIndex is out of range");
+}
+
+void babelwires::UnionFeature::addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex) {
+    assert(isTag(tag) && "The tag is not a valid tag for this union");
+    // All branches are unselected until the union is set to default. This ensures the stored indices are correct.
+    InactiveBranch& inactiveBranch = m_inactiveBranches[tag];
+    inactiveBranch.m_inactiveFields.emplace_back(std::move(fieldAndIndex));
+}
+
+void babelwires::UnionFeature::selectTag(Identifier tag) {
+    if (!isTag(tag)) {
+        // TODO Look up name from identifier
+        throw ModelException() << "\"" << tag << "\" is not a valid tag for this union";
+    }
+    if (isSelectedTag(tag)) {
+        // Nothing to do.
+        return;
+    }
+
+    if (m_selectedTag.has_value()) {
+        // There is at an active branch (always true after setToDefault has been called).
+        assert((m_inactiveBranches.size() == m_tags.size() - 1) && "Inconsistency between m_inactiveBranches and m_tags");
+
+        // Deactivate the fields in the currently selected branch.
+        InactiveBranch newInactiveBranch;
+       
+        // Maybe need to reverse?
+        for (auto identifier : m_activeBranch.m_activeFields) {
+            FieldAndIndex fieldAndIndex = removeField(identifier);
+            fieldAndIndex.m_feature->setToDefault();
+            newInactiveBranch.m_inactiveFields.emplace_back(std::move(fieldAndIndex));
+        }
+
+        m_activeBranch.m_activeFields.clear();
+        m_inactiveBranches.insert(std::pair(tag, std::move(newInactiveBranch)));
+    } else {
+        assert((m_inactiveBranches.size() == m_tags.size()) && "Inconsistency between m_inactiveBranches and m_tags");
+    }
+
+    // Activate the fields in the inactiveBranch.
+
+    auto it = m_inactiveBranches.find(tag);
+    assert((it != m_inactiveBranches.end()) && "Tag not found in inactive branches");
+    InactiveBranch oldInactiveBranch = std::move(it->second);
+    m_inactiveBranches.erase(it);
+
+    for (auto& fieldAndIndex : oldInactiveBranch.m_inactiveFields) {
+        m_activeBranch.m_activeFields.emplace_back(fieldAndIndex.m_identifier);
+        addFieldAndIndexInternal(std::move(fieldAndIndex));
+    }
+
+    m_selectedTag = tag;
+}
+
+const babelwires::UnionFeature::TagValues& babelwires::UnionFeature::getTags() const {
+    return m_tags;
+}
+
+bool babelwires::UnionFeature::isTag(Identifier tag) const {
+    return std::find(m_tags.begin(), m_tags.end(), tag) != m_tags.end();
+}
+
+bool babelwires::UnionFeature::isSelectedTag(Identifier tag) const {
+    assert(isTag(tag) && "isSelectedTag can only be called with an actual tag");
+    const bool isGivenTag = (m_selectedTag == tag);
+    assert(isGivenTag == (m_inactiveBranches.find(tag) != m_inactiveBranches.end()) && "Inconsistency between m_selectedTag and m_inactiveBranches");
+    return isGivenTag;
+}
+
+void babelwires::UnionFeature::doSetToDefault() {
+    setToDefaultNonRecursive();
+    setSubfeaturesToDefault();
+}
+
+void babelwires::UnionFeature::doSetToDefaultNonRecursive() {
+    for (auto& pair : m_inactiveBranches) {
+        for (auto& inactiveField : pair.second.m_inactiveFields) {
+            // After construction, these may not have been set to their default state.
+            inactiveField.m_feature->setToDefault();
+        }
+    }
+    selectTag(m_tags[m_defaultTagIndex]);
+}

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -13,12 +13,16 @@
 
 namespace babelwires {
 
-    /// A Record feature with subfeatures which can be inactive.
+    /// A Record feature which offers alternative sets of fields.
+    /// The record can have normal fields which are always available.
+    /// Other fields are associated with one of a set of tags, which controls whether they are active or not.
+    /// Not every tag needs to have fields associated with it.
     class UnionFeature : public RecordFeature {
       public:
         using TagValues = std::vector<Identifier>;
 
         /// Construct a union with the given set of tags.
+        /// The tags' identifiers must be registered.
         UnionFeature(TagValues tags, unsigned int defaultTagIndex);
 
         /// Add an optional field, which is not present in the record until activated.

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -1,0 +1,67 @@
+/**
+ * A UnionFeature is a Record feature with alternative sets of features.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/Features/recordFeature.hpp>
+
+#include <optional>
+
+namespace babelwires {
+
+    /// A Record feature with subfeatures which can be inactive.
+    class UnionFeature : public RecordFeature {
+      public:
+        using TagValues = std::vector<Identifier>;
+
+        /// Construct a union with the given set of tags.
+        UnionFeature(TagValues tags, unsigned int defaultTagIndex);
+
+        /// Add an optional field, which is not present in the record until activated.
+        template <typename T>
+        T* addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f, const Identifier& identifier);
+
+        /// Select the tag.
+        void selectTag(Identifier tag);
+
+        /// Return the set of tags.
+        const TagValues& getTags() const;
+
+      protected:
+        void addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex);
+        void doSetToDefault() override;
+        void doSetToDefaultNonRecursive() override;
+
+        bool isTag(Identifier tag) const;
+        bool isSelectedTag(Identifier tag) const;
+
+      protected:
+        /// Those fields which are optional.
+        TagValues m_tags;
+        unsigned int m_defaultTagIndex;
+        std::optional<Identifier> m_selectedTag;
+
+        struct ActiveBranch {
+            std::vector<Identifier> m_activeFields;
+        };
+
+        struct InactiveBranch {
+            std::vector<FieldAndIndex> m_inactiveFields;
+        };
+
+        ActiveBranch m_activeBranch;
+        std::unordered_map<Identifier, InactiveBranch> m_inactiveBranches;
+    };
+
+    template <typename T>
+    T* babelwires::UnionFeature::addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f,
+                                                  const Identifier& identifier) {
+        T* fTPtr = f.get();
+        addFieldInBranchInternal(tag, FieldAndIndex{identifier, std::move(f), getNumFeatures()});
+        return fTPtr;
+    }
+} // namespace babelwires

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -43,6 +43,9 @@ namespace babelwires {
         /// Check whether the tag is a tag of this union.
         bool isTag(Identifier tag) const;
 
+        /// Get the fields of the currently selected branch.
+        const std::vector<Identifier> getFieldsOfSelectedBranch() const;
+
       protected:
         void addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex);
         void doSetToDefault() override;

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -28,6 +28,8 @@ namespace babelwires {
         /// Select the tag.
         void selectTag(Identifier tag);
 
+        Identifier getSelectedTag() const;
+
         /// Return the set of tags.
         const TagValues& getTags() const;
 

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -28,35 +28,51 @@ namespace babelwires {
         /// Select the tag.
         void selectTag(Identifier tag);
 
+        /// Return the tag which is currently selected.
         Identifier getSelectedTag() const;
 
         /// Return the set of tags.
         const TagValues& getTags() const;
+
+        /// Return the index of the tag which is currently selected.
+        unsigned int getSelectedTagIndex() const;
+
+        /// Get the index of the given tag.
+        unsigned int getIndexOfTag(Identifier tag) const;
 
       protected:
         void addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex);
         void doSetToDefault() override;
         void doSetToDefaultNonRecursive() override;
 
+        /// Select the tag using an index.
+        void selectTagByIndex(unsigned int index);
+
+        /// Check whether the tag is a tag of this union.
         bool isTag(Identifier tag) const;
-        bool isSelectedTag(Identifier tag) const;
 
       protected:
         /// Those fields which are optional.
         TagValues m_tags;
         unsigned int m_defaultTagIndex;
-        std::optional<Identifier> m_selectedTag;
+        int m_selectedTagIndex = -1;
 
+        /// Information about the currently selected branch.
         struct SelectedBranch {
             std::vector<Identifier> m_activeFields;
         };
 
+        /// Information about an unselected branch.
         struct UnselectedBranch {
             std::vector<FieldAndIndex> m_inactiveFields;
         };
 
+        /// Information about the currently selected branch.
         SelectedBranch m_selectedBranch;
-        std::unordered_map<Identifier, UnselectedBranch> m_unselectedBranches;
+
+        /// Information about the unselected branches in tag order.
+        /// The selected tag does have an entry, but it is always empty.
+        std::vector<UnselectedBranch> m_unselectedBranches;
     };
 
     template <typename T>

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -25,21 +25,8 @@ namespace babelwires {
         /// The tags' identifiers must be registered.
         UnionFeature(TagValues tags, unsigned int defaultTagIndex);
 
-        /// Add an optional field, which is not present in the record until activated.
-        template <typename T>
-        T* addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f, const Identifier& identifier);
-
-        /// Select the tag.
-        void selectTag(Identifier tag);
-
-        /// Return the tag which is currently selected.
-        Identifier getSelectedTag() const;
-
         /// Return the set of tags.
         const TagValues& getTags() const;
-
-        /// Return the index of the tag which is currently selected.
-        unsigned int getSelectedTagIndex() const;
 
         /// Get the index of the given tag.
         unsigned int getIndexOfTag(Identifier tag) const;
@@ -47,8 +34,21 @@ namespace babelwires {
         /// Check whether the tag is a tag of this union.
         bool isTag(Identifier tag) const;
 
+        /// Add a field to the branch corresponding to the given tag.
+        template <typename T>
+        T* addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f, const Identifier& fieldIdentifier);
+
+        /// Select the tag.
+        void selectTag(Identifier tag);
+
+        /// Return the tag which is currently selected.
+        Identifier getSelectedTag() const;
+
+        /// Return the index of the tag which is currently selected.
+        unsigned int getSelectedTagIndex() const;
+
         /// Get the fields of the currently selected branch.
-        const std::vector<Identifier> getFieldsOfSelectedBranch() const;
+        const std::vector<Identifier>& getFieldsOfSelectedBranch() const;
 
       protected:
         void addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex);
@@ -84,9 +84,9 @@ namespace babelwires {
 
     template <typename T>
     T* babelwires::UnionFeature::addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f,
-                                                  const Identifier& identifier) {
+                                                  const Identifier& fieldIdentifier) {
         T* fTPtr = f.get();
-        addFieldInBranchInternal(tag, FieldAndIndex{identifier, std::move(f), getNumFeatures()});
+        addFieldInBranchInternal(tag, FieldAndIndex{fieldIdentifier, std::move(f), getNumFeatures()});
         return fTPtr;
     }
 } // namespace babelwires

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -45,16 +45,16 @@ namespace babelwires {
         unsigned int m_defaultTagIndex;
         std::optional<Identifier> m_selectedTag;
 
-        struct ActiveBranch {
+        struct SelectedBranch {
             std::vector<Identifier> m_activeFields;
         };
 
-        struct InactiveBranch {
+        struct UnselectedBranch {
             std::vector<FieldAndIndex> m_inactiveFields;
         };
 
-        ActiveBranch m_activeBranch;
-        std::unordered_map<Identifier, InactiveBranch> m_inactiveBranches;
+        SelectedBranch m_selectedBranch;
+        std::unordered_map<Identifier, UnselectedBranch> m_unselectedBranches;
     };
 
     template <typename T>

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -40,6 +40,9 @@ namespace babelwires {
         /// Get the index of the given tag.
         unsigned int getIndexOfTag(Identifier tag) const;
 
+        /// Check whether the tag is a tag of this union.
+        bool isTag(Identifier tag) const;
+
       protected:
         void addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex);
         void doSetToDefault() override;
@@ -47,9 +50,6 @@ namespace babelwires {
 
         /// Select the tag using an index.
         void selectTagByIndex(unsigned int index);
-
-        /// Check whether the tag is a tag of this union.
-        bool isTag(Identifier tag) const;
 
       protected:
         /// Those fields which are optional.

--- a/BabelWiresLib/FileFormat/filePath.cpp
+++ b/BabelWiresLib/FileFormat/filePath.cpp
@@ -67,9 +67,6 @@ std::string babelwires::FilePath::serializeToString() const {
 }
 
 babelwires::FilePath babelwires::FilePath::deserializeFromString(const std::string& string) {
-    if (std::all_of(string.begin(),string.end(),::isspace)) {
-        throw ParseException() << "Empty file path";
-    }
     std::filesystem::path path;
     try {
         path = std::filesystem::u8path(string);

--- a/BabelWiresLib/Project/Commands/addModifierCommand.cpp
+++ b/BabelWiresLib/Project/Commands/addModifierCommand.cpp
@@ -36,7 +36,7 @@ bool babelwires::AddModifierCommand::initialize(const Project& project) {
         return false;
     }
 
-    if (const Modifier* modifier = element->findModifier(m_modifierToAdd->m_pathToFeature)) {
+    if (const Modifier *const modifier = element->findModifier(m_modifierToAdd->m_pathToFeature)) {
         m_modifierToRemove = modifier->getModifierData().clone();
     }
     return true;

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
@@ -69,7 +69,7 @@ bool babelwires::SelectUnionBranchCommand::initializeAndExecute(Project& project
 
     SelectUnionBranchModifierData modifierToAdd;
     modifierToAdd.m_pathToFeature = m_pathToUnion;
-    modifierToAdd.m_tag = m_tagToSelect;
+    modifierToAdd.m_tagToSelect = m_tagToSelect;
     m_unionModifierToAdd = std::make_unique<SelectUnionBranchModifierData>(std::move(modifierToAdd));
     
     project.addModifier(m_elementId, *m_unionModifierToAdd);

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
@@ -1,0 +1,64 @@
+/**
+ * The command which activates optionals in a RecordWithOptionalsFeature.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+
+#include <BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
+#include <BabelWiresLib/Project/Modifiers/localModifier.hpp>
+#include <BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp>
+#include <BabelWiresLib/Project/project.hpp>
+#include <BabelWiresLib/Features/rootFeature.hpp>
+
+babelwires::SelectUnionBranchCommand::SelectUnionBranchCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
+                               Identifier tag)
+    : SimpleCommand(commandName)
+    , m_elementId(elementId)
+    , m_pathToUnion(std::move(featurePath))
+    , m_newTag(tag)
+{
+}
+
+bool babelwires::SelectUnionBranchCommand::initialize(const Project& project) {
+    const FeatureElement* elementToModify = project.getFeatureElement(m_elementId);
+    if (!elementToModify) {
+        return false;
+    }
+
+    const Feature* const inputFeature = elementToModify->getInputFeature();
+    if (!inputFeature) {
+        return false;
+    }
+
+    auto unionFeature = m_pathToUnion.tryFollow(*inputFeature)->as<const UnionFeature>();
+    if (!unionFeature) {
+        return false;
+    }
+
+    if (!unionFeature->isTag(m_newTag)) {
+        return false;
+    }
+
+    if (m_newTag == unionFeature->getSelectedTag()) {
+        return false;
+    }
+
+    if (const Modifier *const modifier = elementToModify->findModifier(m_pathToUnion)) {
+        m_oldModifier = modifier->getModifierData().clone();
+    }
+
+    return true;
+}
+
+void babelwires::SelectUnionBranchCommand::execute(Project& project) const {
+    // TODO
+}
+
+void babelwires::SelectUnionBranchCommand::undo(Project& project) const {
+    // TODO
+}

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
@@ -1,0 +1,37 @@
+/**
+ * The command which activates optionals in a RecordWithOptionalsFeature.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+
+#pragma once
+
+#include <BabelWiresLib/Commands/commands.hpp>
+#include <BabelWiresLib/Features/Path/featurePath.hpp>
+#include <BabelWiresLib/Project/projectIds.hpp>
+
+namespace babelwires {
+    class Project;
+    class ModifierData;
+
+    /// Activate an optional in a RecordWithOptionalsFeature
+    class SelectUnionBranchCommand : public SimpleCommand<Project> {
+      public:
+        SelectUnionBranchCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
+                               Identifier optional);
+
+        virtual bool initialize(const Project& project) override;
+        virtual void execute(Project& project) const override;
+        virtual void undo(Project& project) const override;
+
+      private:
+        ElementId m_elementId;
+        FeaturePath m_pathToUnion;
+        Identifier m_newTag;
+
+        std::unique_ptr<ModifierData> m_oldModifier;
+    };
+
+} // namespace babelwires

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
@@ -17,21 +17,21 @@ namespace babelwires {
     class ModifierData;
 
     /// Activate an optional in a RecordWithOptionalsFeature
-    class SelectUnionBranchCommand : public SimpleCommand<Project> {
+    class SelectUnionBranchCommand : public CompoundCommand<Project> {
       public:
         SelectUnionBranchCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier optional);
+                               Identifier tagToSelect);
 
-        virtual bool initialize(const Project& project) override;
+        virtual bool initializeAndExecute(Project& project) override;
         virtual void execute(Project& project) const override;
         virtual void undo(Project& project) const override;
 
       private:
         ElementId m_elementId;
         FeaturePath m_pathToUnion;
-        Identifier m_newTag;
+        Identifier m_tagToSelect;
 
-        std::unique_ptr<ModifierData> m_oldModifier;
+        std::unique_ptr<ModifierData> m_unionModifierToAdd;
+        std::unique_ptr<ModifierData> m_unionModifierToRemove;
     };
-
 } // namespace babelwires

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
@@ -14,7 +14,7 @@
 
 namespace babelwires {
     class Project;
-    class ModifierData;
+    struct ModifierData;
 
     /// Activate an optional in a RecordWithOptionalsFeature
     class SelectUnionBranchCommand : public CompoundCommand<Project> {

--- a/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.cpp
@@ -15,12 +15,12 @@
 
 void babelwires::SelectUnionBranchModifierData::serializeContents(Serializer& serializer) const {
     serializer.serializeValue("path", m_pathToFeature);
-    serializer.serializeValue("tag", m_tag);
+    serializer.serializeValue("select", m_tagToSelect);
 }
 
 void babelwires::SelectUnionBranchModifierData::deserializeContents(Deserializer& deserializer) {
     deserializer.deserializeValue("path", m_pathToFeature);
-    deserializer.deserializeValue("tag", m_tag);
+    deserializer.deserializeValue("select", m_tagToSelect);
 }
 
 void babelwires::SelectUnionBranchModifierData::apply(Feature* targetFeature) const {
@@ -28,10 +28,10 @@ void babelwires::SelectUnionBranchModifierData::apply(Feature* targetFeature) co
     if (!unionFeature) {
         throw ModelException() << "Union modifier applied to feature which is not a union";
     }
-    unionFeature->selectTag(m_tag);
+    unionFeature->selectTag(m_tagToSelect);
 }
 
 void babelwires::SelectUnionBranchModifierData::visitIdentifiers(IdentifierVisitor& visitor) {
     ModifierData::visitIdentifiers(visitor);
-    visitor(m_tag);
+    visitor(m_tagToSelect);
 }

--- a/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.cpp
@@ -1,0 +1,37 @@
+/**
+ * SelectUnionBranchModifierData is used to select a set of optionals in a RecordWithOptionalsFeature
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Features/modelExceptions.hpp>
+
+#include <Common/Serialization/deserializer.hpp>
+#include <Common/Serialization/serializer.hpp>
+
+void babelwires::SelectUnionBranchModifierData::serializeContents(Serializer& serializer) const {
+    serializer.serializeValue("path", m_pathToFeature);
+    serializer.serializeValue("tag", m_tag);
+}
+
+void babelwires::SelectUnionBranchModifierData::deserializeContents(Deserializer& deserializer) {
+    deserializer.deserializeValue("path", m_pathToFeature);
+    deserializer.deserializeValue("tag", m_tag);
+}
+
+void babelwires::SelectUnionBranchModifierData::apply(Feature* targetFeature) const {
+    UnionFeature* unionFeature = targetFeature->as<UnionFeature>();
+    if (!unionFeature) {
+        throw ModelException() << "Union modifier applied to feature which is not a union";
+    }
+    unionFeature->selectTag(m_tag);
+}
+
+void babelwires::SelectUnionBranchModifierData::visitIdentifiers(IdentifierVisitor& visitor) {
+    ModifierData::visitIdentifiers(visitor);
+    visitor(m_tag);
+}

--- a/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
@@ -1,0 +1,24 @@
+/**
+ * ActivateOptionalsModifierData is used to select a set of optionals in a RecordWithOptionalsFeature
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
+
+namespace babelwires {
+    /// Data used to select a set of optionals in a RecordWithOptionalsFeature
+    struct SelectUnionBranchModifierData : LocalModifierData {
+        virtual void apply(Feature* targetFeature) const override;
+        CLONEABLE(SelectUnionBranchModifierData);
+        SERIALIZABLE(SelectUnionBranchModifierData, "selectUnionBranch", LocalModifierData, 1);
+        void serializeContents(Serializer& serializer) const override;
+        void deserializeContents(Deserializer& deserializer) override;
+        void visitIdentifiers(IdentifierVisitor& visitor) override;
+
+        Identifier m_tag;
+    };
+}

--- a/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
@@ -19,6 +19,6 @@ namespace babelwires {
         void deserializeContents(Deserializer& deserializer) override;
         void visitIdentifiers(IdentifierVisitor& visitor) override;
 
-        Identifier m_tag;
+        Identifier m_tagToSelect;
     };
 }

--- a/BabelWiresQtUi/CMakeLists.txt
+++ b/BabelWiresQtUi/CMakeLists.txt
@@ -24,6 +24,7 @@ SET( BABELWIRESQTUI_SRCS
     ModelBridge/RowModels/rowModelRegistry.cpp
     ModelBridge/RowModels/rowModelWithRichText.cpp
     ModelBridge/RowModels/stringRowModel.cpp
+    ModelBridge/RowModels/unionRowModel.cpp
     ValueEditors/dropDownValueEditor.cpp
     ValueEditors/spinBoxValueEditor.cpp
     ValueEditors/lineEditValueEditor.cpp

--- a/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.cpp
@@ -2,16 +2,18 @@
  * The row model for EnumFeatures.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.hpp>
 
-#include <BabelWiresQtUi/ValueEditors/dropDownValueEditor.hpp>
 #include <BabelWiresQtUi/ModelBridge/featureModel.hpp>
+#include <BabelWiresQtUi/ValueEditors/dropDownValueEditor.hpp>
 
 #include <BabelWiresLib/Enums/enum.hpp>
 #include <BabelWiresLib/Features/enumFeature.hpp>
+#include <BabelWiresLib/Project/Commands/addModifierCommand.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 
 #include <Common/Identifiers/identifierRegistry.hpp>
 
@@ -51,7 +53,8 @@ void babelwires::EnumRowModel::setEditorData(QWidget* editor) const {
     dropDownBox->setCurrentIndex(currentIndex);
 }
 
-std::unique_ptr<babelwires::ModifierData> babelwires::EnumRowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>>
+babelwires::EnumRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::EnumFeature& enumFeature = getEnumFeature();
     const babelwires::Enum::EnumValues& values = enumFeature.getEnum().getEnumValues();
     const Identifier value = enumFeature.get();
@@ -65,11 +68,12 @@ std::unique_ptr<babelwires::ModifierData> babelwires::EnumRowModel::createModifi
         auto modifier = std::make_unique<babelwires::EnumValueAssignmentData>();
         modifier->m_pathToFeature = babelwires::FeaturePath(&enumFeature);
         modifier->m_value = newValue;
-        return modifier;
+        return std::make_unique<AddModifierCommand>("Set enum value", m_featureElement->getElementId(),
+                                                    std::move(modifier));
     } else {
         return nullptr;
     }
-   return nullptr;
+    return nullptr;
 }
 
 bool babelwires::EnumRowModel::isItemEditable() const {

--- a/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         virtual void setEditorData(QWidget* editor) const override;
 
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const override;
 
       public:
         const EnumFeature& getEnumFeature() const;

--- a/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.cpp
@@ -11,6 +11,8 @@
 #include <BabelWiresQtUi/ModelBridge/featureModel.hpp>
 
 #include <BabelWiresLib/Features/numericFeature.hpp>
+#include <BabelWiresLib/Project/Commands/addModifierCommand.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 
 #include <QString>
 
@@ -43,7 +45,7 @@ void babelwires::IntRowModel::setEditorData(QWidget* editor) const {
     spinBox->setValue(value);
 }
 
-std::unique_ptr<babelwires::ModifierData> babelwires::IntRowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>> babelwires::IntRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::IntFeature& intFeature = getIntFeature();
     int value = intFeature.get();
     const QSpinBox* spinBox = dynamic_cast<const QSpinBox*>(editor);
@@ -53,7 +55,8 @@ std::unique_ptr<babelwires::ModifierData> babelwires::IntRowModel::createModifie
         auto modifier = std::make_unique<babelwires::IntValueAssignmentData>();
         modifier->m_pathToFeature = babelwires::FeaturePath(&intFeature);
         modifier->m_value = value;
-        return modifier;
+        return std::make_unique<AddModifierCommand>("Set int value", m_featureElement->getElementId(),
+                                            std::move(modifier));
     } else {
         return nullptr;
     }

--- a/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/intRowModel.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         virtual void setEditorData(QWidget* editor) const override;
 
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const override;
 
       public:
         const IntFeature& getIntFeature() const;

--- a/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.cpp
@@ -10,6 +10,8 @@
 #include <BabelWiresQtUi/ValueEditors/lineEditValueEditor.hpp>
 
 #include <BabelWiresLib/Features/numericFeature.hpp>
+#include <BabelWiresLib/Project/Commands/addModifierCommand.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 
 #include <QString>
 #include <QValidator>
@@ -75,8 +77,8 @@ void babelwires::RationalRowModel::setEditorData(QWidget* editor) const {
     lineEditor->setText(ratFeature.get().toString().c_str());
 }
 
-std::unique_ptr<babelwires::ModifierData>
-babelwires::RationalRowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>>
+babelwires::RationalRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::RationalFeature& ratFeature = getRationalFeature();
     Rational value = ratFeature.get();
     auto lineEditor = qobject_cast<const LineEditValueEditor*>(editor);
@@ -91,7 +93,8 @@ babelwires::RationalRowModel::createModifierFromEditor(QWidget* editor) const {
         auto modifier = std::make_unique<babelwires::RationalValueAssignmentData>();
         modifier->m_pathToFeature = babelwires::FeaturePath(&ratFeature);
         modifier->m_value = value;
-        return modifier;
+        return std::make_unique<AddModifierCommand>("Set rational value", m_featureElement->getElementId(),
+                                    std::move(modifier));
     }
     return nullptr;
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rationalRowModel.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         virtual void setEditorData(QWidget* editor) const override;
 
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const override;
 
       public:
         const RationalFeature& getRationalFeature() const;

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModel.cpp
@@ -107,7 +107,7 @@ QWidget* babelwires::RowModel::createEditor(QWidget* parent, const QModelIndex& 
 
 void babelwires::RowModel::setEditorData(QWidget* editor) const {}
 
-std::unique_ptr<babelwires::ModifierData> babelwires::RowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>> babelwires::RowModel::createCommandFromEditor(QWidget* editor) const {
     return nullptr;
 }
 

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModel.hpp
@@ -7,6 +7,7 @@
  **/
 #pragma once
 
+#include <BabelWiresLib/Commands/commands.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
 #include <BabelWiresQtUi/ModelBridge/ContextMenu/featureContextMenu.hpp>
 
@@ -24,7 +25,6 @@ namespace babelwires {
 
     class Feature;
     class FeatureElement;
-    struct ModifierData;
     struct ContentsCacheEntry;
     class Modifier;
     class FeatureModelDelegate;
@@ -60,9 +60,8 @@ namespace babelwires {
         /// Set the data in the editor.
         virtual void setEditorData(QWidget* editor) const;
 
-        /// Given that the user has committed the edit, return a new modifier corresponding
-        /// to that edit.
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const;
+        /// Given that the user has committed the edit, return a new command performing that edit.
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const;
 
         /// Returns true if this RowModel overrides paint and sizeHint.
         /// The default implementation returns false.

--- a/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/rowModelDispatcher.cpp
@@ -16,6 +16,7 @@
 #include <BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.hpp>
 #include <BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.hpp>
 #include <BabelWiresQtUi/ModelBridge/RowModels/mapRowModel.hpp>
+#include <BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp>
 
 #include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 #include <BabelWiresLib/Features/arrayFeature.hpp>
@@ -24,6 +25,7 @@
 #include <BabelWiresLib/Features/stringFeature.hpp>
 #include <BabelWiresLib/Features/enumFeature.hpp>
 #include <BabelWiresLib/Features/mapFeature.hpp>
+#include <BabelWiresLib/Features/unionFeature.hpp>
 #include <BabelWiresLib/FileFormat/fileFeature.hpp>
 
 babelwires::RowModelDispatcher::RowModelDispatcher(const RowModelRegistry& rowModelRegistry,
@@ -57,6 +59,9 @@ babelwires::RowModelDispatcher::RowModelDispatcher(const RowModelRegistry& rowMo
     } else if (feature->as<const babelwires::MapFeature>()) {
         static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::MapRowModel));
         new (m_rowModel) babelwires::MapRowModel();
+    } else if (feature->as<const babelwires::UnionFeature>()) {
+        static_assert(sizeof(babelwires::RowModel) == sizeof(babelwires::UnionRowModel));
+        new (m_rowModel) babelwires::UnionRowModel();
     } else {
         // The base row model is used.
     }

--- a/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.cpp
@@ -10,6 +10,8 @@
 #include <BabelWiresQtUi/ValueEditors/lineEditValueEditor.hpp>
 
 #include <BabelWiresLib/Features/stringFeature.hpp>
+#include <BabelWiresLib/Project/Commands/addModifierCommand.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 
 #include <QString>
 
@@ -42,7 +44,7 @@ void babelwires::StringRowModel::setEditorData(QWidget* editor) const {
     lineEditor->setText(value.c_str());
 }
 
-std::unique_ptr<babelwires::ModifierData> babelwires::StringRowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>> babelwires::StringRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::StringFeature& strFeature = getStringFeature();
     auto lineEditor = qobject_cast<const LineEditValueEditor*>(editor);
     assert(lineEditor && "Unexpected editor");
@@ -51,7 +53,8 @@ std::unique_ptr<babelwires::ModifierData> babelwires::StringRowModel::createModi
         auto modifier = std::make_unique<babelwires::StringValueAssignmentData>();
         modifier->m_pathToFeature = babelwires::FeaturePath(&strFeature);
         modifier->m_value = contents;
-        return modifier;
+        return std::make_unique<AddModifierCommand>("Set string value", m_featureElement->getElementId(),
+                                    std::move(modifier));
     } else {
         return nullptr;
     }

--- a/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/stringRowModel.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         virtual void setEditorData(QWidget* editor) const override;
 
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const override;
 
       public:
         const StringFeature& getStringFeature() const;

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
@@ -46,10 +46,7 @@ void babelwires::UnionRowModel::setEditorData(QWidget* editor) const {
     const Identifier value = unionFeature.getSelectedTag();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
-    const auto& tags = unionFeature.getTags();
-    const auto it = std::find(tags.begin(), tags.end(), value);
-    unsigned int currentIndex = it - tags.begin();
-    dropDownBox->setCurrentIndex(currentIndex);
+    dropDownBox->setCurrentIndex(unionFeature.getSelectedTagIndex());
 }
 
 std::unique_ptr<babelwires::ModifierData> babelwires::UnionRowModel::createModifierFromEditor(QWidget* editor) const {

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
@@ -11,6 +11,8 @@
 #include <BabelWiresQtUi/ModelBridge/featureModel.hpp>
 
 #include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
 
 #include <Common/Identifiers/identifierRegistry.hpp>
 
@@ -49,7 +51,7 @@ void babelwires::UnionRowModel::setEditorData(QWidget* editor) const {
     dropDownBox->setCurrentIndex(unionFeature.getSelectedTagIndex());
 }
 
-std::unique_ptr<babelwires::ModifierData> babelwires::UnionRowModel::createModifierFromEditor(QWidget* editor) const {
+std::unique_ptr<babelwires::Command<babelwires::Project>> babelwires::UnionRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::UnionFeature& unionFeature = getUnionFeature();
     const auto& tags = unionFeature.getTags();
     const Identifier value = unionFeature.getSelectedTag();
@@ -60,10 +62,7 @@ std::unique_ptr<babelwires::ModifierData> babelwires::UnionRowModel::createModif
     assert(newIndex < tags.size());
     const Identifier newValue = tags[newIndex];
     if (value != newValue) {
-        //auto modifier = std::make_unique<babelwires::EnumValueAssignmentData>();
-        //modifier->m_pathToFeature = babelwires::FeaturePath(&unionFeature);
-        //modifier->m_value = newValue;
-        //return modifier;
+        return std::make_unique<SelectUnionBranchCommand>("Select union branch", m_featureElement->getElementId(), babelwires::FeaturePath(&unionFeature), newValue);
     } else {
         return nullptr;
     }

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
@@ -1,0 +1,78 @@
+/**
+ * The row model for UnionFeatures.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp>
+
+#include <BabelWiresQtUi/ValueEditors/dropDownValueEditor.hpp>
+#include <BabelWiresQtUi/ModelBridge/featureModel.hpp>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+
+#include <Common/Identifiers/identifierRegistry.hpp>
+
+#include <QString>
+
+#include <cassert>
+
+const babelwires::UnionFeature& babelwires::UnionRowModel::getUnionFeature() const {
+    assert(getInputThenOutputFeature()->as<const babelwires::UnionFeature>() && "Wrong type of feature stored");
+    return *static_cast<const babelwires::UnionFeature*>(getInputThenOutputFeature());
+}
+
+QVariant babelwires::UnionRowModel::getValueDisplayData() const {
+    const babelwires::UnionFeature& unionFeature = getUnionFeature();
+    const Identifier value = unionFeature.getSelectedTag();
+    return QString(IdentifierRegistry::read()->getName(value).c_str());
+}
+
+QWidget* babelwires::UnionRowModel::createEditor(QWidget* parent, const QModelIndex& index) const {
+    const babelwires::UnionFeature& unionFeature = getUnionFeature();
+    auto dropDownBox = std::make_unique<DropDownValueEditor>(parent, index);
+    {
+        IdentifierRegistry::ReadAccess identifierRegistry = IdentifierRegistry::read();
+        for (auto enumValue : unionFeature.getTags()) {
+            dropDownBox->addItem(identifierRegistry->getName(enumValue).c_str());
+        }
+    }
+    return dropDownBox.release();
+}
+
+void babelwires::UnionRowModel::setEditorData(QWidget* editor) const {
+    const babelwires::UnionFeature& unionFeature = getUnionFeature();
+    const Identifier value = unionFeature.getSelectedTag();
+    auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
+    assert(dropDownBox && "Unexpected editor");
+    const auto& tags = unionFeature.getTags();
+    const auto it = std::find(tags.begin(), tags.end(), value);
+    unsigned int currentIndex = it - tags.begin();
+    dropDownBox->setCurrentIndex(currentIndex);
+}
+
+std::unique_ptr<babelwires::ModifierData> babelwires::UnionRowModel::createModifierFromEditor(QWidget* editor) const {
+    const babelwires::UnionFeature& unionFeature = getUnionFeature();
+    const auto& tags = unionFeature.getTags();
+    const Identifier value = unionFeature.getSelectedTag();
+    auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
+    assert(dropDownBox && "Unexpected editor");
+    const int newIndex = dropDownBox->currentIndex();
+    assert(newIndex >= 0);
+    assert(newIndex < tags.size());
+    const Identifier newValue = tags[newIndex];
+    if (value != newValue) {
+        //auto modifier = std::make_unique<babelwires::EnumValueAssignmentData>();
+        //modifier->m_pathToFeature = babelwires::FeaturePath(&unionFeature);
+        //modifier->m_value = newValue;
+        //return modifier;
+    } else {
+        return nullptr;
+    }
+   return nullptr;
+}
+
+bool babelwires::UnionRowModel::isItemEditable() const {
+    return getInputFeature();
+}

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         virtual void setEditorData(QWidget* editor) const override;
 
-        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+        virtual std::unique_ptr<Command<Project>> createCommandFromEditor(QWidget* editor) const override;
 
       public:
         const UnionFeature& getUnionFeature() const;

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.hpp
@@ -1,0 +1,33 @@
+/**
+ * The row model for EnumFeatures.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresQtUi/ModelBridge/RowModels/rowModel.hpp>
+
+namespace babelwires {
+
+    class UnionFeature;
+
+    /// The row model for IntFeatures.
+    class UnionRowModel : public RowModel {
+      public:
+        virtual QVariant getValueDisplayData() const override;
+
+        virtual bool isItemEditable() const override;
+
+        virtual QWidget* createEditor(QWidget* parent, const QModelIndex& index) const override;
+
+        virtual void setEditorData(QWidget* editor) const override;
+
+        virtual std::unique_ptr<ModifierData> createModifierFromEditor(QWidget* editor) const override;
+
+      public:
+        const UnionFeature& getUnionFeature() const;
+    };
+
+} // namespace babelwires

--- a/BabelWiresQtUi/ModelBridge/featureModelDelegate.cpp
+++ b/BabelWiresQtUi/ModelBridge/featureModelDelegate.cpp
@@ -130,9 +130,8 @@ void babelwires::FeatureModelDelegate::setModelData(QWidget* editor, QAbstractIt
 
     assert(rowModel->isItemEditable() && "We should not be trying to create an editor for a non-editable feature");
     // Allow the function to reject the contents of the editor.
-    if (std::unique_ptr<ModifierData> modifier = rowModel->createModifierFromEditor(editor)) {
-        m_projectBridge.scheduleCommand(
-            std::make_unique<AddModifierCommand>("Set value", element->getElementId(), std::move(modifier)));
+    if (std::unique_ptr<Command<Project>> command = rowModel->createCommandFromEditor(editor)) {
+        m_projectBridge.scheduleCommand(std::move(command));
     }
 }
 

--- a/Common/types.hpp
+++ b/Common/types.hpp
@@ -49,6 +49,19 @@ namespace babelwires {
         ITERATOR end() const { return m_end; }
     };
 
+    template <typename T>
+    struct ReverseIterateWrapper {
+         T& iterable; 
+    };
+
+    template <typename T>
+    auto begin (ReverseIterateWrapper<T> w) { return std::rbegin(w.iterable); }
+
+    template <typename T>
+    auto end (ReverseIterateWrapper<T> w) { return std::rend(w.iterable); }
+
+    template <typename T>
+    ReverseIterateWrapper<T> reverseIterate (T&& iterable) { return { iterable }; }
     //
 
     /// Is str usable as an "identifier" ([a..zA..Z][_a..zA..Z0..9]*).

--- a/TODO.md
+++ b/TODO.md
@@ -18,9 +18,6 @@ Unit Tests:
 
 Model
 * Arrays should have a getDefaultSize.
-* Unions
-  - Switch via context menu option.
-  - If an unselected variant is modified, does that modification get stored when the variant is switched. I presume only in undo stack, which is a little annoying.
 * FileFeature: Remove this and the offset hack in the FeatureCache. 
   - Instead, allow the UI to add non-model rows at top for visualization, and use that.
 * Consider a coercion system so numeric types can always be assigned.

--- a/Tests/BabelWiresLib/CMakeLists.txt
+++ b/Tests/BabelWiresLib/CMakeLists.txt
@@ -56,6 +56,7 @@ SET( LIB_TESTS_SRCS
     targetFileElementTest.cpp
     typeTest.cpp
     typeSystemTest.cpp
+    unionFeatureTest.cpp
     valueNamesTest.cpp
    )
 

--- a/Tests/BabelWiresLib/CMakeLists.txt
+++ b/Tests/BabelWiresLib/CMakeLists.txt
@@ -47,6 +47,7 @@ SET( LIB_TESTS_SRCS
     replaceMapEntryCommandTest.cpp
     resizeElementCommandTest.cpp
     rootFeatureTest.cpp
+    selectUnionBranchModifierDataTest.cpp
     setArraySizeCommandTest.cpp
     setExpandedCommandTest.cpp
     setMapCommandTest.cpp

--- a/Tests/BabelWiresLib/CMakeLists.txt
+++ b/Tests/BabelWiresLib/CMakeLists.txt
@@ -48,6 +48,7 @@ SET( LIB_TESTS_SRCS
     resizeElementCommandTest.cpp
     rootFeatureTest.cpp
     selectUnionBranchModifierDataTest.cpp
+    selectUnionBranchCommandTest.cpp
     setArraySizeCommandTest.cpp
     setExpandedCommandTest.cpp
     setMapCommandTest.cpp

--- a/Tests/BabelWiresLib/TestUtils/CMakeLists.txt
+++ b/Tests/BabelWiresLib/TestUtils/CMakeLists.txt
@@ -8,6 +8,7 @@ SET( LIB_TEST_UTILS_SRCS
     testRecord.cpp
     testFeatureWithOptionals.cpp
     testRootFeature.cpp
+    testUnionFeature.cpp
     testValueAndType.cpp
    )
 

--- a/Tests/BabelWiresLib/TestUtils/CMakeLists.txt
+++ b/Tests/BabelWiresLib/TestUtils/CMakeLists.txt
@@ -8,7 +8,7 @@ SET( LIB_TEST_UTILS_SRCS
     testRecord.cpp
     testFeatureWithOptionals.cpp
     testRootFeature.cpp
-    testUnionFeature.cpp
+    testFeatureWithUnion.cpp
     testValueAndType.cpp
    )
 

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
@@ -1,24 +1,24 @@
 #include <gtest/gtest.h>
 
-#include <Tests/BabelWiresLib/TestUtils/testUnionFeature.hpp>
+#include <Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp>
 
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToUnionFeature =
-    babelwires::FeaturePath::deserializeFromString(testUtils::TestUnionFeature::s_unionFeatureIdInitializer);
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFf0 =
-    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_ff0IdInitializer);
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFf1 =
-    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_ff1IdInitializer);
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldA0 =
-    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldA0IdInitializer);
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldA1 =
-    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldA1IdInitializer);
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0 =
-    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToUnionFeature =
+    babelwires::FeaturePath::deserializeFromString(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFf0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_ff0IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFf1 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_ff1IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldA0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldA0IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldA1 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldA1IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer);
 
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0_Array_1 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_arrayIdInitializer + "/1");
-const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0_Int2 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_recordIdInitializer + "/" + testUtils::TestRecordFeature::s_int2IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0_Array_1 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_arrayIdInitializer + "/1");
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0_Int2 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_recordIdInitializer + "/" + testUtils::TestRecordFeature::s_int2IdInitializer);
 
-testUtils::TestUnionFeature::TestUnionFeature(const babelwires::ProjectContext& context)
+testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectContext& context)
     : RootFeature(context)
     , m_tagAId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
           s_tagAIdInitializer, s_tagAFieldName, s_tagAUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
@@ -98,7 +98,7 @@ testUtils::TestFeatureElementWithUnion::TestFeatureElementWithUnion(const babelw
 testUtils::TestFeatureElementWithUnion::TestFeatureElementWithUnion(const babelwires::ProjectContext& context, const TestFeatureElementWithUnionData& data, babelwires::ElementId newId)
     : FeatureElement(data, newId) {
     setFactoryName(data.m_factoryIdentifier);
-    m_feature = std::make_unique<TestUnionFeature>(context);
+    m_feature = std::make_unique<TestFeatureWithUnion>(context);
 }
 
 void testUtils::TestFeatureElementWithUnion::doProcess(babelwires::UserLogger&) {}

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
@@ -41,6 +41,7 @@ namespace testUtils {
         static constexpr char s_fieldA1Uuid[] = "00000000-1111-2222-3333-8800000000A1";
         static constexpr char s_fieldB0Uuid[] = "00000000-1111-2222-3333-8800000000B0";
 
+        // Note: tagB is the default.
         babelwires::Identifier m_tagAId;
         babelwires::Identifier m_tagBId;
         babelwires::Identifier m_unionFeatureId;

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
@@ -11,8 +11,8 @@
 
 namespace testUtils {
     /// A record with optional fields.
-    struct TestUnionFeature : babelwires::RootFeature {
-        TestUnionFeature(const babelwires::ProjectContext& context);
+    struct TestFeatureWithUnion : babelwires::RootFeature {
+        TestFeatureWithUnion(const babelwires::ProjectContext& context);
 
         static constexpr char s_tagAIdInitializer[] = "tagA";
         static constexpr char s_tagBIdInitializer[] = "tagB";
@@ -103,7 +103,7 @@ namespace testUtils {
         using babelwires::FeatureElement::getInputFeature;
         using babelwires::FeatureElement::getOutputFeature;
 
-        std::unique_ptr<testUtils::TestUnionFeature> m_feature;
+        std::unique_ptr<testUtils::TestFeatureWithUnion> m_feature;
     };
 
 } // namespace testUtils

--- a/Tests/BabelWiresLib/TestUtils/testUnionFeature.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testUnionFeature.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <Tests/BabelWiresLib/TestUtils/testUnionFeature.hpp>
+
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToUnionFeature =
+    babelwires::FeaturePath::deserializeFromString(testUtils::TestUnionFeature::s_unionFeatureIdInitializer);
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFf0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_ff0IdInitializer);
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFf1 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_ff1IdInitializer);
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldA0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldA0IdInitializer);
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldA1 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldA1IdInitializer);
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0 =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer);
+
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0_Array_1 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_arrayIdInitializer + "/1");
+const babelwires::FeaturePath testUtils::TestUnionFeature::s_pathToFieldB0_Int2 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestUnionFeature::s_unionFeatureIdInitializer) + "/" + testUtils::TestUnionFeature::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_recordIdInitializer + "/" + testUtils::TestRecordFeature::s_int2IdInitializer);
+
+testUtils::TestUnionFeature::TestUnionFeature(const babelwires::ProjectContext& context)
+    : RootFeature(context)
+    , m_tagAId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_tagAIdInitializer, s_tagAFieldName, s_tagAUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_tagBId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_tagBIdInitializer, s_tagBFieldName, s_tagBUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_unionFeatureId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_unionFeatureIdInitializer, s_unionFeatureFieldName, s_unionFeatureUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_ff0IdInitializer, s_ff0FieldName, s_ff0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_ff1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_ff1IdInitializer, s_ff1FieldName, s_ff1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_fieldA0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_fieldA0IdInitializer, s_fieldA0FieldName, s_fieldA0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_fieldA1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_fieldA1IdInitializer, s_fieldA1FieldName, s_fieldA1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_fieldB0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_fieldB0IdInitializer, s_fieldB0FieldName, s_fieldB0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
+    {
+        auto testUnionFeaturePtr = std::make_unique<babelwires::UnionFeature>(babelwires::UnionFeature::TagValues{m_tagAId, m_tagBId}, 1);
+        m_unionFeature = testUnionFeaturePtr.get();
+        addField(std::move(testUnionFeaturePtr), m_unionFeatureId);
+    }
+    {
+        auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
+        m_fieldA0Feature = intFeaturePtr.get();
+        m_unionFeature->addFieldInBranch(m_tagAId, std::move(intFeaturePtr), m_fieldA0Id);
+    }
+    {
+        auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
+        m_ff0Feature = intFeaturePtr.get();
+        m_unionFeature->addField(std::move(intFeaturePtr), m_ff0Id);
+    }
+    {
+        auto testRecordFeaturePtr = std::make_unique<testUtils::TestRecordFeature>();
+        m_fieldB0Feature = testRecordFeaturePtr.get();
+        m_unionFeature->addFieldInBranch(m_tagBId, std::move(testRecordFeaturePtr), m_fieldB0Id);
+    }
+    {
+        auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
+        m_fieldA1Feature = intFeaturePtr.get();
+        m_unionFeature->addFieldInBranch(m_tagAId, std::move(intFeaturePtr), m_fieldA1Id);
+    }
+    {
+        auto testRecordFeaturePtr = std::make_unique<testUtils::TestRecordFeature>();
+        m_ff1Feature = testRecordFeaturePtr.get();
+        m_unionFeature->addField(std::move(testRecordFeaturePtr), m_ff1Id);
+    }
+}
+
+testUtils::TestFeatureElementWithUnionData::TestFeatureElementWithUnionData() {
+    m_factoryIdentifier = "TestWithOptsFactory";
+    m_factoryVersion = 1;
+}
+
+testUtils::TestFeatureElementWithUnionData::TestFeatureElementWithUnionData(const TestFeatureElementWithUnionData& other,
+                                                             babelwires::ShallowCloneContext context)
+    : ElementData(other, context)
+    {}
+
+bool testUtils::TestFeatureElementWithUnionData::checkFactoryVersion(const babelwires::ProjectContext& context,
+                                                               babelwires::UserLogger& userLogger) {
+    return true;
+}
+
+std::unique_ptr<babelwires::FeatureElement> testUtils::TestFeatureElementWithUnionData::doCreateFeatureElement(
+    const babelwires::ProjectContext& context, babelwires::UserLogger& userLogger, babelwires::ElementId newId) const {
+    return std::make_unique<TestFeatureElementWithUnion>(context, *this, newId);
+}
+
+void testUtils::TestFeatureElementWithUnionData::serializeContents(babelwires::Serializer& serializer) const {}
+
+void testUtils::TestFeatureElementWithUnionData::deserializeContents(babelwires::Deserializer& deserializer) {}
+
+testUtils::TestFeatureElementWithUnion::TestFeatureElementWithUnion(const babelwires::ProjectContext& context)
+    : TestFeatureElementWithUnion(context, TestFeatureElementWithUnionData(), 10) {}
+
+testUtils::TestFeatureElementWithUnion::TestFeatureElementWithUnion(const babelwires::ProjectContext& context, const TestFeatureElementWithUnionData& data, babelwires::ElementId newId)
+    : FeatureElement(data, newId) {
+    setFactoryName(data.m_factoryIdentifier);
+    m_feature = std::make_unique<TestUnionFeature>(context);
+}
+
+void testUtils::TestFeatureElementWithUnion::doProcess(babelwires::UserLogger&) {}
+
+babelwires::RootFeature* testUtils::TestFeatureElementWithUnion::getInputFeature() {
+    return m_feature.get();
+}
+
+babelwires::RootFeature* testUtils::TestFeatureElementWithUnion::getOutputFeature() {
+    return m_feature.get();
+}

--- a/Tests/BabelWiresLib/TestUtils/testUnionFeature.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testUnionFeature.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Features/rootFeature.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>
+#include <BabelWiresLib/Project/FeatureElements/featureElementData.hpp>
+
+#include <Tests/BabelWiresLib/TestUtils/testRecord.hpp>
+
+namespace testUtils {
+    /// A record with optional fields.
+    struct TestUnionFeature : babelwires::RootFeature {
+        TestUnionFeature(const babelwires::ProjectContext& context);
+
+        static constexpr char s_tagAIdInitializer[] = "tagA";
+        static constexpr char s_tagBIdInitializer[] = "tagB";
+        static constexpr char s_unionFeatureIdInitializer[] = "subrd";
+        static constexpr char s_ff0IdInitializer[] = "ff0";
+        static constexpr char s_ff1IdInitializer[] = "ff1";
+        static constexpr char s_fieldA0IdInitializer[] = "A0";
+        static constexpr char s_fieldA1IdInitializer[] = "A1";
+        static constexpr char s_fieldB0IdInitializer[] = "B0";
+
+        static constexpr char s_tagAFieldName[] = "tagA";
+        static constexpr char s_tagBFieldName[] = "tagB";
+        static constexpr char s_unionFeatureFieldName[] = "union";
+        static constexpr char s_ff0FieldName[] = "fixed field 0";
+        static constexpr char s_ff1FieldName[] = "fixed field 1";
+        static constexpr char s_fieldA0FieldName[] = "branch A field 0";
+        static constexpr char s_fieldA1FieldName[] = "branch A field 1";
+        static constexpr char s_fieldB0FieldName[] = "branch B field 0";
+
+        static constexpr char s_tagAUuid[] = "00000000-1111-2222-3333-88000000000A";
+        static constexpr char s_tagBUuid[] = "00000000-1111-2222-3333-88000000000B";
+        static constexpr char s_unionFeatureUuid[] = "00000000-1111-2222-3333-880000000000";
+        static constexpr char s_ff0Uuid[] = "00000000-1111-2222-3333-880000000001";
+        static constexpr char s_ff1Uuid[] = "00000000-1111-2222-3333-880000000002";
+        static constexpr char s_fieldA0Uuid[] = "00000000-1111-2222-3333-8800000000A0";
+        static constexpr char s_fieldA1Uuid[] = "00000000-1111-2222-3333-8800000000A1";
+        static constexpr char s_fieldB0Uuid[] = "00000000-1111-2222-3333-8800000000B0";
+
+        babelwires::Identifier m_tagAId;
+        babelwires::Identifier m_tagBId;
+        babelwires::Identifier m_unionFeatureId;
+        babelwires::Identifier m_ff0Id;
+        babelwires::Identifier m_ff1Id;
+        babelwires::Identifier m_fieldA0Id;
+        babelwires::Identifier m_fieldA1Id;
+        babelwires::Identifier m_fieldB0Id;
+
+        babelwires::UnionFeature* m_unionFeature;
+        babelwires::IntFeature* m_ff0Feature;
+        testUtils::TestRecordFeature* m_ff1Feature;
+        babelwires::IntFeature* m_fieldA0Feature;
+        babelwires::IntFeature* m_fieldA1Feature;
+        testUtils::TestRecordFeature* m_fieldB0Feature;
+
+        // For convenience
+        static const babelwires::FeaturePath s_pathToUnionFeature;
+        static const babelwires::FeaturePath s_pathToFf0;
+        static const babelwires::FeaturePath s_pathToFf1;
+        static const babelwires::FeaturePath s_pathToFieldA0;
+        static const babelwires::FeaturePath s_pathToFieldA1;
+        static const babelwires::FeaturePath s_pathToFieldB0;
+
+        static const babelwires::FeaturePath s_pathToFieldB0_Array_1;
+        static const babelwires::FeaturePath s_pathToFieldB0_Int2;
+    };
+
+    struct TestFeatureElementWithUnionData : babelwires::ElementData {
+        CLONEABLE(TestFeatureElementWithUnionData);
+        CUSTOM_CLONEABLE(TestFeatureElementWithUnionData);
+        SERIALIZABLE(TestFeatureElementWithUnionData, "TestFeatureElementWithUnionData",
+                     babelwires::ElementData, 1);
+
+        // By default, create a TestRecordFeature.
+        TestFeatureElementWithUnionData();
+        TestFeatureElementWithUnionData(const TestFeatureElementWithUnionData& other) = default;
+        TestFeatureElementWithUnionData(const TestFeatureElementWithUnionData& other,
+                                            babelwires::ShallowCloneContext);
+
+        // Dummy implementations.
+        void serializeContents(babelwires::Serializer& serializer) const override;
+        void deserializeContents(babelwires::Deserializer& deserializer) override;
+        bool checkFactoryVersion(const babelwires::ProjectContext& context,
+                                 babelwires::UserLogger& userLogger) override;
+
+        // Creates a TestFeatureElement.
+        std::unique_ptr<babelwires::FeatureElement> doCreateFeatureElement(const babelwires::ProjectContext& context,
+                                                                           babelwires::UserLogger& userLogger,
+                                                                           babelwires::ElementId newId) const override;
+    };
+
+    struct TestFeatureElementWithUnion : babelwires::FeatureElement {
+        TestFeatureElementWithUnion(const babelwires::ProjectContext& context);
+        TestFeatureElementWithUnion(const babelwires::ProjectContext& context, const TestFeatureElementWithUnionData& data, babelwires::ElementId newId);
+        void doProcess(babelwires::UserLogger&) override;
+
+        babelwires::RootFeature* getInputFeature() override;
+        babelwires::RootFeature* getOutputFeature() override;
+        using babelwires::FeatureElement::getInputFeature;
+        using babelwires::FeatureElement::getOutputFeature;
+
+        std::unique_ptr<testUtils::TestUnionFeature> m_feature;
+    };
+
+} // namespace testUtils

--- a/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
@@ -78,7 +78,7 @@ TEST(ActivateOptionalsModifierDataTest, apply1) {
     EXPECT_TRUE(recordFeature.isActivated("op2"));
 }
 
-TEST(ActivateOptionalsModifierDataTest, failure) {
+TEST(ActivateOptionalsModifierDataTest, failureNotOptionals) {
     babelwires::ActivateOptionalsModifierData data;
     data.m_selectedOptionals.emplace_back("op5");
     data.m_selectedOptionals.emplace_back("op6");
@@ -96,16 +96,26 @@ TEST(ActivateOptionalsModifierDataTest, failure) {
     EXPECT_THROW(data.apply(&recordFeature), babelwires::ModelException);
 }
 
+TEST(ActivateOptionalsModifierDataTest, failureNotARecordWithOptionals) {
+    babelwires::ActivateOptionalsModifierData data;
+    data.m_selectedOptionals.emplace_back("op");
+
+    babelwires::IntFeature notARecordWithOptionals;
+    
+    EXPECT_THROW(data.apply(&notARecordWithOptionals), babelwires::ModelException);
+}
+
 TEST(ActivateOptionalsModifierDataTest, clone) {
     babelwires::ActivateOptionalsModifierData data;
+    data.m_pathToFeature = babelwires::FeaturePath::deserializeFromString("foo/bar/boo");
     data.m_selectedOptionals.emplace_back("op0");
     data.m_selectedOptionals.emplace_back("op1");
     
-    auto dataPtr = data.clone();
-    ASSERT_NE(dataPtr, nullptr);
-    EXPECT_TRUE(testUtils::areEqualSets(data.m_selectedOptionals, { "op0", "op1" }));
+    auto clonePtr = data.clone();
+    ASSERT_NE(clonePtr, nullptr);
+    EXPECT_EQ(clonePtr->m_pathToFeature, data.m_pathToFeature);
+    EXPECT_TRUE(testUtils::areEqualSets(clonePtr->m_selectedOptionals, data.m_selectedOptionals));
 }
-
 
 TEST(ActivateOptionalsModifierDataTest, serialization) {
     std::string serializedContents;

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -28,7 +28,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     ASSERT_NE(element, nullptr);
     const auto* targetElement =
         testEnvironment.m_project.getFeatureElement(targetId)->as<testUtils::TestFeatureElement>();
-    ASSERT_NE(element, nullptr);
+    ASSERT_NE(targetElement, nullptr);
 
     const auto getInputFeature = [element]() {
         return element->getInputFeature()->as<testUtils::TestFeatureWithOptionals>();

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -185,7 +185,6 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
 
     const auto* element = testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
-    ASSERT_NE(element, nullptr);
     const testUtils::TestFeatureWithOptionals* inputFeature =
         element->getInputFeature()->as<testUtils::TestFeatureWithOptionals>();
     ASSERT_NE(inputFeature, nullptr);
@@ -204,7 +203,6 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
         testEnvironment.m_project.addFeatureElement(testUtils::TestFeatureElementWithOptionalsData());
 
     const auto* element = testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithOptionals>();
-    ASSERT_NE(element, nullptr);
     ASSERT_NE(element, nullptr);
     const testUtils::TestFeatureWithOptionals* inputFeature =
         element->getInputFeature()->as<testUtils::TestFeatureWithOptionals>();

--- a/Tests/BabelWiresLib/filePathTest.cpp
+++ b/Tests/BabelWiresLib/filePathTest.cpp
@@ -24,10 +24,7 @@ TEST(FilePathTest, deserializeFromString) {
     EXPECT_EQ(babelwires::FilePath::deserializeFromString("Foo/Bar/Bar.boo"), "Foo/Bar/Bar.boo");
     EXPECT_EQ(babelwires::FilePath::deserializeFromString("/Foo/Bar.boo"), "/Foo/Bar.boo");
     EXPECT_EQ(babelwires::FilePath::deserializeFromString("c:/Foo/Bar.boo"), "c:/Foo/Bar.boo");
-
-    EXPECT_THROW(babelwires::FilePath::deserializeFromString(""), babelwires::ParseException);
-    EXPECT_THROW(babelwires::FilePath::deserializeFromString("\t"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::FilePath::deserializeFromString("\n"), babelwires::ParseException);
+    EXPECT_EQ(babelwires::FilePath::deserializeFromString(""), "");
 }
 
 TEST(FilePathTest, interpretRelativeTo) {

--- a/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
+++ b/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
@@ -47,7 +47,6 @@ TEST(RecordWithOptionalsFeatureTest, fieldOrder) {
     EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
     EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
 
-
     recordFeature.activateField(op2);
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 4);

--- a/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Project/project.hpp>
+#include <BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp>
+#include <BabelWiresLib/Project/Modifiers/modifier.hpp>
+#include <BabelWiresLib/Project/Modifiers/connectionModifierData.hpp>
+
+#include <Common/Identifiers/identifierRegistry.hpp>
+
+#include <Tests/BabelWiresLib/TestUtils/testFeatureElement.hpp>
+#include <Tests/BabelWiresLib/TestUtils/testEnvironment.hpp>
+#include <Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp>
+
+TEST(SelectUnionBranchCommandTest, executeAndUndo) {
+    babelwires::IdentifierRegistryScope identifierRegistry;
+    testUtils::TestEnvironment testEnvironment;
+
+    const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(testUtils::TestFeatureElementWithUnionData());
+    const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(testUtils::TestFeatureElementData());
+    const babelwires::ElementId targetId = testEnvironment.m_project.addFeatureElement(testUtils::TestFeatureElementData());
+
+    const testUtils::TestFeatureElementWithUnion* element =
+        testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithUnion>();
+    ASSERT_NE(element, nullptr);
+    const auto* targetElement =
+        testEnvironment.m_project.getFeatureElement(targetId)->as<testUtils::TestFeatureElement>();
+    ASSERT_NE(targetElement, nullptr);
+
+    const auto getInputFeature = [element]() {
+        return element->getInputFeature()->as<testUtils::TestFeatureWithUnion>();
+    };
+    ASSERT_NE(getInputFeature(), nullptr);
+
+    {
+        babelwires::SelectUnionBranchModifierData selectUnionBranchData;
+        selectUnionBranchData.m_pathToFeature = testUtils::TestFeatureWithUnion::s_pathToUnionFeature;
+        selectUnionBranchData.m_tagToSelect = getInputFeature()->m_tagBId;
+        testEnvironment.m_project.addModifier(elementId, selectUnionBranchData);
+    }
+    {
+        babelwires::ConnectionModifierData inputConnection;
+        inputConnection.m_pathToFeature = testUtils::TestFeatureWithUnion::s_pathToFieldB0_Array_1;
+        inputConnection.m_pathToSourceFeature = testUtils::TestRootFeature::s_pathToInt2;
+        inputConnection.m_sourceId = sourceId;
+        testEnvironment.m_project.addModifier(elementId, inputConnection);
+    }
+    {
+        babelwires::ConnectionModifierData outputConnection;
+        outputConnection.m_pathToFeature = testUtils::TestRootFeature::s_pathToInt2;
+        outputConnection.m_pathToSourceFeature = testUtils::TestFeatureWithUnion::s_pathToFieldB0_Int2;
+        outputConnection.m_sourceId = elementId;
+        testEnvironment.m_project.addModifier(targetId, outputConnection);
+    }
+
+    const auto checkModifiers = [&testEnvironment, element, targetElement](bool isCommandExecuted) {
+        const babelwires::Modifier* inputConnection =
+            element->findModifier(testUtils::TestFeatureWithUnion::s_pathToFieldB0_Array_1);
+        const babelwires::Modifier* outputConnection =
+            targetElement->findModifier(testUtils::TestRootFeature::s_pathToInt2);
+        int numModifiersAtElement = 0;
+        int numModifiersAtTarget = 0;
+        for (const auto* m : element->getEdits().modifierRange()) {
+            ++numModifiersAtElement;
+        }
+        for (const auto* m : targetElement->getEdits().modifierRange()) {
+            ++numModifiersAtTarget;
+        }
+        if (isCommandExecuted) {
+            EXPECT_EQ(inputConnection, nullptr);
+            EXPECT_EQ(outputConnection, nullptr);
+            EXPECT_EQ(numModifiersAtElement, 1);
+            EXPECT_EQ(numModifiersAtTarget, 0);
+        } else {
+            EXPECT_NE(inputConnection, nullptr);
+            EXPECT_NE(outputConnection, nullptr);
+            EXPECT_EQ(numModifiersAtElement, 2);
+            EXPECT_EQ(numModifiersAtTarget, 1);
+        }
+    };
+    
+    babelwires::SelectUnionBranchCommand command("Test command", elementId,
+                                               testUtils::TestFeatureWithUnion::s_pathToUnionFeature, getInputFeature()->m_tagAId);
+
+    EXPECT_EQ(command.getName(), "Test command");
+    EXPECT_EQ(getInputFeature()->m_unionFeature->getSelectedTag(), getInputFeature()->m_tagBId);
+    checkModifiers(false);
+    
+    testEnvironment.m_project.process();
+    EXPECT_TRUE(command.initializeAndExecute(testEnvironment.m_project));
+
+    EXPECT_EQ(getInputFeature()->m_unionFeature->getSelectedTag(), getInputFeature()->m_tagAId);
+    checkModifiers(true);
+
+    command.undo(testEnvironment.m_project);
+    testEnvironment.m_project.process();
+
+    EXPECT_EQ(getInputFeature()->m_unionFeature->getSelectedTag(), getInputFeature()->m_tagBId);
+    checkModifiers(false);
+
+    command.execute(testEnvironment.m_project);
+    testEnvironment.m_project.process();
+
+    EXPECT_EQ(getInputFeature()->m_unionFeature->getSelectedTag(), getInputFeature()->m_tagAId);
+    checkModifiers(true);
+}
+

--- a/Tests/BabelWiresLib/selectUnionBranchModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchModifierDataTest.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+#include <BabelWiresLib/Features/numericFeature.hpp>
+#include <BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp>
+
+#include <Common/Serialization/XML/xmlDeserializer.hpp>
+#include <Common/Serialization/XML/xmlSerializer.hpp>
+
+#include <Tests/TestUtils/testLog.hpp>
+#include <Tests/TestUtils/equalSets.hpp>
+
+TEST(SelectUnionBranchModifierDataTest, apply) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::SelectUnionBranchModifierData data;
+    data.m_tagToSelect = tagC;
+
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    babelwires::Identifier fieldIdC0("fldC0");
+    fieldIdC0.setDiscriminator(1);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+
+    babelwires::Identifier ff1("ff1");
+    ff1.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+
+    unionFeature.setToDefault();
+
+    data.apply(&unionFeature);
+
+    EXPECT_EQ(unionFeature.getSelectedTag(), tagC);
+}
+
+TEST(SelectUnionBranchModifierDataTest, failureNotATag) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::SelectUnionBranchModifierData data;
+    data.m_tagToSelect = "notTag";
+
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    unionFeature.setToDefault();
+
+    EXPECT_THROW(data.apply(&unionFeature), babelwires::ModelException);
+}
+
+TEST(SelectUnionBranchModifierDataTest, failureNotAUnion) {
+    babelwires::SelectUnionBranchModifierData data;
+    data.m_tagToSelect = "tag";
+
+    babelwires::IntFeature notAUnionFeature;
+    
+    EXPECT_THROW(data.apply(&notAUnionFeature), babelwires::ModelException);
+}
+
+TEST(SelectUnionBranchModifierDataTest, clone) {
+    babelwires::SelectUnionBranchModifierData data;
+    data.m_pathToFeature = babelwires::FeaturePath::deserializeFromString("foo/bar/boo");
+    data.m_tagToSelect = "tag";
+    
+    auto clonePtr = data.clone();
+    ASSERT_NE(clonePtr, nullptr);
+    EXPECT_EQ(clonePtr->m_pathToFeature, data.m_pathToFeature);
+    EXPECT_EQ(clonePtr->m_tagToSelect, data.m_tagToSelect);
+}
+
+TEST(SelectUnionBranchModifierDataTest, serialization) {
+    std::string serializedContents;
+    {
+        babelwires::SelectUnionBranchModifierData data;
+        data.m_pathToFeature = babelwires::FeaturePath::deserializeFromString("foo/bar/boo");
+        data.m_tagToSelect = "tag";
+    
+        babelwires::XmlSerializer serializer;
+        serializer.serializeObject(data);
+        std::ostringstream os;
+        serializer.write(os);
+        serializedContents = std::move(os.str());
+    }
+    testUtils::TestLog log;
+    babelwires::AutomaticDeserializationRegistry deserializationReg;
+    babelwires::XmlDeserializer deserializer(serializedContents, deserializationReg, log);
+    auto dataPtr = deserializer.deserializeObject<babelwires::SelectUnionBranchModifierData>();
+    deserializer.finalize();
+
+    ASSERT_NE(dataPtr, nullptr);
+    EXPECT_EQ(dataPtr->m_pathToFeature, babelwires::FeaturePath::deserializeFromString("foo/bar/boo"));
+    EXPECT_EQ(dataPtr->m_tagToSelect, "tag");
+}

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -15,7 +15,7 @@ TEST(UnionFeatureTest, fieldOrder) {
     babelwires::Identifier tagC("tagC");
     tagC.setDiscriminator(1);
 
-    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 1);
+    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 0);
 
@@ -43,10 +43,29 @@ TEST(UnionFeatureTest, fieldOrder) {
     fieldIdC1.setDiscriminator(1);
     babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
 
+    recordFeature.setToDefault();
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+
+    recordFeature.selectTag(tagB);
+
     EXPECT_EQ(recordFeature.getNumFeatures(), 2);
     EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
     EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
 
+    recordFeature.selectTag(tagA);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+
+    // Same tag again.
     recordFeature.selectTag(tagA);
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 4);
@@ -84,11 +103,215 @@ TEST(UnionFeatureTest, fieldOrder) {
     EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
     EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
     EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+}
 
+TEST(UnionFeatureTest, changes) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    babelwires::Identifier fieldIdC0("fldC0");
+    fieldIdC0.setDiscriminator(1);
+    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+
+    babelwires::Identifier fieldIdA1("fldA1");
+    fieldIdA1.setDiscriminator(1);
+    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+
+    babelwires::Identifier ff1("ff1");
+    ff1.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+
+    babelwires::Identifier fieldIdC1("fldC1");
+    fieldIdC1.setDiscriminator(1);
+    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+
+    recordFeature.setToDefault();
+
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+
+    recordFeature.clearChanges();
+    recordFeature.selectTag(tagA);
+
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+
+    recordFeature.clearChanges();
+    // Same tag again.
+    recordFeature.selectTag(tagA);
+
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+
+    recordFeature.clearChanges();
+    recordFeature.selectTag(tagB);
+
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+
+    recordFeature.clearChanges();
+    recordFeature.selectTag(tagC);
+
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+}
+
+TEST(UnionFeatureTest, hash) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    babelwires::Identifier fieldIdC0("fldC0");
+    fieldIdC0.setDiscriminator(1);
+    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+
+    babelwires::Identifier fieldIdA1("fldA1");
+    fieldIdA1.setDiscriminator(1);
+    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+
+    babelwires::Identifier ff1("ff1");
+    ff1.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+
+    babelwires::Identifier fieldIdC1("fldC1");
+    fieldIdC1.setDiscriminator(1);
+    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+
+    recordFeature.setToDefault();
+
+    const size_t hashC = recordFeature.getHash();
+
+    recordFeature.selectTag(tagA);
+
+    const size_t hashA = recordFeature.getHash();
+    EXPECT_NE(hashA, hashC);
 
     recordFeature.selectTag(tagB);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+    const size_t hashB = recordFeature.getHash();
+    EXPECT_NE(hashB, hashC);
+    EXPECT_NE(hashB, hashA);
+
+    recordFeature.selectTag(tagC);
+
+    const size_t hashC_2 = recordFeature.getHash();
+    EXPECT_EQ(hashC, hashC_2);
+
+    recordFeature.selectTag(tagB);
+
+    const size_t hashB_2 = recordFeature.getHash();
+    EXPECT_EQ(hashB, hashB_2);
+
+    recordFeature.selectTag(tagA);
+
+    const size_t hashA_2 = recordFeature.getHash();
+    EXPECT_EQ(hashA, hashA_2);
+}
+
+TEST(UnionFeatureTest, queries) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    babelwires::Identifier fieldIdC0("fldC0");
+    fieldIdC0.setDiscriminator(1);
+    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+
+    babelwires::Identifier fieldIdA1("fldA1");
+    fieldIdA1.setDiscriminator(1);
+    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+
+    babelwires::Identifier ff1("ff1");
+    ff1.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+
+    babelwires::Identifier fieldIdC1("fldC1");
+    fieldIdC1.setDiscriminator(1);
+    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+
+    // Queries that do not depend on the active state of the union.
+
+    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getTags(), {tagA, tagB, tagC}));
+
+    EXPECT_TRUE(recordFeature.isTag(tagA));
+    EXPECT_TRUE(recordFeature.isTag(tagB));
+    EXPECT_TRUE(recordFeature.isTag(tagC));
+    EXPECT_FALSE(recordFeature.isTag("flerm"));
+    EXPECT_FALSE(recordFeature.isTag(fieldIdA0));
+    EXPECT_FALSE(recordFeature.isTag(ff1));
+
+    EXPECT_EQ(recordFeature.getIndexOfTag(tagA), 0);
+    EXPECT_EQ(recordFeature.getIndexOfTag(tagB), 1);
+    EXPECT_EQ(recordFeature.getIndexOfTag(tagC), 2);
+
+    // Queries that require the union to be in an active state.
+
+    recordFeature.setToDefault();
+
+    EXPECT_EQ(recordFeature.getSelectedTag(), tagC);
+    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 2);
+    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {fieldIdC0, fieldIdC1}));
+
+    recordFeature.selectTag(tagB);
+
+    EXPECT_EQ(recordFeature.getSelectedTag(), tagB);
+    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 1);
+    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {}));
+
+    recordFeature.selectTag(tagA);
+
+    EXPECT_EQ(recordFeature.getSelectedTag(), tagA);
+    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 0);
+    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {fieldIdA0, fieldIdA1}));
 }

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <BabelWiresLib/Features/unionFeature.hpp>
+
+#include <BabelWiresLib/Features/numericFeature.hpp>
+#include <BabelWiresLib/Features/featureMixins.hpp>
+
+#include <Tests/TestUtils/equalSets.hpp>
+
+TEST(UnionFeatureTest, fieldOrder) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 1);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+
+    babelwires::Identifier fieldIdA0("fldA0");
+    fieldIdA0.setDiscriminator(1);
+    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+
+    babelwires::Identifier ff0("ff0");
+    ff0.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+
+    babelwires::Identifier fieldIdC0("fldC0");
+    fieldIdC0.setDiscriminator(1);
+    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+
+    babelwires::Identifier fieldIdA1("fldA1");
+    fieldIdA1.setDiscriminator(1);
+    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+
+    babelwires::Identifier ff1("ff1");
+    ff1.setDiscriminator(1);
+    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+
+    babelwires::Identifier fieldIdC1("fldC1");
+    fieldIdC1.setDiscriminator(1);
+    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+
+    recordFeature.selectTag(tagA);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+
+    recordFeature.selectTag(tagB);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+
+    recordFeature.selectTag(tagC);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+
+    recordFeature.selectTag(tagA);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+
+    recordFeature.selectTag(tagC);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+
+
+    recordFeature.selectTag(tagB);
+
+    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
+    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+}

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <BabelWiresLib/Features/unionFeature.hpp>
-
 #include <BabelWiresLib/Features/numericFeature.hpp>
-#include <BabelWiresLib/Features/featureMixins.hpp>
 
 #include <Tests/TestUtils/equalSets.hpp>
 
@@ -15,94 +13,94 @@ TEST(UnionFeatureTest, fieldOrder) {
     babelwires::Identifier tagC("tagC");
     tagC.setDiscriminator(1);
 
-    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
     babelwires::Identifier fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
-    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
     babelwires::Identifier ff0("ff0");
     ff0.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
     babelwires::Identifier fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
-    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
     babelwires::Identifier fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
-    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+    babelwires::IntFeature* fieldA1 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
     babelwires::Identifier ff1("ff1");
     ff1.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
     babelwires::Identifier fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
-    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+    babelwires::IntFeature* fieldC1 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
 
-    recordFeature.setToDefault();
+    unionFeature.setToDefault();
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
-    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
-    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldC1);
 
-    recordFeature.selectTag(tagB);
+    unionFeature.selectTag(tagB);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 2);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature1);
 
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
-    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(3), fixedFeature1);
 
     // Same tag again.
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
-    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(3), fixedFeature1);
 
-    recordFeature.selectTag(tagB);
+    unionFeature.selectTag(tagB);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 2);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 2);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature1);
 
-    recordFeature.selectTag(tagC);
+    unionFeature.selectTag(tagC);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
-    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
-    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldC1);
 
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fieldA0);
-    EXPECT_EQ(recordFeature.getFeature(1), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(2), fieldA1);
-    EXPECT_EQ(recordFeature.getFeature(3), fixedFeature1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(3), fixedFeature1);
 
-    recordFeature.selectTag(tagC);
+    unionFeature.selectTag(tagC);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 4);
-    EXPECT_EQ(recordFeature.getFeature(0), fixedFeature0);
-    EXPECT_EQ(recordFeature.getFeature(1), fieldC0);
-    EXPECT_EQ(recordFeature.getFeature(2), fixedFeature1);
-    EXPECT_EQ(recordFeature.getFeature(3), fieldC1);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldC1);
 }
 
 TEST(UnionFeatureTest, changes) {
@@ -113,68 +111,68 @@ TEST(UnionFeatureTest, changes) {
     babelwires::Identifier tagC("tagC");
     tagC.setDiscriminator(1);
 
-    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
     babelwires::Identifier fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
-    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
     babelwires::Identifier ff0("ff0");
     ff0.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
     babelwires::Identifier fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
-    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
     babelwires::Identifier fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
-    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+    babelwires::IntFeature* fieldA1 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
     babelwires::Identifier ff1("ff1");
     ff1.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
     babelwires::Identifier fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
-    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+    babelwires::IntFeature* fieldC1 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
 
-    recordFeature.setToDefault();
+    unionFeature.setToDefault();
 
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 
-    recordFeature.clearChanges();
-    recordFeature.selectTag(tagA);
+    unionFeature.clearChanges();
+    unionFeature.selectTag(tagA);
 
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 
-    recordFeature.clearChanges();
+    unionFeature.clearChanges();
     // Same tag again.
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 
-    recordFeature.clearChanges();
-    recordFeature.selectTag(tagB);
+    unionFeature.clearChanges();
+    unionFeature.selectTag(tagB);
 
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 
-    recordFeature.clearChanges();
-    recordFeature.selectTag(tagC);
+    unionFeature.clearChanges();
+    unionFeature.selectTag(tagC);
 
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
-    EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
-    EXPECT_TRUE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::SomethingChanged));
+    EXPECT_FALSE(unionFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
+    EXPECT_TRUE(unionFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 }
 
 TEST(UnionFeatureTest, hash) {
@@ -185,62 +183,62 @@ TEST(UnionFeatureTest, hash) {
     babelwires::Identifier tagC("tagC");
     tagC.setDiscriminator(1);
 
-    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
     babelwires::Identifier fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
-    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
     babelwires::Identifier ff0("ff0");
     ff0.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
     babelwires::Identifier fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
-    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
     babelwires::Identifier fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
-    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+    babelwires::IntFeature* fieldA1 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
     babelwires::Identifier ff1("ff1");
     ff1.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
     babelwires::Identifier fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
-    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+    babelwires::IntFeature* fieldC1 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
 
-    recordFeature.setToDefault();
+    unionFeature.setToDefault();
 
-    const size_t hashC = recordFeature.getHash();
+    const size_t hashC = unionFeature.getHash();
 
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    const size_t hashA = recordFeature.getHash();
+    const size_t hashA = unionFeature.getHash();
     EXPECT_NE(hashA, hashC);
 
-    recordFeature.selectTag(tagB);
+    unionFeature.selectTag(tagB);
 
-    const size_t hashB = recordFeature.getHash();
+    const size_t hashB = unionFeature.getHash();
     EXPECT_NE(hashB, hashC);
     EXPECT_NE(hashB, hashA);
 
-    recordFeature.selectTag(tagC);
+    unionFeature.selectTag(tagC);
 
-    const size_t hashC_2 = recordFeature.getHash();
+    const size_t hashC_2 = unionFeature.getHash();
     EXPECT_EQ(hashC, hashC_2);
 
-    recordFeature.selectTag(tagB);
+    unionFeature.selectTag(tagB);
 
-    const size_t hashB_2 = recordFeature.getHash();
+    const size_t hashB_2 = unionFeature.getHash();
     EXPECT_EQ(hashB, hashB_2);
 
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    const size_t hashA_2 = recordFeature.getHash();
+    const size_t hashA_2 = unionFeature.getHash();
     EXPECT_EQ(hashA, hashA_2);
 }
 
@@ -252,66 +250,66 @@ TEST(UnionFeatureTest, queries) {
     babelwires::Identifier tagC("tagC");
     tagC.setDiscriminator(1);
 
-    babelwires::UnionFeature recordFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
-    EXPECT_EQ(recordFeature.getNumFeatures(), 0);
+    EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
     babelwires::Identifier fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
-    babelwires::IntFeature* fieldA0 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
     babelwires::Identifier ff0("ff0");
     ff0.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
     babelwires::Identifier fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
-    babelwires::IntFeature* fieldC0 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
     babelwires::Identifier fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
-    babelwires::IntFeature* fieldA1 = recordFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+    babelwires::IntFeature* fieldA1 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
     babelwires::Identifier ff1("ff1");
     ff1.setDiscriminator(1);
-    babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
     babelwires::Identifier fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
-    babelwires::IntFeature* fieldC1 = recordFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+    babelwires::IntFeature* fieldC1 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
 
     // Queries that do not depend on the active state of the union.
 
-    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getTags(), {tagA, tagB, tagC}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getTags(), {tagA, tagB, tagC}));
 
-    EXPECT_TRUE(recordFeature.isTag(tagA));
-    EXPECT_TRUE(recordFeature.isTag(tagB));
-    EXPECT_TRUE(recordFeature.isTag(tagC));
-    EXPECT_FALSE(recordFeature.isTag("flerm"));
-    EXPECT_FALSE(recordFeature.isTag(fieldIdA0));
-    EXPECT_FALSE(recordFeature.isTag(ff1));
+    EXPECT_TRUE(unionFeature.isTag(tagA));
+    EXPECT_TRUE(unionFeature.isTag(tagB));
+    EXPECT_TRUE(unionFeature.isTag(tagC));
+    EXPECT_FALSE(unionFeature.isTag("flerm"));
+    EXPECT_FALSE(unionFeature.isTag(fieldIdA0));
+    EXPECT_FALSE(unionFeature.isTag(ff1));
 
-    EXPECT_EQ(recordFeature.getIndexOfTag(tagA), 0);
-    EXPECT_EQ(recordFeature.getIndexOfTag(tagB), 1);
-    EXPECT_EQ(recordFeature.getIndexOfTag(tagC), 2);
+    EXPECT_EQ(unionFeature.getIndexOfTag(tagA), 0);
+    EXPECT_EQ(unionFeature.getIndexOfTag(tagB), 1);
+    EXPECT_EQ(unionFeature.getIndexOfTag(tagC), 2);
 
     // Queries that require the union to be in an active state.
 
-    recordFeature.setToDefault();
+    unionFeature.setToDefault();
 
-    EXPECT_EQ(recordFeature.getSelectedTag(), tagC);
-    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 2);
-    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {fieldIdC0, fieldIdC1}));
+    EXPECT_EQ(unionFeature.getSelectedTag(), tagC);
+    EXPECT_EQ(unionFeature.getSelectedTagIndex(), 2);
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {fieldIdC0, fieldIdC1}));
 
-    recordFeature.selectTag(tagB);
+    unionFeature.selectTag(tagB);
 
-    EXPECT_EQ(recordFeature.getSelectedTag(), tagB);
-    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 1);
-    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {}));
+    EXPECT_EQ(unionFeature.getSelectedTag(), tagB);
+    EXPECT_EQ(unionFeature.getSelectedTagIndex(), 1);
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {}));
 
-    recordFeature.selectTag(tagA);
+    unionFeature.selectTag(tagA);
 
-    EXPECT_EQ(recordFeature.getSelectedTag(), tagA);
-    EXPECT_EQ(recordFeature.getSelectedTagIndex(), 0);
-    EXPECT_TRUE(testUtils::areEqualSets(recordFeature.getFieldsOfSelectedBranch(), {fieldIdA0, fieldIdA1}));
+    EXPECT_EQ(unionFeature.getSelectedTag(), tagA);
+    EXPECT_EQ(unionFeature.getSelectedTagIndex(), 0);
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {fieldIdA0, fieldIdA1}));
 }


### PR DESCRIPTION
A "tagged union" / "sum type" / "disjunction type" kind of feature: It allows records to offer alternative sets of fields.

Worth knowing:
1. It's a normal record, so fields can be added which are not affected by the selected tag.
2. A tag need not have any associated fields, in which case only the normal fields are available.
3. If you have modifications on fields in a branch and you change tag, those modifications do not return if you switch back to the earlier tag. (They are restored by undo, however.)

Future work:
* Allow changes to be deeper than just fields of the union. Implementation idea: 
    * Preserve any modifier in the old selected branch whose path will still resolve in the newly selected branch.
    * This is sufficient, because a union author can put _similar_ compound features in more than one branch, labelled with an equivalent field identifier (discriminators would not have to agree, I think).