### PR TITLE
Unions with overlapping branches

### DIFF
--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -120,22 +120,23 @@ babelwires::UnionFeature::getFieldsRemovedByChangeOfBranch(Identifier proposedTa
 
 babelwires::UnionFeature::BranchAdjustment babelwires::UnionFeature::getBranchAdjustment(unsigned int tagIndex) const {
     assert((tagIndex != m_selectedTagIndex) && "Same branch");
-    std::vector<Identifier> currentBranch;
+    std::vector<Identifier> fieldsToRemove;
     if (m_selectedTagIndex >= 0) {
-        currentBranch = m_fieldsInBranches[m_selectedTagIndex];
+        fieldsToRemove = m_fieldsInBranches[m_selectedTagIndex];
     }
-    std::vector<Identifier> newBranch = m_fieldsInBranches[tagIndex];
+    const std::vector<Identifier>& targetBranch = m_fieldsInBranches[tagIndex];
+    std::vector<Identifier> fieldsToAdd = targetBranch;
     // This doesn't need to be N^2, but these vectors are likely to be very small, so it's fine.
-    currentBranch.erase(std::remove_if(currentBranch.begin(), currentBranch.end(),
-                                       [&newBranch](auto t) {
-                                           return std::find(newBranch.begin(), newBranch.end(), t) != newBranch.end();
-                                       }),
-                        currentBranch.end());
-    newBranch.erase(std::remove_if(newBranch.begin(), newBranch.end(),
-                                   [&currentBranch](auto t) {
-                                       return std::find(currentBranch.begin(), currentBranch.end(), t) !=
-                                              currentBranch.end();
+    fieldsToAdd.erase(std::remove_if(fieldsToAdd.begin(), fieldsToAdd.end(),
+                                   [&fieldsToRemove](auto t) {
+                                       return std::find(fieldsToRemove.begin(), fieldsToRemove.end(), t) !=
+                                              fieldsToRemove.end();
                                    }),
-                    newBranch.end());
-    return BranchAdjustment{currentBranch, newBranch};
+                    fieldsToAdd.end());
+    fieldsToRemove.erase(std::remove_if(fieldsToRemove.begin(), fieldsToRemove.end(),
+                                       [&targetBranch](auto t) {
+                                           return std::find(targetBranch.begin(), targetBranch.end(), t) != targetBranch.end();
+                                       }),
+                        fieldsToRemove.end());
+    return BranchAdjustment{fieldsToRemove, fieldsToAdd};
 }

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -9,23 +9,33 @@
 
 #include <BabelWiresLib/Features/modelExceptions.hpp>
 
-babelwires::UnionFeature::UnionFeature(TagValues tags, unsigned int defaultTagIndex) 
+babelwires::UnionFeature::UnionFeature(TagValues tags, unsigned int defaultTagIndex)
     : m_tags(std::move(tags))
-    , m_defaultTagIndex(defaultTagIndex)
-{
+    , m_defaultTagIndex(defaultTagIndex) {
     assert((m_defaultTagIndex < m_tags.size()) && "defaultTagIndex is out of range");
-    assert(std::all_of(m_tags.begin(), m_tags.end(), [](const auto& t) {return t.getDiscriminator() != 0;}) && "Union tags must be registered identifiers");
-    m_unselectedBranches.resize(m_tags.size());
+    assert(std::all_of(m_tags.begin(), m_tags.end(), [](const auto& t) { return t.getDiscriminator() != 0; }) &&
+           "Union tags must be registered identifiers");
+    m_fieldsInBranches.resize(m_tags.size());
 }
 
-void babelwires::UnionFeature::addFieldInBranchInternal(const Identifier& tag, FieldAndIndex fieldAndIndex) {
-    assert(isTag(tag) && "The tag is not a valid tag for this union");
-    const unsigned int tagIndex = getIndexOfTag(tag);
-    // All branches are unselected until the union is set to default. This ensures the stored indices are correct.
-    UnselectedBranch& unselectedBranch = m_unselectedBranches[tagIndex];
-    // Each field already added for this branch will bump the target location of the new field by one.
-    fieldAndIndex.m_index += unselectedBranch.m_inactiveFields.size();
-    unselectedBranch.m_inactiveFields.emplace_back(std::move(fieldAndIndex));
+void babelwires::UnionFeature::addFieldInBranchesInternal(const std::vector<Identifier>& tags, Field field) {
+    assert((tags.size() > 0) && "Each branch field must be associated with at least one tag");
+    assert((tryGetChildFromStep(PathStep{field.m_identifier}) == nullptr) &&
+           "Field identifier already used in the main record");
+    assert((m_fieldInfo.find(field.m_identifier) == m_fieldInfo.end()) &&
+           "Field identifier already used in another branch");
+
+    const int numRecordFeatures = getNumFeatures();
+    auto& fieldInfo = m_fieldInfo[field.m_identifier];
+    fieldInfo.m_feature = std::move(field.m_feature);
+    fieldInfo.m_feature->setToDefault();
+    for (const auto& tag : tags) {
+        unsigned int tagIndex = getIndexOfTag(tag);
+        auto& tagToBranchFieldIndices = m_fieldsInBranches[tagIndex];
+        fieldInfo.m_tagsWithIntendedIndices.emplace_back(TagIndexAndIntendedFieldIndex{
+            tagIndex, numRecordFeatures + static_cast<int>(tagToBranchFieldIndices.size())});
+        tagToBranchFieldIndices.emplace_back(field.m_identifier);
+    }
 }
 
 void babelwires::UnionFeature::selectTag(Identifier tag) {
@@ -45,31 +55,24 @@ void babelwires::UnionFeature::selectTagByIndex(unsigned int index) {
         return;
     }
 
-    if (m_selectedTagIndex >= 0) {
-        UnselectedBranch& newUnselectedBranch = m_unselectedBranches[m_selectedTagIndex];
-        assert(newUnselectedBranch.m_inactiveFields.empty() && "The unselected branch object of the selected tag should be empty");
+    BranchAdjustment adjustment = getBranchAdjustment(index);
 
-        // Deactivate the fields in the currently selected branch.
-
-        // Iterate in reverse order, so the fieldAndIndex picks up the correct indices.
-        for (auto identifier : reverseIterate(m_selectedBranch.m_activeFields)) {
-            FieldAndIndex fieldAndIndex = removeField(identifier);
-            fieldAndIndex.m_feature->setToDefault();
-            newUnselectedBranch.m_inactiveFields.emplace_back(std::move(fieldAndIndex));
-        }
-        std::reverse(newUnselectedBranch.m_inactiveFields.begin(), newUnselectedBranch.m_inactiveFields.end());
-
-        m_selectedBranch.m_activeFields.clear();
+    for (auto fieldIdentifier : adjustment.m_fieldsToRemove) {
+        FieldInfo& fieldInfo = m_fieldInfo[fieldIdentifier];
+        assert((fieldInfo.m_feature == nullptr) && "The fieldInfo of an active field must be unset");
+        FieldAndIndex fieldAndIndex = removeField(fieldIdentifier);
+        fieldInfo.m_feature.swap(fieldAndIndex.m_feature);
+        fieldInfo.m_feature->setToDefault();
     }
 
-    // Activate the fields in the unselectedBranch.
+    for (auto fieldIdentifier : adjustment.m_fieldsToAdd) {
+        FieldInfo& fieldInfo = m_fieldInfo[fieldIdentifier];
+        assert((fieldInfo.m_feature != nullptr) && "The fieldInfo of an inactive field must be set");
 
-    decltype(UnselectedBranch::m_inactiveFields) oldUnselectedFields;
-    oldUnselectedFields.swap(m_unselectedBranches[index].m_inactiveFields);
-
-    for (auto& fieldAndIndex : oldUnselectedFields) {
-        m_selectedBranch.m_activeFields.emplace_back(fieldAndIndex.m_identifier);
-        addFieldAndIndexInternal(std::move(fieldAndIndex));
+        auto it = std::find_if(fieldInfo.m_tagsWithIntendedIndices.begin(), fieldInfo.m_tagsWithIntendedIndices.end(),
+                            [index](const auto& tagAndField) { return tagAndField.m_tagIndex == index; });
+        assert((it != fieldInfo.m_tagsWithIntendedIndices.end()) && "The tag does not have this field in its branch");
+        addFieldAndIndexInternal(FieldAndIndex{fieldIdentifier, std::move(fieldInfo.m_feature), it->m_fieldIndex});
     }
 
     m_selectedTagIndex = index;
@@ -84,17 +87,12 @@ bool babelwires::UnionFeature::isTag(Identifier tag) const {
 }
 
 void babelwires::UnionFeature::doSetToDefault() {
+    // Inactive fields should all be in a default state.
     setToDefaultNonRecursive();
     setSubfeaturesToDefault();
 }
 
 void babelwires::UnionFeature::doSetToDefaultNonRecursive() {
-    for (auto& unselectedBranch : m_unselectedBranches) {
-        for (auto& inactiveField : unselectedBranch.m_inactiveFields) {
-            // After construction, these may not have been set to their default state.
-            inactiveField.m_feature->setToDefault();
-        }
-    }
     selectTagByIndex(m_defaultTagIndex);
 }
 
@@ -113,6 +111,31 @@ unsigned int babelwires::UnionFeature::getIndexOfTag(Identifier tag) const {
     return it - m_tags.begin();
 }
 
-const std::vector<babelwires::Identifier>& babelwires::UnionFeature::getFieldsOfSelectedBranch() const {
-    return m_selectedBranch.m_activeFields;
+std::vector<babelwires::Identifier>
+babelwires::UnionFeature::getFieldsRemovedByChangeOfBranch(Identifier proposedTag) const {
+    unsigned int tagIndex = getIndexOfTag(proposedTag);
+    babelwires::UnionFeature::BranchAdjustment branchAdjustment = getBranchAdjustment(tagIndex);
+    return std::move(branchAdjustment.m_fieldsToRemove);
+}
+
+babelwires::UnionFeature::BranchAdjustment babelwires::UnionFeature::getBranchAdjustment(unsigned int tagIndex) const {
+    assert((tagIndex != m_selectedTagIndex) && "Same branch");
+    std::vector<Identifier> currentBranch;
+    if (m_selectedTagIndex >= 0) {
+        currentBranch = m_fieldsInBranches[m_selectedTagIndex];
+    }
+    std::vector<Identifier> newBranch = m_fieldsInBranches[tagIndex];
+    // This doesn't need to be N^2, but these vectors are likely to be very small, so it's fine.
+    currentBranch.erase(std::remove_if(currentBranch.begin(), currentBranch.end(),
+                                       [&newBranch](auto t) {
+                                           return std::find(newBranch.begin(), newBranch.end(), t) != newBranch.end();
+                                       }),
+                        currentBranch.end());
+    newBranch.erase(std::remove_if(newBranch.begin(), newBranch.end(),
+                                   [&currentBranch](auto t) {
+                                       return std::find(currentBranch.begin(), currentBranch.end(), t) !=
+                                              currentBranch.end();
+                                   }),
+                    newBranch.end());
+    return BranchAdjustment{currentBranch, newBranch};
 }

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
@@ -53,7 +53,7 @@ bool babelwires::SelectUnionBranchCommand::initializeAndExecute(Project& project
         m_unionModifierToRemove = modifier->getModifierData().clone();
     }
 
-    for (const auto& field : unionFeature->getFieldsOfSelectedBranch()) {
+    for (const auto& field : unionFeature->getFieldsRemovedByChangeOfBranch(m_tagToSelect)) {
         FeaturePath pathToField = m_pathToUnion;
         pathToField.pushStep(PathStep(field));
         addSubCommand(std::make_unique<RemoveAllEditsCommand>("Remove union branch subcommand", m_elementId, pathToField));

--- a/Common/Identifiers/identifier.hpp
+++ b/Common/Identifiers/identifier.hpp
@@ -64,7 +64,7 @@ namespace babelwires {
         /// The maximum number of characters which can be contained.
         static constexpr unsigned int N = (NUM_BLOCKS * sizeof(std::uint64_t)) - 2;
 
-        IdentifierBase() : IdentifierBase("unset") {}
+        IdentifierBase() : IdentifierBase("_unset") {}
 
         /// Constructor from a string literal.
         template <unsigned int M, typename std::enable_if_t<(1 < M) && (M <= N), int> = 0>

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
@@ -14,6 +14,10 @@ const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldA1 =
     babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldA1IdInitializer);
 const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0 =
     babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldAB =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldABIdInitializer);
+const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldBC =
+    babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldBCIdInitializer);
 
 const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0_Array_1 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_arrayIdInitializer + "/1");
 const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0_Int2 = babelwires::FeaturePath::deserializeFromString(std::string(testUtils::TestFeatureWithUnion::s_unionFeatureIdInitializer) + "/" + testUtils::TestFeatureWithUnion::s_fieldB0IdInitializer + "/" + testUtils::TestRecordFeature::s_recordIdInitializer + "/" + testUtils::TestRecordFeature::s_int2IdInitializer);
@@ -24,6 +28,8 @@ testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectC
           s_tagAIdInitializer, s_tagAFieldName, s_tagAUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_tagBId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
           s_tagBIdInitializer, s_tagBFieldName, s_tagBUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_tagCId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_tagCIdInitializer, s_tagCFieldName, s_tagCUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_unionFeatureId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
           s_unionFeatureIdInitializer, s_unionFeatureFieldName, s_unionFeatureUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
@@ -35,9 +41,13 @@ testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectC
     , m_fieldA1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
           s_fieldA1IdInitializer, s_fieldA1FieldName, s_fieldA1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_fieldB0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
-          s_fieldB0IdInitializer, s_fieldB0FieldName, s_fieldB0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
+          s_fieldB0IdInitializer, s_fieldB0FieldName, s_fieldB0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_fieldABId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_fieldABIdInitializer, s_fieldABFieldName, s_fieldABUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
+    , m_fieldBCId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+          s_fieldBCIdInitializer, s_fieldBCFieldName, s_fieldBCUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
     {
-        auto testUnionFeaturePtr = std::make_unique<babelwires::UnionFeature>(babelwires::UnionFeature::TagValues{m_tagAId, m_tagBId}, 1);
+        auto testUnionFeaturePtr = std::make_unique<babelwires::UnionFeature>(babelwires::UnionFeature::TagValues{m_tagAId, m_tagBId, m_tagCId}, 1);
         m_unionFeature = testUnionFeaturePtr.get();
         addField(std::move(testUnionFeaturePtr), m_unionFeatureId);
     }
@@ -58,6 +68,11 @@ testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectC
     }
     {
         auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
+        m_fieldABFeature = intFeaturePtr.get();
+        m_unionFeature->addFieldInBranches({m_tagAId, m_tagBId}, std::move(intFeaturePtr), m_fieldABId);
+    }
+    {
+        auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
         m_fieldA1Feature = intFeaturePtr.get();
         m_unionFeature->addFieldInBranch(m_tagAId, std::move(intFeaturePtr), m_fieldA1Id);
     }
@@ -65,6 +80,11 @@ testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectC
         auto testRecordFeaturePtr = std::make_unique<testUtils::TestRecordFeature>();
         m_ff1Feature = testRecordFeaturePtr.get();
         m_unionFeature->addField(std::move(testRecordFeaturePtr), m_ff1Id);
+    }
+    {
+        auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
+        m_fieldBCFeature = intFeaturePtr.get();
+        m_unionFeature->addFieldInBranches({m_tagBId, m_tagCId}, std::move(intFeaturePtr), m_fieldBCId);
     }
 }
 

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
@@ -16,40 +16,52 @@ namespace testUtils {
 
         static constexpr char s_tagAIdInitializer[] = "tagA";
         static constexpr char s_tagBIdInitializer[] = "tagB";
+        static constexpr char s_tagCIdInitializer[] = "tagC";
         static constexpr char s_unionFeatureIdInitializer[] = "subrd";
         static constexpr char s_ff0IdInitializer[] = "ff0";
         static constexpr char s_ff1IdInitializer[] = "ff1";
         static constexpr char s_fieldA0IdInitializer[] = "A0";
         static constexpr char s_fieldA1IdInitializer[] = "A1";
         static constexpr char s_fieldB0IdInitializer[] = "B0";
-
+        static constexpr char s_fieldABIdInitializer[] = "AB";
+        static constexpr char s_fieldBCIdInitializer[] = "BC";
+        
         static constexpr char s_tagAFieldName[] = "tagA";
         static constexpr char s_tagBFieldName[] = "tagB";
+        static constexpr char s_tagCFieldName[] = "tagC";
         static constexpr char s_unionFeatureFieldName[] = "union";
         static constexpr char s_ff0FieldName[] = "fixed field 0";
         static constexpr char s_ff1FieldName[] = "fixed field 1";
         static constexpr char s_fieldA0FieldName[] = "branch A field 0";
         static constexpr char s_fieldA1FieldName[] = "branch A field 1";
         static constexpr char s_fieldB0FieldName[] = "branch B field 0";
+        static constexpr char s_fieldABFieldName[] = "branch AB";
+        static constexpr char s_fieldBCFieldName[] = "branch BC";
 
         static constexpr char s_tagAUuid[] = "00000000-1111-2222-3333-88000000000A";
         static constexpr char s_tagBUuid[] = "00000000-1111-2222-3333-88000000000B";
+        static constexpr char s_tagCUuid[] = "00000000-1111-2222-3333-88000000000C";
         static constexpr char s_unionFeatureUuid[] = "00000000-1111-2222-3333-880000000000";
         static constexpr char s_ff0Uuid[] = "00000000-1111-2222-3333-880000000001";
         static constexpr char s_ff1Uuid[] = "00000000-1111-2222-3333-880000000002";
         static constexpr char s_fieldA0Uuid[] = "00000000-1111-2222-3333-8800000000A0";
         static constexpr char s_fieldA1Uuid[] = "00000000-1111-2222-3333-8800000000A1";
         static constexpr char s_fieldB0Uuid[] = "00000000-1111-2222-3333-8800000000B0";
+        static constexpr char s_fieldABUuid[] = "00000000-1111-2222-3333-8800000000AB";
+        static constexpr char s_fieldBCUuid[] = "00000000-1111-2222-3333-8800000000BC";
 
         // Note: tagB is the default.
         babelwires::Identifier m_tagAId;
         babelwires::Identifier m_tagBId;
+        babelwires::Identifier m_tagCId;
         babelwires::Identifier m_unionFeatureId;
         babelwires::Identifier m_ff0Id;
         babelwires::Identifier m_ff1Id;
         babelwires::Identifier m_fieldA0Id;
         babelwires::Identifier m_fieldA1Id;
         babelwires::Identifier m_fieldB0Id;
+        babelwires::Identifier m_fieldABId;
+        babelwires::Identifier m_fieldBCId;
 
         babelwires::UnionFeature* m_unionFeature;
         babelwires::IntFeature* m_ff0Feature;
@@ -57,6 +69,8 @@ namespace testUtils {
         babelwires::IntFeature* m_fieldA0Feature;
         babelwires::IntFeature* m_fieldA1Feature;
         testUtils::TestRecordFeature* m_fieldB0Feature;
+        babelwires::IntFeature* m_fieldABFeature;
+        babelwires::IntFeature* m_fieldBCFeature;
 
         // For convenience
         static const babelwires::FeaturePath s_pathToUnionFeature;
@@ -68,6 +82,9 @@ namespace testUtils {
 
         static const babelwires::FeaturePath s_pathToFieldB0_Array_1;
         static const babelwires::FeaturePath s_pathToFieldB0_Int2;
+
+        static const babelwires::FeaturePath s_pathToFieldAB;
+        static const babelwires::FeaturePath s_pathToFieldBC;
     };
 
     struct TestFeatureElementWithUnionData : babelwires::ElementData {

--- a/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
@@ -151,7 +151,7 @@ TEST(SelectUnionBranchCommandTest, failSafelyNoOptional) {
     EXPECT_FALSE(command.initializeAndExecute(testEnvironment.m_project));
 }
 
-TEST(DeactivateOptionalsCommandTest, failSafelyAlreadySelected) {
+TEST(SelectUnionBranchCommandTest, failSafelyAlreadySelected) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
 

--- a/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
@@ -54,6 +54,18 @@ TEST(SelectUnionBranchCommandTest, executeAndUndo) {
         outputConnection.m_sourceId = elementId;
         testEnvironment.m_project.addModifier(targetId, outputConnection);
     }
+    {
+        babelwires::IntValueAssignmentData assignInt;
+        assignInt.m_pathToFeature = testUtils::TestFeatureWithUnion::s_pathToFieldAB;
+        assignInt.m_value = 12;
+        testEnvironment.m_project.addModifier(elementId, assignInt);
+    }
+    {
+        babelwires::IntValueAssignmentData assignInt;
+        assignInt.m_pathToFeature = testUtils::TestFeatureWithUnion::s_pathToFieldBC;
+        assignInt.m_value = 4;
+        testEnvironment.m_project.addModifier(elementId, assignInt);
+    }
 
     const auto checkModifiers = [&testEnvironment, element, targetElement](bool isCommandExecuted) {
         const babelwires::Modifier* inputConnection =
@@ -71,12 +83,12 @@ TEST(SelectUnionBranchCommandTest, executeAndUndo) {
         if (isCommandExecuted) {
             EXPECT_EQ(inputConnection, nullptr);
             EXPECT_EQ(outputConnection, nullptr);
-            EXPECT_EQ(numModifiersAtElement, 1);
+            EXPECT_EQ(numModifiersAtElement, 2);
             EXPECT_EQ(numModifiersAtTarget, 0);
         } else {
             EXPECT_NE(inputConnection, nullptr);
             EXPECT_NE(outputConnection, nullptr);
-            EXPECT_EQ(numModifiersAtElement, 2);
+            EXPECT_EQ(numModifiersAtElement, 4);
             EXPECT_EQ(numModifiersAtTarget, 1);
         }
     };

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -4,6 +4,7 @@
 #include <BabelWiresLib/Features/numericFeature.hpp>
 
 #include <Tests/TestUtils/equalSets.hpp>
+#include <Tests/TestUtils/testIdentifiers.hpp>
 
 TEST(UnionFeatureTest, fieldOrder) {
     babelwires::Identifier tagA("tagA");
@@ -101,6 +102,116 @@ TEST(UnionFeatureTest, fieldOrder) {
     EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
     EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
     EXPECT_EQ(unionFeature.getFeature(3), fieldC1);
+}
+
+TEST(UnionFeatureTest, fieldOrderWithOverlappingBranches) {
+    babelwires::Identifier tagA("tagA");
+    tagA.setDiscriminator(1);
+    babelwires::Identifier tagB("tagB");
+    tagB.setDiscriminator(1);
+    babelwires::Identifier tagC("tagC");
+    tagC.setDiscriminator(1);
+
+    babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 0);
+
+    babelwires::Identifier fieldIdA0 = testUtils::getTestRegisteredIdentifier("fldA0");
+    babelwires::Identifier ff0 = testUtils::getTestRegisteredIdentifier("ff0");
+    babelwires::Identifier fieldIdAB = testUtils::getTestRegisteredIdentifier("fldAB");
+    babelwires::Identifier fieldIdC0 = testUtils::getTestRegisteredIdentifier("fldC0");
+    babelwires::Identifier fieldIdA1 = testUtils::getTestRegisteredIdentifier("fldA1");
+    babelwires::Identifier ff1 = testUtils::getTestRegisteredIdentifier("ff1");
+    babelwires::Identifier fieldIdBC = testUtils::getTestRegisteredIdentifier("fldBC");
+    babelwires::Identifier fieldIdC1 = testUtils::getTestRegisteredIdentifier("fldC1");
+    babelwires::Identifier fieldIdAC = testUtils::getTestRegisteredIdentifier("fldAC");
+
+    babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
+    babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
+    babelwires::IntFeature* fieldAB = unionFeature.addFieldInBranches({tagA, tagB}, std::make_unique<babelwires::IntFeature>(), fieldIdAB);
+    babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
+    babelwires::IntFeature* fieldA1 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
+    babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
+    babelwires::IntFeature* fieldBC = unionFeature.addFieldInBranches({tagB, tagC}, std::make_unique<babelwires::IntFeature>(), fieldIdBC);
+    babelwires::IntFeature* fieldC1 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
+    babelwires::IntFeature* fieldAC = unionFeature.addFieldInBranches({tagA, tagC}, std::make_unique<babelwires::IntFeature>(), fieldIdAC);
+    
+    unionFeature.setToDefault();
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldBC);
+    EXPECT_EQ(unionFeature.getFeature(4), fieldC1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
+
+    unionFeature.selectTag(tagB);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldAB);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldBC);
+
+    unionFeature.selectTag(tagA);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldAB);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(4), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
+
+    // Same tag again.
+    unionFeature.selectTag(tagA);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldAB);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(4), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
+
+    unionFeature.selectTag(tagB);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 4);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldAB);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldBC);
+
+    unionFeature.selectTag(tagC);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldBC);
+    EXPECT_EQ(unionFeature.getFeature(4), fieldC1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
+
+    unionFeature.selectTag(tagA);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fieldA0);
+    EXPECT_EQ(unionFeature.getFeature(1), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(2), fieldAB);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldA1);
+    EXPECT_EQ(unionFeature.getFeature(4), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
+
+    unionFeature.selectTag(tagC);
+
+    EXPECT_EQ(unionFeature.getNumFeatures(), 6);
+    EXPECT_EQ(unionFeature.getFeature(0), fixedFeature0);
+    EXPECT_EQ(unionFeature.getFeature(1), fieldC0);
+    EXPECT_EQ(unionFeature.getFeature(2), fixedFeature1);
+    EXPECT_EQ(unionFeature.getFeature(3), fieldBC);
+    EXPECT_EQ(unionFeature.getFeature(4), fieldC1);
+    EXPECT_EQ(unionFeature.getFeature(5), fieldAC);
 }
 
 TEST(UnionFeatureTest, changes) {

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -299,17 +299,20 @@ TEST(UnionFeatureTest, queries) {
 
     EXPECT_EQ(unionFeature.getSelectedTag(), tagC);
     EXPECT_EQ(unionFeature.getSelectedTagIndex(), 2);
-    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {fieldIdC0, fieldIdC1}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagA), {fieldIdC0, fieldIdC1}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagB), {fieldIdC0, fieldIdC1}));
 
     unionFeature.selectTag(tagB);
 
     EXPECT_EQ(unionFeature.getSelectedTag(), tagB);
     EXPECT_EQ(unionFeature.getSelectedTagIndex(), 1);
-    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagA), {}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagC), {}));
 
     unionFeature.selectTag(tagA);
 
     EXPECT_EQ(unionFeature.getSelectedTag(), tagA);
     EXPECT_EQ(unionFeature.getSelectedTagIndex(), 0);
-    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsOfSelectedBranch(), {fieldIdA0, fieldIdA1}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagB), {fieldIdA0, fieldIdA1}));
+    EXPECT_TRUE(testUtils::areEqualSets(unionFeature.getFieldsRemovedByChangeOfBranch(tagC), {fieldIdA0, fieldIdA1}));
 }


### PR DESCRIPTION
When a union has three or more branches, there are cases where we want subfeatures to be common to some but not all branches.