### PR TITLE
Fix new connections with no collapse features

### DIFF
--- a/BabelWiresLib/Features/features.hpp
+++ b/BabelWiresLib/Features/features.hpp
@@ -70,6 +70,7 @@ namespace babelwires {
         };
 
         /// How should this feature appear in a feature element?
+        /// The system assumes that styles do not change over the lifetime of a feature.
         virtual Style getStyle() const;
 
       protected:

--- a/BabelWiresLib/Project/Commands/removeAllEditsCommand.cpp
+++ b/BabelWiresLib/Project/Commands/removeAllEditsCommand.cpp
@@ -63,7 +63,7 @@ bool babelwires::RemoveAllEditsCommand::initialize(const Project& project) {
         }
     }
 
-    const auto pathsInThisEntry = elementToModify->getEdits().getAllExpandedPaths(m_pathToFeature);
+    const auto pathsInThisEntry = elementToModify->getEdits().getAllExplicitlyExpandedPaths(m_pathToFeature);
     m_expandedPathsRemoved.insert(m_expandedPathsRemoved.end(), pathsInThisEntry.begin(),
                                                pathsInThisEntry.end());
 

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -36,7 +36,7 @@ babelwires::ContentsCacheEntry::ContentsCacheEntry(std::string label, const Feat
     , m_hasFailedHiddenModifiers(false)
     , m_hasSubModifiers(false) {}
 
-babelwires::ContentsCache::ContentsCache(const EditTree& edits)
+babelwires::ContentsCache::ContentsCache(EditTree& edits)
     : m_edits(edits) {}
 
 namespace {
@@ -55,7 +55,7 @@ namespace babelwires {
     namespace Detail {
 
         struct ContentsCacheBuilder {
-            ContentsCacheBuilder(std::vector<ContentsCacheEntry>& rows, const EditTree& edits)
+            ContentsCacheBuilder(std::vector<ContentsCacheEntry>& rows, EditTree& edits)
                 : m_identifierRegistry(IdentifierRegistry::read())
                 , m_rows(rows)
                 , m_edits(edits) {}
@@ -77,6 +77,9 @@ namespace babelwires {
                         return row.m_isExpanded;
                     }
                 } else {
+                    if (path.getNumSteps() > 0) {
+                        m_edits.setImplicitlyExpanded(path, true);
+                    }
                     row.m_isExpandable = false;
                 }
                 return true;
@@ -232,7 +235,7 @@ namespace babelwires {
 
             IdentifierRegistry::ReadAccess m_identifierRegistry;
             std::vector<ContentsCacheEntry>& m_rows;
-            const EditTree& m_edits;
+            EditTree& m_edits;
         };
 
     } // namespace Detail
@@ -279,7 +282,7 @@ void babelwires::ContentsCache::updateModifierFlags() {
         return;
     }
 
-    using Iterator = EditTree::Iterator<const EditTree>;
+    using Iterator = EditTree::Iterator<EditTree>;
 
     struct StackData {
         StackData(int index)
@@ -302,7 +305,7 @@ void babelwires::ContentsCache::updateModifierFlags() {
 
     for (int index = 0; index < m_rows.size(); ++index) {
         if (index > 0) {
-            // See if there is an approrpriate editTree iterator in the parent's set.
+            // See if there is an appropriate editTree iterator in the parent's set.
             stackDataStack.emplace_back(index);
             const PathStep& stepToHere = m_rows[index].m_path.getLastStep();
             StackData& parentStackData = stackDataStack[stackDataStack.size() - 2];

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
@@ -2,7 +2,7 @@
  * The ContentsCache summarizes the contents of a FeatureElement visible to the user.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -25,7 +25,7 @@ namespace babelwires {
     class ContentsCache;
 
     namespace Detail {
-      struct ContentsCacheBuilder;
+        struct ContentsCacheBuilder;
     }
 
     /// The information cached about a single row in the contents of a feature element.
@@ -104,7 +104,8 @@ namespace babelwires {
         /// The EditTree object is never replaced, so we can keep a reference.
         /// (The input/output features can change (e.g. after a reload) so we
         /// can't store them in this object.)
-        ContentsCache(const EditTree& edits);
+        /// Non-const because of features with a not collapsable style.
+        ContentsCache(EditTree& edits);
 
         /// Build the cache with the given input and output features.
         void setFeatures(const RootFeature* inputFeature, const RootFeature* outputFeature);
@@ -150,7 +151,11 @@ namespace babelwires {
       private:
         /// The rows of the contents. The first row may be hidden if there's no useful information there.
         std::vector<ContentsCacheEntry> m_rows;
-        const EditTree& m_edits;
+
+        /// The edits carries the information about which nodes have been expanded.
+        /// Non-const because the cache builder can encounter features whose style states that they are not collapsable
+        /// (i.e. that they are expanded without required an edit) and we have to update the edit tree with that fact.
+        EditTree& m_edits;
 
         /// We hide the roots unless necessary (root is a file or there are hidden failed modifiers)
         int m_indexOffset = 0;

--- a/BabelWiresLib/Project/FeatureElements/editTree.hpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree.hpp
@@ -29,7 +29,11 @@ namespace babelwires {
         Modifier* findModifier(const FeaturePath& featurePath);
         const Modifier* findModifier(const FeaturePath& featurePath) const;
         bool isExpanded(const FeaturePath& featurePath) const;
+
         void setExpanded(const FeaturePath& featurePath, bool expanded);
+
+        /// The feature at the path is not collapsible, so it should be treated as expanded without an edit.
+        void setImplicitlyExpanded(const FeaturePath& featurePath, bool expanded);
 
         /// Adjust edits which refer to an array at the path, starting at the startIndex.
         void adjustArrayIndices(const FeaturePath& pathToArray, ArrayIndex startIndex, int adjustment);
@@ -49,8 +53,8 @@ namespace babelwires {
         /// Remove the tail of the path hidden within a collapsed compound feature.
         void truncatePathAtFirstCollapsedNode(FeaturePath& path, State state) const;
 
-        /// Return all the expanded paths in the tree.
-        std::vector<FeaturePath> getAllExpandedPaths(const FeaturePath& path = FeaturePath()) const;
+        /// Return all the explicitly expanded paths in the tree.
+        std::vector<FeaturePath> getAllExplicitlyExpandedPaths(const FeaturePath& path = FeaturePath()) const;
 
       public:
         // Iteration through the tree of nodes.
@@ -142,6 +146,9 @@ namespace babelwires {
 
             /// True after m_isExpanded is changed, until clearChanges is called.
             bool m_isExpandedChanged = false;
+
+            /// The feature at the path is not collapsible, so it should be treated as expanded without an edit.
+            bool m_isImplicitlyExpanded = false;
 
             /// Is this tree node needed, either because it has descendents or it
             /// carries an edit?

--- a/BabelWiresLib/Project/FeatureElements/featureElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElement.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<babelwires::ElementData> babelwires::FeatureElement::extractElem
     for (const auto& m : m_edits.modifierRange()) {
         data->m_modifiers.emplace_back(m->getModifierData().clone());
     }
-    data->m_expandedPaths = m_edits.getAllExpandedPaths();
+    data->m_expandedPaths = m_edits.getAllExplicitlyExpandedPaths();
     // Strip out the currently unused paths.
     auto it = std::remove_if(data->m_expandedPaths.begin(), data->m_expandedPaths.end(), [this](const FeaturePath& p) {
         if (const Feature* inputFeature = getInputFeature()) {

--- a/BabelWiresQtUi/ModelBridge/projectBridge.cpp
+++ b/BabelWiresQtUi/ModelBridge/projectBridge.cpp
@@ -171,8 +171,6 @@ void babelwires::ProjectBridge::onNodeMoved(QtNodes::Node& n, const QPointF& new
     }
 }
 
-#include <iostream>
-
 void babelwires::ProjectBridge::onNodeResized(QtNodes::Node& n, const QSize& newSize) {
     switch (m_state) {
         case State::ListeningToFlowScene: {

--- a/Tests/BabelWiresLib/editTreeTest.cpp
+++ b/Tests/BabelWiresLib/editTreeTest.cpp
@@ -561,6 +561,105 @@ TEST(EditTreeTest, truncatePaths) {
     }
 }
 
+TEST(EditTreeTest, truncatePathsWithImplicitlyExpandedPaths) {
+    babelwires::EditTree tree;
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+
+    tree.setExpanded(babelwires::FeaturePath::deserializeFromString("aa"), true);
+    // An implicitly expanded path might only be encountered after a path was expanded.
+    tree.setImplicitlyExpanded(babelwires::FeaturePath::deserializeFromString("aa/5"), true);
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+
+    tree.clearChanges();
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb"));
+    }
+
+    tree.setExpanded(babelwires::FeaturePath::deserializeFromString("aa/5/bb"), true);
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb"));
+    }
+
+    tree.clearChanges();
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc"));
+    }
+
+    EXPECT_TRUE(testUtils::areEqualSets(std::vector<babelwires::FeaturePath>{babelwires::FeaturePath::deserializeFromString("aa"), babelwires::FeaturePath::deserializeFromString("aa/5/bb")}, tree.getAllExplicitlyExpandedPaths()));
+
+    tree.setExpanded(babelwires::FeaturePath::deserializeFromString("aa"), false);
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc"));
+    }
+
+    tree.clearChanges();
+
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::CurrentState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+    {
+        babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
+        tree.truncatePathAtFirstCollapsedNode(path, babelwires::EditTree::State::PreviousState);
+        EXPECT_EQ(path, babelwires::FeaturePath::deserializeFromString("aa"));
+    }
+
+    EXPECT_TRUE(testUtils::areEqualSets(std::vector<babelwires::FeaturePath>{babelwires::FeaturePath::deserializeFromString("aa/5/bb")}, tree.getAllExplicitlyExpandedPaths()));
+}
+
 TEST(EditTreeTest, treeIteration) {
     babelwires::EditTree tree;
 

--- a/Tests/BabelWiresLib/editTreeTest.cpp
+++ b/Tests/BabelWiresLib/editTreeTest.cpp
@@ -372,7 +372,7 @@ TEST(EditTreeTest, modifiersAndExpansion) {
     EXPECT_FALSE(tree.isExpanded(path6));
 }
 
-TEST(EditTreeTest, getAllExpandedPaths) {
+TEST(EditTreeTest, getAllExplicitlyExpandedPaths) {
     babelwires::EditTree tree;
 
     const babelwires::FeaturePath path1 = babelwires::FeaturePath::deserializeFromString("tt/tt/tt/4");
@@ -392,30 +392,30 @@ TEST(EditTreeTest, getAllExpandedPaths) {
 
     using setOfPaths = std::vector<babelwires::FeaturePath>;
 
-    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExpandedPaths(), setOfPaths{path1, path2, path4, path5, path6}));
+    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExplicitlyExpandedPaths(), setOfPaths{path1, path2, path4, path5, path6}));
 
     tree.setExpanded(path3, true);
 
     EXPECT_TRUE(
-        testUtils::areEqualSets(tree.getAllExpandedPaths(), setOfPaths{path1, path2, path3, path4, path5, path6}));
+        testUtils::areEqualSets(tree.getAllExplicitlyExpandedPaths(), setOfPaths{path1, path2, path3, path4, path5, path6}));
 
     tree.setExpanded(path3, false);
 
-    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExpandedPaths(), setOfPaths{path1, path2, path4, path5, path6}));
+    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExplicitlyExpandedPaths(), setOfPaths{path1, path2, path4, path5, path6}));
 
     tree.setExpanded(path6, false);
     tree.setExpanded(path1, false);
     tree.removeModifier(tree.findModifier(path5));
     tree.clearChanges();
 
-    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExpandedPaths(), setOfPaths{path2, path4, path5}));
+    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExplicitlyExpandedPaths(), setOfPaths{path2, path4, path5}));
 
     tree.setExpanded(path2, false);
     tree.setExpanded(path4, false);
     tree.setExpanded(path5, false);
     tree.clearChanges();
 
-    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExpandedPaths(), setOfPaths{}));
+    EXPECT_TRUE(testUtils::areEqualSets(tree.getAllExplicitlyExpandedPaths(), setOfPaths{}));
 }
 
 namespace {


### PR DESCRIPTION
I forgot about truncation when I introduced the "Not Collapsable" style, and no unit tests picked it up. Any new connection between nodes with an uncollapsable feature would assert.

The truncation algorithm in the EditTree needs to know about expanded nodes, but the style-based expansion was entirely managed by the ContentsCache. In this change, the ContentsCache informs the EditTree when it encounters features which have a style which says they should always be expanded. I don't love the bi-directional dependency, but the change itself is relatively straightforward, so I'll accept it.