### PR TITLE
Minor registry improvements

### DIFF
--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -12,5 +12,5 @@
 #include <BabelWiresLib/TypeSystem/intType.hpp>
 
 void babelwires::registerLib(babelwires::ProjectContext& context) {
-    context.m_typeSystem.addEntry(std::make_unique<IntType>());
+    context.m_typeSystem.addEntry<IntType>();
 }

--- a/Common/Registry/registry.hpp
+++ b/Common/Registry/registry.hpp
@@ -101,6 +101,12 @@ namespace babelwires {
         template<typename ENTRY_SUBTYPE, std::enable_if_t<std::is_base_of_v<ENTRY, ENTRY_SUBTYPE>, std::nullptr_t> = nullptr>
         ENTRY_SUBTYPE* addEntry(std::unique_ptr<ENTRY_SUBTYPE> newEntry);
 
+        /// Create a new entry and transfer it to the registry.
+        template<typename ENTRY_SUBTYPE, typename... ARGS, std::enable_if_t<std::is_base_of_v<ENTRY, ENTRY_SUBTYPE>, std::nullptr_t> = nullptr>
+        ENTRY_SUBTYPE* addEntry(ARGS&&... args) {
+          return addEntry(std::make_unique<ENTRY_SUBTYPE>(std::forward<ARGS>(args)...));
+        }
+
         /// Find an entry by an internal key which should be stable between
         /// versions of the program.
         /// If the provided identifier is unresolved, it will be resolved by setting its (mutable) discriminator to

--- a/Common/Registry/registry.hpp
+++ b/Common/Registry/registry.hpp
@@ -119,6 +119,15 @@ namespace babelwires {
         /// match that of the registered entry. Care should be taken to ensure the reference is not a temporary.
         const ENTRY& getRegisteredEntry(const LongIdentifier& identifier) const;
 
+        /// If ENTRY_SUBTYPE has the common static method "getThisIdentifier", then you can look it up by type
+        /// and get a typed reference back.
+        template<typename ENTRY_SUBTYPE, std::enable_if_t<std::is_base_of_v<ENTRY, ENTRY_SUBTYPE>, std::nullptr_t> = nullptr>
+        const ENTRY_SUBTYPE& getEntryByType() const {
+          const ENTRY& entry = getRegisteredEntry(ENTRY_SUBTYPE::getThisIdentifier());
+          assert(dynamic_cast<const ENTRY_SUBTYPE*>(&entry) && "The registered type was not of the expected type");
+          return static_cast<const ENTRY_SUBTYPE&>(entry);
+        }
+
       public:
         class Iterator;
         // Iteration.

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@ Processors:
 
 Refactor: 
 * Consider replacing virtual deserialize() method by deserializing constructor
+  - Tried this in PR #14. Breaks symmetry.
 * Move some of the logic in doProcess up into FeatureElement.
 * Split featureElementData into separate files - replace any dynamic casts.
 * Split Features & Import/Export out from the project lib. 
@@ -39,6 +40,7 @@ Refactor:
 * Arrays and optional modification are special-cased in the project: Could that be handled instead by a virtual "merge" method?
   - Also, they are special cased in the removeModifierCommand. Could that be handled instead by a virtual "removeModifier" method?
   - It's slightly unfortunate to have modifierData know about commands, but overall might be worth it.
+* Try to use Value to store value in a value feature, and use it in set value modifiers.
 
 Parallel processing:
 * Not implemented, but code written with this in mind.
@@ -65,3 +67,7 @@ Ideas:
 * SelectableArrays: For arrays larger than 16 elements:
   - Each element has an input drop down which selects the output array element.
   - This would be useful for complex input formats.
+
+Types:
+* Automatically provide an augmented version of each enum with a dummy value ("------" or "\_|\_" maybe?)
+  - Would allow percussion / chord processor to drop events (or add them in?)

--- a/Tests/BabelWiresLib/TestUtils/testEnum.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testEnum.cpp
@@ -49,10 +49,10 @@ testUtils::TestSubSubEnum2::TestSubSubEnum2()
                        1) {}
 
 void testUtils::addTestEnumTypes(babelwires::TypeSystem& typeSystem) {
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestSubSubEnum1>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestSubSubEnum2>());
+    typeSystem.addEntry<testUtils::TestEnum>();
+    typeSystem.addEntry<testUtils::TestSubEnum>();
+    typeSystem.addEntry<testUtils::TestSubSubEnum1>();
+    typeSystem.addEntry<testUtils::TestSubSubEnum2>();
 
     typeSystem.addRelatedTypes(testUtils::TestEnum::getThisIdentifier(),
                                {{}, {testUtils::TestSubSubEnum1::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/TestUtils/testEnvironment.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testEnvironment.cpp
@@ -7,7 +7,7 @@ testUtils::TestEnvironment::TestEnvironment()
     : m_projectContext{m_sourceFileFormatReg, m_targetFileFormatReg, m_processorReg, m_deserializationReg, m_typeSystem,
                        std::default_random_engine(0x123456789abcdeful)}
     , m_project(m_projectContext, m_log) {
-    m_targetFileFormatReg.addEntry(std::make_unique<TestTargetFileFormat>());
-    m_sourceFileFormatReg.addEntry(std::make_unique<TestSourceFileFormat>());
-    m_processorReg.addEntry(std::make_unique<TestProcessorFactory>());
+    m_targetFileFormatReg.addEntry<TestTargetFileFormat>();
+    m_sourceFileFormatReg.addEntry<TestSourceFileFormat>();
+    m_processorReg.addEntry<TestProcessorFactory>();
 }

--- a/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
@@ -16,7 +16,7 @@
 TEST(AddEntryToMapCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -56,7 +56,7 @@ TEST(AddEntryToMapCommandTest, executeAndUndo) {
 TEST(AddEntryToMapCommandTest, failAtEnd) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
+++ b/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
@@ -16,7 +16,7 @@
 TEST(ChangeEntryKindCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -53,7 +53,7 @@ TEST(ChangeEntryKindCommandTest, executeAndUndo) {
 TEST(ChangeEntryKindCommandTest, failFallbackNotAtEnd) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -81,7 +81,7 @@ TEST(ChangeEntryKindCommandTest, failFallbackNotAtEnd) {
 TEST(ChangeEntryKindCommandTest, failNotFallbackAtEnd) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/enumFeatureTest.cpp
+++ b/Tests/BabelWiresLib/enumFeatureTest.cpp
@@ -12,7 +12,7 @@
 TEST(FeatureTest, enumFeature) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    testEnvironment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    testEnvironment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
     babelwires::EnumFeature& enumFeature = *rootFeature.addField(std::make_unique<babelwires::EnumFeature>(testUtils::TestEnum::getThisIdentifier()), testUtils::getTestRegisteredIdentifier("aaa"));
@@ -34,7 +34,7 @@ TEST(FeatureTest, enumFeature) {
 TEST(FeatureTest, enumFeatureChanges) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    testEnvironment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    testEnvironment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
     babelwires::EnumFeature& enumFeature = *rootFeature.addField(std::make_unique<babelwires::EnumFeature>(testUtils::TestEnum::getThisIdentifier()), testUtils::getTestRegisteredIdentifier("flerm"));
@@ -70,7 +70,7 @@ TEST(FeatureTest, enumFeatureChanges) {
 TEST(FeatureTest, enumFeatureHash) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    testEnvironment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    testEnvironment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
     babelwires::EnumFeature& enumFeature = *rootFeature.addField(std::make_unique<babelwires::EnumFeature>(testUtils::TestEnum::getThisIdentifier()), testUtils::getTestRegisteredIdentifier("flerm"));

--- a/Tests/BabelWiresLib/enumTest.cpp
+++ b/Tests/BabelWiresLib/enumTest.cpp
@@ -96,9 +96,9 @@ TEST(EnumTest, subEnum) {
 
     babelwires::TypeSystem typeSystem;
 
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestEnum>();
     // Have to register Sub-Enums in the TypeSystem or they don't work.
-    typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    typeSystem.addEntry<testUtils::TestSubEnum>();
 
     const auto& testEnum = typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier());
     const auto& testSubEnum = typeSystem.getRegisteredEntry(testUtils::TestSubEnum::getThisIdentifier());

--- a/Tests/BabelWiresLib/enumTest.cpp
+++ b/Tests/BabelWiresLib/enumTest.cpp
@@ -100,8 +100,8 @@ TEST(EnumTest, subEnum) {
     // Have to register Sub-Enums in the TypeSystem or they don't work.
     typeSystem.addEntry<testUtils::TestSubEnum>();
 
-    const auto& testEnum = typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier());
-    const auto& testSubEnum = typeSystem.getRegisteredEntry(testUtils::TestSubEnum::getThisIdentifier());
+    const auto& testEnum = typeSystem.getEntryByType<testUtils::TestEnum>();
+    const auto& testSubEnum = typeSystem.getEntryByType<testUtils::TestSubEnum>();
 
     auto value = testSubEnum.createValue();
     EXPECT_TRUE(value);

--- a/Tests/BabelWiresLib/mapDataTest.cpp
+++ b/Tests/BabelWiresLib/mapDataTest.cpp
@@ -135,7 +135,7 @@ TEST(MapDataTest, equality) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    typeSystem.addEntry<testUtils::TestType>();
 
     mapData.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
 
@@ -180,7 +180,7 @@ TEST(MapDataTest, getHash) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    typeSystem.addEntry<testUtils::TestType>();
 
     mapData.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
 
@@ -201,7 +201,7 @@ TEST(MapDataTest, isInvalid_validMap) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     mapData.setSourceTypeId(testUtils::TestType::getThisIdentifier());
     mapData.setTargetTypeId(testUtils::TestType::getThisIdentifier());
@@ -221,7 +221,7 @@ TEST(MapDataTest, isInvalid_outOfPlaceFallback) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     mapData.setSourceTypeId(testUtils::TestType::getThisIdentifier());
     mapData.setTargetTypeId(testUtils::TestType::getThisIdentifier());
@@ -237,7 +237,7 @@ TEST(MapDataTest, isInvalid_noFallback) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     mapData.setSourceTypeId(testUtils::TestType::getThisIdentifier());
     mapData.setTargetTypeId(testUtils::TestType::getThisIdentifier());
@@ -251,7 +251,7 @@ TEST(MapDataTest, isValid_typeMismatch) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     mapData.setSourceTypeId(testTypeId1);
     mapData.setTargetTypeId(testUtils::TestType::getThisIdentifier());
@@ -270,7 +270,7 @@ TEST(MapDataTest, serializationTest) {
     
         babelwires::IdentifierRegistryScope identifierRegistry;
         babelwires::TypeSystem typeSystem;
-        typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+        typeSystem.addEntry<testUtils::TestType>();  
 
         // Note: We want to be able to serialize when entries do not match the types, as in this case.
         auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier());
@@ -314,7 +314,7 @@ TEST(MapDataTest, cloneTest) {
 
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     // Note: We want to be able to clone when entries do not match the types, as in this case.
     auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier());

--- a/Tests/BabelWiresLib/mapEntryDataTest.cpp
+++ b/Tests/BabelWiresLib/mapEntryDataTest.cpp
@@ -44,8 +44,8 @@ TEST(MapEntryDataTest, getKindName) {
 TEST(MapEntryDataTest, create) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const auto oneToOne = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                            testUtils::TestEnum::getThisIdentifier(),
@@ -85,8 +85,8 @@ TEST(MapEntryDataTest, create) {
 TEST(MapEntryDataTest, equalityByKind) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                     testUtils::TestEnum::getThisIdentifier());
@@ -105,8 +105,8 @@ TEST(MapEntryDataTest, equalityByKind) {
 TEST(MapEntryDataTest, oneToOneEqualitySameTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                testUtils::TestType::getThisIdentifier());
@@ -135,8 +135,8 @@ TEST(MapEntryDataTest, oneToOneEqualitySameTypes) {
 TEST(MapEntryDataTest, oneToOneEqualityDifferentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                testUtils::TestType::getThisIdentifier());
@@ -168,8 +168,8 @@ TEST(MapEntryDataTest, oneToOneEqualityDifferentTypes) {
 TEST(MapEntryDataTest, allToOneEqualitySameTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -190,8 +190,8 @@ TEST(MapEntryDataTest, allToOneEqualitySameTypes) {
 TEST(MapEntryDataTest, allToOneEqualityDifferentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -204,8 +204,8 @@ TEST(MapEntryDataTest, allToOneEqualityDifferentTypes) {
 TEST(MapEntryDataTest, hashByKind) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                     testUtils::TestEnum::getThisIdentifier());
@@ -224,8 +224,8 @@ TEST(MapEntryDataTest, hashByKind) {
 TEST(MapEntryDataTest, oneToOneHashSameTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                testUtils::TestType::getThisIdentifier());
@@ -254,8 +254,8 @@ TEST(MapEntryDataTest, oneToOneHashSameTypes) {
 TEST(MapEntryDataTest, oneToOneHashDifferentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
                                                testUtils::TestType::getThisIdentifier());
@@ -287,8 +287,8 @@ TEST(MapEntryDataTest, oneToOneHashDifferentTypes) {
 TEST(MapEntryDataTest, allToOneHashSameTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -309,8 +309,8 @@ TEST(MapEntryDataTest, allToOneHashSameTypes) {
 TEST(MapEntryDataTest, allToOneHashDifferentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -323,8 +323,8 @@ TEST(MapEntryDataTest, allToOneHashDifferentTypes) {
 TEST(MapEntryDataTest, oneToOneValidate) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                               testUtils::TestEnum::getThisIdentifier());
@@ -345,8 +345,8 @@ TEST(MapEntryDataTest, oneToOneValidate) {
 TEST(MapEntryDataTest, allToOneValidate) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -366,8 +366,8 @@ TEST(MapEntryDataTest, allToOneValidate) {
 TEST(MapEntryDataTest, allToSameValidate) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToSameFallbackMapEntryData allToSame;
 
@@ -387,8 +387,8 @@ TEST(MapEntryDataTest, allToSameValidate) {
 TEST(MapEntryDataTest, oneToOneGetAndSetValues) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                               testUtils::TestEnum::getThisIdentifier());
@@ -412,8 +412,8 @@ TEST(MapEntryDataTest, oneToOneGetAndSetValues) {
 TEST(MapEntryDataTest, allToOneGetAndSetValues) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -431,8 +431,8 @@ TEST(MapEntryDataTest, oneToOneSerialize) {
     {
         babelwires::IdentifierRegistryScope identifierRegistry;
         babelwires::TypeSystem typeSystem;
-        typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
-        typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+        typeSystem.addEntry<testUtils::TestType>();  
+        typeSystem.addEntry<testUtils::TestEnum>();
 
         babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                               testUtils::TestEnum::getThisIdentifier());
@@ -478,7 +478,7 @@ TEST(MapEntryDataTest, allToOneSerialize) {
     {
         babelwires::IdentifierRegistryScope identifierRegistry;
         babelwires::TypeSystem typeSystem;
-        typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+        typeSystem.addEntry<testUtils::TestType>();  
 
         babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -513,7 +513,7 @@ TEST(MapEntryDataTest, allToSameSerialize) {
     {
         babelwires::IdentifierRegistryScope identifierRegistry;
         babelwires::TypeSystem typeSystem;
-        typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+        typeSystem.addEntry<testUtils::TestType>();  
 
         babelwires::AllToSameFallbackMapEntryData allToSame;
 
@@ -536,8 +536,8 @@ TEST(MapEntryDataTest, allToSameSerialize) {
 TEST(MapEntryDataTest, oneToOneClone) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();  
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                             testUtils::TestEnum::getThisIdentifier());
@@ -571,7 +571,7 @@ TEST(MapEntryDataTest, oneToOneClone) {
 TEST(MapEntryDataTest, allToOneClone) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
 
@@ -594,7 +594,7 @@ TEST(MapEntryDataTest, allToOneClone) {
 TEST(MapEntryDataTest, allToSameClone) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());  
+    typeSystem.addEntry<testUtils::TestType>();  
 
     babelwires::AllToSameFallbackMapEntryData allToSame;
 

--- a/Tests/BabelWiresLib/mapFeatureTest.cpp
+++ b/Tests/BabelWiresLib/mapFeatureTest.cpp
@@ -37,7 +37,7 @@ TEST(MapFeatureTest, construction) {
 TEST(MapFeatureTest, setToDefault) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     // MapFeatures expect to be able to find the typeSystem via the rootFeature at the root of the feature hierarchy.
     babelwires::RootFeature rootFeature(environment.m_projectContext);
@@ -67,9 +67,9 @@ TEST(MapFeatureTest, isCompatible) {
 TEST(MapFeatureTest, assign) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
     environment.m_typeSystem.addRelatedTypes(testUtils::TestSubEnum::getThisIdentifier(),
                                              {{testUtils::TestEnum::getThisIdentifier()}, {}});
 
@@ -152,9 +152,9 @@ TEST(MapFeatureTest, assign) {
 TEST(MapFeatureTest, setAndGet) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
     environment.m_typeSystem.addRelatedTypes(testUtils::TestSubEnum::getThisIdentifier(),
                                              {{testUtils::TestEnum::getThisIdentifier()}, {}});
 

--- a/Tests/BabelWiresLib/mapHelperTest.cpp
+++ b/Tests/BabelWiresLib/mapHelperTest.cpp
@@ -142,7 +142,7 @@ namespace {
 TEST(MapHelperTest, unorderedMapApplicator_allToOneFallback) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapData mapData = setUpTestTypeMapData(typeSystem, mapData, true);
 
@@ -158,7 +158,7 @@ TEST(MapHelperTest, unorderedMapApplicator_allToOneFallback) {
 TEST(MapHelperTest, unorderedMapApplicator_allToSameFallback) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapData mapData = setUpTestTypeMapData(typeSystem, mapData, false);
 
@@ -174,8 +174,8 @@ TEST(MapHelperTest, unorderedMapApplicator_allToSameFallback) {
 TEST(MapHelperTest, unorderedMapApplicator_differentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestType>();
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const testUtils::TestEnum& testEnum =
         *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
@@ -195,7 +195,7 @@ TEST(MapHelperTest, unorderedMapApplicator_differentTypes) {
 TEST(MapHelperTest, enumSourceMapApplicator_allToOneFallback) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const testUtils::TestEnum& testEnum =
         *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
@@ -215,7 +215,7 @@ TEST(MapHelperTest, enumSourceMapApplicator_allToOneFallback) {
 TEST(MapHelperTest, enumSourceMapApplicator_allToSameFallback) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const testUtils::TestEnum& testEnum =
         *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
@@ -235,7 +235,7 @@ TEST(MapHelperTest, enumSourceMapApplicator_allToSameFallback) {
 TEST(MapHelperTest, enumSourceMapApplicator_differentTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    typeSystem.addEntry<testUtils::TestEnum>();
 
     const testUtils::TestEnum& testEnum =
         *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();

--- a/Tests/BabelWiresLib/mapHelperTest.cpp
+++ b/Tests/BabelWiresLib/mapHelperTest.cpp
@@ -177,8 +177,7 @@ TEST(MapHelperTest, unorderedMapApplicator_differentTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const testUtils::TestEnum& testEnum =
-        *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
+    const testUtils::TestEnum& testEnum = typeSystem.getEntryByType<testUtils::TestEnum>();
 
     babelwires::MapData mapData = setUpTestTypeTestEnumMapData(typeSystem, mapData);
 
@@ -197,8 +196,7 @@ TEST(MapHelperTest, enumSourceMapApplicator_allToOneFallback) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const testUtils::TestEnum& testEnum =
-        *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
+    const testUtils::TestEnum& testEnum = typeSystem.getEntryByType<testUtils::TestEnum>();
 
     babelwires::MapData mapData = setUpTestEnumMapData(typeSystem, mapData, true);
 
@@ -217,8 +215,7 @@ TEST(MapHelperTest, enumSourceMapApplicator_allToSameFallback) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const testUtils::TestEnum& testEnum =
-        *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
+    const testUtils::TestEnum& testEnum = typeSystem.getEntryByType<testUtils::TestEnum>();
 
     babelwires::MapData mapData = setUpTestEnumMapData(typeSystem, mapData, false);
 
@@ -237,8 +234,7 @@ TEST(MapHelperTest, enumSourceMapApplicator_differentTypes) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const testUtils::TestEnum& testEnum =
-        *typeSystem.getRegisteredEntry(testUtils::TestEnum::getThisIdentifier()).as<testUtils::TestEnum>();
+    const testUtils::TestEnum& testEnum = typeSystem.getEntryByType<testUtils::TestEnum>();
 
     babelwires::MapData mapData = setUpTestEnumTestTypeMapData(typeSystem, mapData);
 

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -23,7 +23,7 @@ namespace {
 TEST(MapProjectTest, mapProjectEntry) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     babelwires::TypeSystem typeSystem;
-    typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
                                               testUtils::TestType::getThisIdentifier());
@@ -48,8 +48,8 @@ TEST(MapProjectTest, mapProjectEntry) {
 TEST(MapProjectTest, allowedTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -72,8 +72,8 @@ TEST(MapProjectTest, getProjectContext) {
 TEST(MapProjectTest, types) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -95,8 +95,8 @@ TEST(MapProjectTest, types) {
 TEST(MapProjectTest, badTypes) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -132,9 +132,9 @@ TEST(MapProjectTest, badTypes) {
 TEST(MapProjectTest, setAndExtractMapData) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -165,9 +165,9 @@ TEST(MapProjectTest, setAndExtractMapData) {
 TEST(MapProjectTest, modifyMapData) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -225,9 +225,9 @@ TEST(MapProjectTest, modifyMapData) {
 TEST(MapProjectTest, typeChangeAndValidity) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubSubEnum1>());
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubSubEnum1>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -284,9 +284,9 @@ TEST(MapProjectTest, typeChangeAndValidity) {
 TEST(MapProjectTest, modifyValidity) {
      babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestSubEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
+    environment.m_typeSystem.addEntry<testUtils::TestSubEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 
@@ -326,8 +326,8 @@ TEST(MapProjectTest, modifyValidity) {
 TEST(MapProjectTest, badMap) {
      babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
 

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -87,9 +87,9 @@ TEST(MapProjectTest, types) {
     EXPECT_EQ(mapProject.getTargetTypeId(), testUtils::TestEnum::getThisIdentifier());
 
     EXPECT_EQ(mapProject.getSourceType(),
-              environment.m_typeSystem.getEntryByIdentifier(testUtils::TestType::getThisIdentifier()));
+              &environment.m_typeSystem.getEntryByType<testUtils::TestType>());
     EXPECT_EQ(mapProject.getTargetType(),
-              environment.m_typeSystem.getEntryByIdentifier(testUtils::TestEnum::getThisIdentifier()));
+              &environment.m_typeSystem.getEntryByType<testUtils::TestEnum>());
 }
 
 TEST(MapProjectTest, badTypes) {

--- a/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
+++ b/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
@@ -287,7 +287,7 @@ TEST(RecordWithOptionalsFeatureTest, setToDefault) {
 TEST(RecordWithOptionalsFeatureTest, inactiveEnumCanBeDefaulted) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    testEnvironment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    testEnvironment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
 

--- a/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
@@ -16,7 +16,7 @@
 TEST(RemoveEntryFromMapCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -66,7 +66,7 @@ TEST(RemoveEntryFromMapCommandTest, executeAndUndo) {
 TEST(RemoveEntryFromMapCommandTest, removeInvalid) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -115,7 +115,7 @@ TEST(RemoveEntryFromMapCommandTest, removeInvalid) {
 TEST(RemoveEntryFromMapCommandTest, failAtEnd) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
+++ b/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
@@ -16,7 +16,7 @@
 TEST(ReplaceMapEntryCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -73,7 +73,7 @@ TEST(ReplaceMapEntryCommandTest, executeAndUndo) {
 TEST(ReplaceMapEntryCommandTest, failBeyondEnd) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -100,7 +100,7 @@ TEST(ReplaceMapEntryCommandTest, failBeyondEnd) {
 TEST(ReplaceMapEntryCommandTest, replaceInvalid) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -160,7 +160,7 @@ TEST(ReplaceMapEntryCommandTest, replaceInvalid) {
 TEST(ReplaceMapEntryCommandTest, failInvalid) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/setMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapCommandTest.cpp
@@ -16,7 +16,7 @@
 TEST(SetMapCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -85,7 +85,7 @@ TEST(SetMapCommandTest, executeAndUndo) {
 TEST(SetMapCommandTest, invalidOldMap) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});
@@ -161,7 +161,7 @@ TEST(SetMapCommandTest, invalidOldMap) {
 TEST(SetMapCommandTest, invalidNewMap) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
@@ -18,7 +18,7 @@
 TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
     testUtils::addTestEnumTypes(environment.m_typeSystem);
 
     babelwires::MapProject mapProject(environment.m_projectContext);
@@ -81,8 +81,8 @@ TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
 TEST(SetMapSourceTypeCommandTest, failWithUnallowedType) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
@@ -18,7 +18,7 @@
 TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
     testUtils::addTestEnumTypes(environment.m_typeSystem);
 
     babelwires::MapProject mapProject(environment.m_projectContext);
@@ -83,8 +83,8 @@ TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
 TEST(SetMapTargetTypeCommandTest, failWithUnallowedType) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment environment;
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestType>());
-    environment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    environment.m_typeSystem.addEntry<testUtils::TestType>();
+    environment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::MapProject mapProject(environment.m_projectContext);
     mapProject.setAllowedSourceTypeId({{testUtils::TestType::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -13,7 +13,7 @@
 
 namespace {
     void addTestTypes(babelwires::TypeSystem& typeSystem) {
-        typeSystem.addEntry(std::make_unique<testUtils::TestType>());
+        typeSystem.addEntry<testUtils::TestType>();
         testUtils::addTestEnumTypes(typeSystem);
     }
 } // namespace

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -492,7 +492,7 @@ TEST(UnionFeatureTest, queries) {
 TEST(UnionFeatureTest, unselectedEnumCanBeDefaulted) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    testEnvironment.m_typeSystem.addEntry(std::make_unique<testUtils::TestEnum>());
+    testEnvironment.m_typeSystem.addEntry<testUtils::TestEnum>();
 
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
 

--- a/Tests/Common/audioInterfaceRegistryTest.cpp
+++ b/Tests/Common/audioInterfaceRegistryTest.cpp
@@ -92,7 +92,7 @@ TEST(AudioInterfaceRegistryTest, destinationsAndSources) {
     EXPECT_TRUE(reg.getDestinationNames().empty());
     EXPECT_TRUE(reg.getSourceNames().empty());
 
-    reg.addEntry(std::make_unique<TestAudioInterface>("foo", 10));
+    reg.addEntry<TestAudioInterface>("foo", 10);
 
     using setOfStrings = std::vector<std::string>;
 
@@ -118,7 +118,7 @@ TEST(AudioInterfaceRegistryTest, destinationsAndSources) {
         auto sourceFoo3 = reg.getSource("foo::foo3");
         EXPECT_EQ(sourceFoo3->getNumChannels(), 13);
     }
-    reg.addEntry(std::make_unique<TestAudioInterface>("erm", 20));
+    reg.addEntry<TestAudioInterface>("erm", 20);
     EXPECT_TRUE(testUtils::areEqualSets(reg.getDestinationNames(),
                                         setOfStrings{"foo::foo1", "foo::foo2", "erm::erm1", "erm::erm2"}));
     {

--- a/Tests/Common/registryTest.cpp
+++ b/Tests/Common/registryTest.cpp
@@ -43,7 +43,7 @@ TEST(RegistryTest, base) {
         "test", "Test", "00000000-1111-2222-3333-444444444444",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
-    registry.addEntry(std::make_unique<TestRegistryEntry>(entryId, 1, TestRegistryEntry::Extensions{"test"}, 15));
+    registry.addEntry<TestRegistryEntry>(entryId, 1, TestRegistryEntry::Extensions{"test"}, 15);
 
     ASSERT_NE(registry.getEntryByIdentifier("test"), nullptr);
     EXPECT_NE(&registry.getRegisteredEntry("test"), nullptr);


### PR DESCRIPTION
Use two templated methods to reduce registration boilerplate.