### PR TITLE
Improved TypeRef

### DIFF
--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -38,9 +38,8 @@ SET( BABELWIRESLIB_SRCS
 	TypeSystem/intValue.cpp
 	TypeSystem/enumValue.cpp
 	TypeSystem/type.cpp
-	TypeSystem/typeConstructor.cpp
-	TypeSystem/typeConstructorArguments.cpp
 	TypeSystem/typeRef.cpp
+	TypeSystem/typeConstructorArguments.cpp
 	Maps/Commands/addEntryToMapCommand.cpp
 	Maps/Commands/removeEntryFromMapCommand.cpp
 	Maps/Commands/replaceMapEntryCommand.cpp

--- a/BabelWiresLib/Enums/addBlankToEnum.cpp
+++ b/BabelWiresLib/Enums/addBlankToEnum.cpp
@@ -16,7 +16,7 @@ unsigned int babelwires::AddBlankToEnum::getArity() const {
 }
 
 babelwires::ShortId babelwires::AddBlankToEnum::getBlankValue() {
-    return REGISTERED_ID("____", "____", "9e715cdc-399a-48b7-bc04-ad98e9e900d9");
+    return BW_SHORT_ID("____", "____", "9e715cdc-399a-48b7-bc04-ad98e9e900d9");
 }
 
 std::unique_ptr<babelwires::Type> babelwires::AddBlankToEnum::constructType(TypeRef newTypeRef,

--- a/BabelWiresLib/Enums/addBlankToEnum.cpp
+++ b/BabelWiresLib/Enums/addBlankToEnum.cpp
@@ -11,17 +11,12 @@
 #include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 
-unsigned int babelwires::AddBlankToEnum::getArity() const {
-    return 1;
-}
-
 babelwires::ShortId babelwires::AddBlankToEnum::getBlankValue() {
     return BW_SHORT_ID("____", "____", "9e715cdc-399a-48b7-bc04-ad98e9e900d9");
 }
 
 std::unique_ptr<babelwires::Type> babelwires::AddBlankToEnum::constructType(TypeRef newTypeRef,
-                                                                      const std::vector<const Type*>& arguments) const {
-    assert((arguments.size() == 1) && "AddBlankToEnum is unary.");
+                                                                      const std::array<const Type*, 1>& arguments) const {
     const Enum* const srcEnum = arguments[0]->as<Enum>();
     if (!srcEnum) {
         throw TypeSystemException() << "Non-enum argument << " << arguments[0]->getName() << " provided to AddBlankToEnum";
@@ -43,10 +38,7 @@ babelwires::Enum::EnumValues babelwires::AddBlankToEnum::ensureBlankValue(const 
 }
 
 
-babelwires::SubtypeOrder babelwires::AddBlankToEnum::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments, const TypeRef& other) const {
-    if (arguments.m_typeArguments.size() != 1) {
-        return SubtypeOrder::IsUnrelated;
-    }
+babelwires::SubtypeOrder babelwires::AddBlankToEnum::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<1>& arguments, const TypeRef& other) const {
     const SubtypeOrder argOrder = typeSystem.compareSubtype(arguments.m_typeArguments[0], other);
     if ((argOrder == SubtypeOrder::IsEquivalent) || (argOrder == SubtypeOrder::IsSupertype)) {
         return SubtypeOrder::IsSupertype;
@@ -54,10 +46,7 @@ babelwires::SubtypeOrder babelwires::AddBlankToEnum::compareSubtypeHelper(const 
     return SubtypeOrder::IsUnrelated;
 }
 
-babelwires::SubtypeOrder babelwires::AddBlankToEnum::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& argumentsA, const TypeConstructorArguments& argumentsB) const {
-    if ((argumentsA.m_typeArguments.size() != 1) || (argumentsB.m_typeArguments.size() != 1)) {
-        return SubtypeOrder::IsUnrelated;    
-    }
+babelwires::SubtypeOrder babelwires::AddBlankToEnum::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<1>& argumentsA, const TypeConstructorArguments<1>& argumentsB) const {
     return typeSystem.compareSubtype(argumentsA.m_typeArguments[0], argumentsB.m_typeArguments[0]);
 }
 

--- a/BabelWiresLib/Enums/addBlankToEnum.cpp
+++ b/BabelWiresLib/Enums/addBlankToEnum.cpp
@@ -15,7 +15,7 @@ unsigned int babelwires::AddBlankToEnum::getArity() const {
     return 1;
 }
 
-babelwires::Identifier babelwires::AddBlankToEnum::getBlankValue() {
+babelwires::ShortId babelwires::AddBlankToEnum::getBlankValue() {
     return REGISTERED_ID("____", "____", "9e715cdc-399a-48b7-bc04-ad98e9e900d9");
 }
 

--- a/BabelWiresLib/Enums/addBlankToEnum.hpp
+++ b/BabelWiresLib/Enums/addBlankToEnum.hpp
@@ -21,7 +21,7 @@ namespace babelwires {
 
         /// The blank value that gets added to enums.
         /// Note that the blank value is only permitted at the end of the enum.
-        static Identifier getBlankValue();
+        static ShortId getBlankValue();
 
         unsigned int getArity() const override;
 

--- a/BabelWiresLib/Enums/addBlankToEnum.hpp
+++ b/BabelWiresLib/Enums/addBlankToEnum.hpp
@@ -15,7 +15,7 @@ namespace babelwires {
     /// This is useful in map targets to indicate when the map should exclude an entry, rather than select a mapped
     /// value.
     /// AddBlankToEnum to an enum which already has a blank returns an enum with the same values.
-    class AddBlankToEnum : public TypeConstructor {
+    class AddBlankToEnum : public TypeConstructor<1> {
       public:
         TYPE_CONSTRUCTOR("AddBlankToEnum", "{0} + _", "bd5af7a5-4a75-4807-a3d8-93851e1a7d00", 1);
 
@@ -23,14 +23,12 @@ namespace babelwires {
         /// Note that the blank value is only permitted at the end of the enum.
         static ShortId getBlankValue();
 
-        unsigned int getArity() const override;
-
         std::unique_ptr<Type> constructType(TypeRef newTypeRef,
-                                            const std::vector<const Type*>& arguments) const override;
+                                            const std::array<const Type*, 1>& arguments) const override;
 
-        virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& argumentsA, const TypeConstructorArguments& argumentsB) const override;
+        virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<1>& argumentsA, const TypeConstructorArguments<1>& argumentsB) const override;
 
-        virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments, const TypeRef& other) const override;
+        virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<1>& arguments, const TypeRef& other) const override;
 
         /// Add a blank to the values unless one is already there.
         static Enum::EnumValues ensureBlankValue(const Enum::EnumValues& srcValues);

--- a/BabelWiresLib/Enums/enum.cpp
+++ b/BabelWiresLib/Enums/enum.cpp
@@ -28,7 +28,7 @@ unsigned int babelwires::Enum::getIndexOfDefaultValue() const {
     return m_indexOfDefaultValue;
 }
 
-int babelwires::Enum::tryGetIndexFromIdentifier(babelwires::Identifier id) const {
+int babelwires::Enum::tryGetIndexFromIdentifier(babelwires::ShortId id) const {
     const auto it = m_valueToIndex.find(id);
     if (it != m_valueToIndex.end()) {
         return it->second;
@@ -36,20 +36,20 @@ int babelwires::Enum::tryGetIndexFromIdentifier(babelwires::Identifier id) const
     return -1;
 }
 
-unsigned int babelwires::Enum::getIndexFromIdentifier(babelwires::Identifier id) const {
+unsigned int babelwires::Enum::getIndexFromIdentifier(babelwires::ShortId id) const {
     const EnumValues& values = getEnumValues();
     const auto it = m_valueToIndex.find(id);
     assert((it != m_valueToIndex.end()) && "id not found in enum");
     return it->second;
 }
 
-babelwires::Identifier babelwires::Enum::getIdentifierFromIndex(unsigned int index) const {
+babelwires::ShortId babelwires::Enum::getIdentifierFromIndex(unsigned int index) const {
     const EnumValues& values = getEnumValues();
     assert(index < values.size());
     return values[index];
 }
 
-bool babelwires::Enum::isAValue(const babelwires::Identifier& id) const {
+bool babelwires::Enum::isAValue(const babelwires::ShortId& id) const {
     const EnumValues& values = getEnumValues();
     const auto it = m_valueToIndex.find(id);
     if (it == m_valueToIndex.end()) {
@@ -67,7 +67,7 @@ std::unique_ptr<babelwires::Value> babelwires::Enum::createValue() const {
 bool babelwires::Enum::verifySupertype(const Type& supertype) const {
     const Enum& parentEnum = supertype.is<Enum>();
     for (const auto& v : m_values) {
-        Identifier parentId = v;
+        ShortId parentId = v;
         assert(parentEnum.isAValue(parentId));
         // I don't _know_ that this would cause problems, but it simplifies things to require this.
         assert((parentId.getDiscriminator() == v.getDiscriminator()) &&

--- a/BabelWiresLib/Enums/enum.hpp
+++ b/BabelWiresLib/Enums/enum.hpp
@@ -21,7 +21,7 @@ namespace babelwires {
         /// The set of values. We use Identifiers to get versionable serialization support.
         /// The EnumValues vector may not contain duplicates.
         /// Note: This matches the result of REGISTERED_ID_VECTOR.
-        using EnumValues = std::vector<Identifier>;
+        using EnumValues = std::vector<ShortId>;
 
         /// Enums need a set of values and a way of identifying the default.
         /// The values object can be the "output" of the REGISTERED_ID_VECTOR macro.
@@ -35,17 +35,17 @@ namespace babelwires {
         unsigned int getIndexOfDefaultValue() const;
 
         /// Get the index within EnumValues of the given id.
-        unsigned int getIndexFromIdentifier(Identifier id) const;
+        unsigned int getIndexFromIdentifier(ShortId id) const;
 
         /// Return the index within EnumValues of the given id, or -1.
-        int tryGetIndexFromIdentifier(Identifier id) const;
+        int tryGetIndexFromIdentifier(ShortId id) const;
 
         /// Get the identifier within EnumValues at the given index.
-        Identifier getIdentifierFromIndex(unsigned int index) const;
+        ShortId getIdentifierFromIndex(unsigned int index) const;
 
         /// Is the identifier one of the values in the enum?
         /// This can resolve the discriminator in the identifier.
-        bool isAValue(const Identifier& id) const;
+        bool isAValue(const ShortId& id) const;
 
         std::unique_ptr<Value> createValue() const override;
 
@@ -55,7 +55,7 @@ namespace babelwires {
         /// The enum values in their intended order.
         EnumValues m_values;
         /// Supports faster lookup for identifier-based queries.
-        std::unordered_map<Identifier, int> m_valueToIndex;
+        std::unordered_map<ShortId, int> m_valueToIndex;
         unsigned int m_indexOfDefaultValue;
     };
 } // namespace babelwires

--- a/BabelWiresLib/Enums/enumWithCppEnum.hpp
+++ b/BabelWiresLib/Enums/enumWithCppEnum.hpp
@@ -19,10 +19,10 @@
     enum class Value { Y(ENUM_SELECT_FIRST_ARGUMENT) NUM_VALUES, NotAValue = NUM_VALUES };
 
 #define ENUM_DEFINE_CPP_METHODS                                                                                        \
-    Value getValueFromIdentifier(babelwires::Identifier id) const {                                                    \
+    Value getValueFromIdentifier(babelwires::ShortId id) const {                                                    \
         return static_cast<Value>(getIndexFromIdentifier(id));                                                         \
     }                                                                                                                  \
-    babelwires::Identifier getIdentifierFromValue(Value value) const {                                                 \
+    babelwires::ShortId getIdentifierFromValue(Value value) const {                                                 \
         return getIdentifierFromIndex(static_cast<unsigned int>(value));                                               \
     }
 

--- a/BabelWiresLib/Features/Path/pathStep.cpp
+++ b/BabelWiresLib/Features/Path/pathStep.cpp
@@ -1,5 +1,5 @@
 /**
- * A PathStep is a union of a Identifier and an ArrayIndex.
+ * A PathStep is a union of a ShortId and an ArrayIndex.
  *
  * (C) 2021 Malcolm Tyrrell
  * 
@@ -13,7 +13,7 @@
 #include <sstream>
 
 void babelwires::PathStep::writeToStream(std::ostream& os) const {
-    if (const Identifier* f = asField()) {
+    if (const ShortId* f = asField()) {
         os << *f;
     } else {
         os << getIndex();
@@ -21,7 +21,7 @@ void babelwires::PathStep::writeToStream(std::ostream& os) const {
 }
 
 std::string babelwires::PathStep::serializeToString() const {
-    if (const Identifier* f = asField()) {
+    if (const ShortId* f = asField()) {
         return f->serializeToString();
     } else {
         return std::to_string(getIndex());
@@ -41,6 +41,6 @@ babelwires::PathStep babelwires::PathStep::deserializeFromString(std::string_vie
         }
         return arrayIndex;
     } else {
-        return PathStep(Identifier::deserializeFromString(str));
+        return PathStep(ShortId::deserializeFromString(str));
     }
 }

--- a/BabelWiresLib/Features/Path/pathStep.hpp
+++ b/BabelWiresLib/Features/Path/pathStep.hpp
@@ -1,5 +1,5 @@
 /**
- * A PathStep is a union of a Identifier and an ArrayIndex.
+ * A PathStep is a union of a ShortId and an ArrayIndex.
  *
  * (C) 2021 Malcolm Tyrrell
  * 
@@ -15,12 +15,12 @@ namespace babelwires {
 
     using ArrayIndex = std::uint16_t;
 
-    /// A PathStep is a union of a Identifier and an ArrayIndex.
+    /// A PathStep is a union of a ShortId and an ArrayIndex.
     union PathStep {
       public:
         // explicit, because a temporary PathStep contains a copy of f, and any modification to its mutable
         // discriminator will be lost.
-        explicit PathStep(const Identifier& f)
+        explicit PathStep(const ShortId& f)
             : m_fieldIdentifier(f) {}
         PathStep(ArrayIndex index)
             : m_arrayIndex(Index()) {
@@ -39,13 +39,13 @@ namespace babelwires {
         bool isIndex() const { return !isField(); }
 
         /// Get the contained field identifier or assert.
-        const Identifier& getField() const {
+        const ShortId& getField() const {
             assert(isField());
             return m_fieldIdentifier;
         }
 
         /// Get the contained field identifier or assert.
-        Identifier& getField() {
+        ShortId& getField() {
             assert(isField());
             return m_fieldIdentifier;
         }
@@ -63,7 +63,7 @@ namespace babelwires {
         }
 
         /// If the step contains a field identifier, return a pointer to it.
-        const Identifier* asField() const { return isField() ? &m_fieldIdentifier : nullptr; }
+        const ShortId* asField() const { return isField() ? &m_fieldIdentifier : nullptr; }
 
         /// If the step contains an array index, return a pointer to it.
         const ArrayIndex* asIndex() const { return isIndex() ? &m_arrayIndex.m_index : nullptr; }
@@ -93,7 +93,7 @@ namespace babelwires {
         friend struct std::hash<PathStep>;
 
         // A union of these.
-        Identifier m_fieldIdentifier;
+        ShortId m_fieldIdentifier;
 
         struct Index {
             /// The last two bytes are used as the tag.

--- a/BabelWiresLib/Features/enumFeature.cpp
+++ b/BabelWiresLib/Features/enumFeature.cpp
@@ -27,11 +27,11 @@ const babelwires::Enum& babelwires::EnumFeature::getEnum() const {
     return *e;
 }
 
-babelwires::Identifier babelwires::EnumFeature::get() const {
+babelwires::ShortId babelwires::EnumFeature::get() const {
     return m_value;
 }
 
-void babelwires::EnumFeature::set(Identifier id) {
+void babelwires::EnumFeature::set(ShortId id) {
     const Enum& e = getEnum();
     const Enum::EnumValues& values = e.getEnumValues();
     const auto it = std::find(values.begin(), values.end(), id);
@@ -47,7 +47,7 @@ void babelwires::EnumFeature::set(Identifier id) {
 
 void babelwires::EnumFeature::doSetToDefault() {
     const Enum& e = getEnum();
-    const Identifier defaultValue = e.getIdentifierFromIndex(e.getIndexOfDefaultValue());
+    const ShortId defaultValue = e.getIdentifierFromIndex(e.getIndexOfDefaultValue());
     if (defaultValue != m_value) {
         setChanged(Changes::ValueChanged);
         m_value = defaultValue;
@@ -55,7 +55,7 @@ void babelwires::EnumFeature::doSetToDefault() {
 }
 
 std::size_t babelwires::EnumFeature::doGetHash() const {
-    return std::hash<Identifier>{}(m_value);
+    return std::hash<ShortId>{}(m_value);
 }
 
 std::string babelwires::EnumFeature::doGetValueType() const {
@@ -64,6 +64,6 @@ std::string babelwires::EnumFeature::doGetValueType() const {
 
 void babelwires::EnumFeature::doAssign(const ValueFeature& other) {
     const EnumFeature& otherEnum = static_cast<const EnumFeature&>(other);
-    Identifier otherValue = otherEnum.get();
+    ShortId otherValue = otherEnum.get();
     set(otherValue);
 }

--- a/BabelWiresLib/Features/enumFeature.hpp
+++ b/BabelWiresLib/Features/enumFeature.hpp
@@ -30,10 +30,10 @@ namespace babelwires {
         const Enum& getEnum() const;
 
         /// Get the current value of the feature.
-        Identifier get() const;
+        ShortId get() const;
 
         /// Set the value in the feature.
-        void set(Identifier value);
+        void set(ShortId value);
 
       protected:
         std::string doGetValueType() const override;
@@ -46,7 +46,7 @@ namespace babelwires {
         TypeRef m_enum;
 
         ///
-        Identifier m_value;
+        ShortId m_value;
     };
 
     /// EnumFeature for RegisteredEnums, which can be conveniently constructed, since it assumes the Enum it

--- a/BabelWiresLib/Features/recordFeature.cpp
+++ b/BabelWiresLib/Features/recordFeature.cpp
@@ -31,7 +31,7 @@ const babelwires::Feature* babelwires::RecordFeature::doGetFeature(int i) const 
     return m_fields.at(i).m_feature.get();
 }
 
-babelwires::Identifier babelwires::RecordFeature::getFieldIdentifier(int i) const {
+babelwires::ShortId babelwires::RecordFeature::getFieldIdentifier(int i) const {
     return m_fields.at(i).m_identifier;
 }
 
@@ -49,7 +49,7 @@ namespace {
     template <typename R>
     typename babelwires::CopyConst<R, babelwires::Feature>::type*
     tryGetChildFromStepT(R* record, const babelwires::PathStep& step) {
-        if (const babelwires::Identifier* field = step.asField()) {
+        if (const babelwires::ShortId* field = step.asField()) {
             const int childIndex = record->getChildIndexFromStep(*field);
             if (childIndex >= 0) {
                 return record->getFeature(childIndex);
@@ -68,9 +68,9 @@ const babelwires::Feature* babelwires::RecordFeature::tryGetChildFromStep(const 
     return tryGetChildFromStepT(this, step);
 }
 
-int babelwires::RecordFeature::getChildIndexFromStep(const Identifier& identifier) const {
+int babelwires::RecordFeature::getChildIndexFromStep(const ShortId& identifier) const {
     for (int i = 0; i < getNumFeatures(); ++i) {
-        Identifier f = getFieldIdentifier(i);
+        ShortId f = getFieldIdentifier(i);
         if (f == identifier) {
             // Since step has resolved, ensure it gets the correct discriminator.
             f.copyDiscriminatorTo(identifier);
@@ -98,7 +98,7 @@ void babelwires::RecordFeature::addFieldAndIndexInternal(FieldAndIndex fieldAndI
     addFieldInternal(std::move(fieldAndIndex), targetIndex);
 }
 
-babelwires::RecordFeature::FieldAndIndex babelwires::RecordFeature::removeField(Identifier identifier) {
+babelwires::RecordFeature::FieldAndIndex babelwires::RecordFeature::removeField(ShortId identifier) {
     int i;
     for (i = 0; i < m_fields.size(); ++i) {
         if (identifier == m_fields[i].m_identifier) {

--- a/BabelWiresLib/Features/recordFeature.hpp
+++ b/BabelWiresLib/Features/recordFeature.hpp
@@ -19,7 +19,7 @@ namespace babelwires {
     class RecordFeature : public CompoundFeature {
       public:
         /// The identifier must be already be registered with a field name.
-        /// Fields are normally give names using the REGISTERED_ID macro in fieldName.h.
+        /// Fields are normally give names using the BW_SHORT_ID macro in fieldName.h.
         /// The identifier need only be unique in the Record.
         template <typename T> T* addField(std::unique_ptr<T> f, const ShortId& identifier);
 

--- a/BabelWiresLib/Features/recordFeature.hpp
+++ b/BabelWiresLib/Features/recordFeature.hpp
@@ -21,9 +21,9 @@ namespace babelwires {
         /// The identifier must be already be registered with a field name.
         /// Fields are normally give names using the REGISTERED_ID macro in fieldName.h.
         /// The identifier need only be unique in the Record.
-        template <typename T> T* addField(std::unique_ptr<T> f, const Identifier& identifier);
+        template <typename T> T* addField(std::unique_ptr<T> f, const ShortId& identifier);
 
-        Identifier getFieldIdentifier(int index) const;
+        ShortId getFieldIdentifier(int index) const;
 
         virtual int getNumFeatures() const override;
         virtual PathStep getStepToChild(const Feature* child) const override;
@@ -32,7 +32,7 @@ namespace babelwires {
 
         /// Returns -1 if not found.
         /// Sets the descriminator of identifier on a match.
-        int getChildIndexFromStep(const Identifier& identifier) const;
+        int getChildIndexFromStep(const ShortId& identifier) const;
 
       protected:
         virtual void doSetToDefault() override;
@@ -43,7 +43,7 @@ namespace babelwires {
 
         /// The per-field data.
         struct Field {
-            Identifier m_identifier;
+            ShortId m_identifier;
             std::unique_ptr<Feature> m_feature;
         };
 
@@ -56,7 +56,7 @@ namespace babelwires {
         /// Convenience method which calls the addFieldInternal.
         void addFieldAndIndexInternal(FieldAndIndex fieldAndIndex);
 
-        FieldAndIndex removeField(Identifier identifier);
+        FieldAndIndex removeField(ShortId identifier);
 
       protected:
         std::vector<Field> m_fields;

--- a/BabelWiresLib/Features/recordFeature_inl.hpp
+++ b/BabelWiresLib/Features/recordFeature_inl.hpp
@@ -5,7 +5,7 @@
  * 
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
-template <typename T> T* babelwires::RecordFeature::addField(std::unique_ptr<T> f, const Identifier& identifier) {
+template <typename T> T* babelwires::RecordFeature::addField(std::unique_ptr<T> f, const ShortId& identifier) {
     T* fTPtr = f.get();
     addFieldInternal(Field{identifier, std::move(f)});
     return fTPtr;

--- a/BabelWiresLib/Features/recordWithOptionalsFeature.cpp
+++ b/BabelWiresLib/Features/recordWithOptionalsFeature.cpp
@@ -17,7 +17,7 @@ void babelwires::RecordWithOptionalsFeature::addOptionalFieldInternal(FieldAndIn
     m_inactiveFields.emplace_back(std::move(f));
 }
 
-void babelwires::RecordWithOptionalsFeature::activateField(Identifier identifier) {
+void babelwires::RecordWithOptionalsFeature::activateField(ShortId identifier) {
     const auto it = std::find_if(m_inactiveFields.begin(), m_inactiveFields.end(),
                                  [identifier](const FieldAndIndex& f) { return f.m_identifier == identifier; });
     if(it == m_inactiveFields.end()) {
@@ -28,7 +28,7 @@ void babelwires::RecordWithOptionalsFeature::activateField(Identifier identifier
     m_inactiveFields.erase(it);
 }
 
-void babelwires::RecordWithOptionalsFeature::deactivateField(Identifier identifier) {
+void babelwires::RecordWithOptionalsFeature::deactivateField(ShortId identifier) {
     if (!isOptional(identifier) || !isActivated(identifier)) {
         throw ModelException() << "The field " << identifier << " is not an active optional field, so it cannot be deactivated";
     }
@@ -43,16 +43,16 @@ void babelwires::RecordWithOptionalsFeature::deactivateField(Identifier identifi
     m_inactiveFields.insert(insertionPoint, std::move(f));
 }
 
-bool babelwires::RecordWithOptionalsFeature::isOptional(Identifier identifier) const {
+bool babelwires::RecordWithOptionalsFeature::isOptional(ShortId identifier) const {
     return std::find(m_optionalFields.begin(), m_optionalFields.end(), identifier) != m_optionalFields.end();
 }
 
-bool babelwires::RecordWithOptionalsFeature::isActivated(Identifier identifier) const {
+bool babelwires::RecordWithOptionalsFeature::isActivated(ShortId identifier) const {
     assert(isOptional(identifier) && "The identifier does not identify an optional field");
     return tryGetChildFromStep(PathStep(identifier));
 }
 
-const std::vector<babelwires::Identifier>& babelwires::RecordWithOptionalsFeature::getOptionalFields() const {
+const std::vector<babelwires::ShortId>& babelwires::RecordWithOptionalsFeature::getOptionalFields() const {
     return m_optionalFields;
 }
 

--- a/BabelWiresLib/Features/recordWithOptionalsFeature.hpp
+++ b/BabelWiresLib/Features/recordWithOptionalsFeature.hpp
@@ -16,23 +16,23 @@ namespace babelwires {
     class RecordWithOptionalsFeature : public RecordFeature {
         public:
             /// Add an optional field, which is not present in the record until activated.
-            template <typename T> T* addOptionalField(std::unique_ptr<T> f, const Identifier& identifier);
+            template <typename T> T* addOptionalField(std::unique_ptr<T> f, const ShortId& identifier);
 
             /// Active the field, so it appears in the record.
-            void activateField(Identifier identifier);
+            void activateField(ShortId identifier);
 
             /// Deactivate the field, so it does not appear in the record.
             /// This operation sets the subfeature to its default state.
-            void deactivateField(Identifier identifier);
+            void deactivateField(ShortId identifier);
 
             /// Is the given field an optional (irrespective of whether its activated or not).
-            bool isOptional(Identifier identifier) const;
+            bool isOptional(ShortId identifier) const;
 
             /// Is the given optional field activated?
-            bool isActivated(Identifier identifier) const;
+            bool isActivated(ShortId identifier) const;
 
             /// Get the set of optional fields.
-            const std::vector<Identifier>& getOptionalFields() const;
+            const std::vector<ShortId>& getOptionalFields() const;
 
             /// Get the count of the currently inactive optional fields.
             int getNumInactiveFields() const;
@@ -43,13 +43,13 @@ namespace babelwires {
             void doSetToDefaultNonRecursive() override;
         protected:
             /// Those fields which are optional.
-            std::vector<Identifier> m_optionalFields;
+            std::vector<ShortId> m_optionalFields;
 
             /// The inactive fields, sorted by activeIndex;
             std::vector<FieldAndIndex> m_inactiveFields;
     };
 
-    template <typename T> T* babelwires::RecordWithOptionalsFeature::addOptionalField(std::unique_ptr<T> f, const Identifier& identifier) {
+    template <typename T> T* babelwires::RecordWithOptionalsFeature::addOptionalField(std::unique_ptr<T> f, const ShortId& identifier) {
         T* fTPtr = f.get();
         addOptionalFieldInternal(FieldAndIndex{identifier, std::move(f), getNumFeatures()});
         return fTPtr;

--- a/BabelWiresLib/Features/unionFeature.cpp
+++ b/BabelWiresLib/Features/unionFeature.cpp
@@ -18,7 +18,7 @@ babelwires::UnionFeature::UnionFeature(TagValues tags, unsigned int defaultTagIn
     m_fieldsInBranches.resize(m_tags.size());
 }
 
-void babelwires::UnionFeature::addFieldInBranchesInternal(const std::vector<Identifier>& tags, Field field) {
+void babelwires::UnionFeature::addFieldInBranchesInternal(const std::vector<ShortId>& tags, Field field) {
     assert((tags.size() > 0) && "Each branch field must be associated with at least one tag");
     assert((tryGetChildFromStep(PathStep{field.m_identifier}) == nullptr) &&
            "Field identifier already used in the main record");
@@ -40,7 +40,7 @@ void babelwires::UnionFeature::addFieldInBranchesInternal(const std::vector<Iden
     }
 }
 
-void babelwires::UnionFeature::selectTag(Identifier tag) {
+void babelwires::UnionFeature::selectTag(ShortId tag) {
     if (!isTag(tag)) {
         // TODO Look up name from identifier
         throw ModelException() << "\"" << tag << "\" is not a valid tag for this union";
@@ -84,7 +84,7 @@ const babelwires::UnionFeature::TagValues& babelwires::UnionFeature::getTags() c
     return m_tags;
 }
 
-bool babelwires::UnionFeature::isTag(Identifier tag) const {
+bool babelwires::UnionFeature::isTag(ShortId tag) const {
     return std::find(m_tags.begin(), m_tags.end(), tag) != m_tags.end();
 }
 
@@ -105,7 +105,7 @@ void babelwires::UnionFeature::doSetToDefaultNonRecursive() {
     selectTagByIndex(m_defaultTagIndex);
 }
 
-babelwires::Identifier babelwires::UnionFeature::getSelectedTag() const {
+babelwires::ShortId babelwires::UnionFeature::getSelectedTag() const {
     assert((m_selectedTagIndex >= 0) && "Cannot call getSelectedTag until the union has been set to default");
     return m_tags[m_selectedTagIndex];
 }
@@ -114,14 +114,14 @@ unsigned int babelwires::UnionFeature::getSelectedTagIndex() const {
     return m_selectedTagIndex;
 }
 
-unsigned int babelwires::UnionFeature::getIndexOfTag(Identifier tag) const {
+unsigned int babelwires::UnionFeature::getIndexOfTag(ShortId tag) const {
     const auto it = std::find(m_tags.begin(), m_tags.end(), tag);
     assert((it != m_tags.end()) && "The given tag is not a valid tag of this union");
     return it - m_tags.begin();
 }
 
-std::vector<babelwires::Identifier>
-babelwires::UnionFeature::getFieldsRemovedByChangeOfBranch(Identifier proposedTag) const {
+std::vector<babelwires::ShortId>
+babelwires::UnionFeature::getFieldsRemovedByChangeOfBranch(ShortId proposedTag) const {
     unsigned int tagIndex = getIndexOfTag(proposedTag);
     babelwires::UnionFeature::BranchAdjustment branchAdjustment = getBranchAdjustment(tagIndex);
     return std::move(branchAdjustment.m_fieldsToRemove);
@@ -129,12 +129,12 @@ babelwires::UnionFeature::getFieldsRemovedByChangeOfBranch(Identifier proposedTa
 
 babelwires::UnionFeature::BranchAdjustment babelwires::UnionFeature::getBranchAdjustment(unsigned int tagIndex) const {
     assert((tagIndex != m_selectedTagIndex) && "Same branch");
-    std::vector<Identifier> fieldsToRemove;
+    std::vector<ShortId> fieldsToRemove;
     if (m_selectedTagIndex >= 0) {
         fieldsToRemove = m_fieldsInBranches[m_selectedTagIndex];
     }
-    const std::vector<Identifier>& targetBranch = m_fieldsInBranches[tagIndex];
-    std::vector<Identifier> fieldsToAdd = targetBranch;
+    const std::vector<ShortId>& targetBranch = m_fieldsInBranches[tagIndex];
+    std::vector<ShortId> fieldsToAdd = targetBranch;
     // This doesn't need to be N^2, but these vectors are likely to be very small, so it's fine.
     fieldsToAdd.erase(std::remove_if(fieldsToAdd.begin(), fieldsToAdd.end(),
                                    [&fieldsToRemove](auto t) {

--- a/BabelWiresLib/Features/unionFeature.hpp
+++ b/BabelWiresLib/Features/unionFeature.hpp
@@ -19,7 +19,7 @@ namespace babelwires {
     /// Not every tag needs to have fields associated with it.
     class UnionFeature : public RecordFeature {
       public:
-        using TagValues = std::vector<Identifier>;
+        using TagValues = std::vector<ShortId>;
 
         /// Construct a union with the given set of tags.
         /// The tags' identifiers must be registered.
@@ -29,33 +29,33 @@ namespace babelwires {
         const TagValues& getTags() const;
 
         /// Get the index of the given tag.
-        unsigned int getIndexOfTag(Identifier tag) const;
+        unsigned int getIndexOfTag(ShortId tag) const;
 
         /// Check whether the tag is a tag of this union.
-        bool isTag(Identifier tag) const;
+        bool isTag(ShortId tag) const;
 
         /// Add a field to the branch corresponding to the given tag.
         template <typename T>
-        T* addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f, const Identifier& fieldIdentifier);
+        T* addFieldInBranch(const ShortId& tag, std::unique_ptr<T> f, const ShortId& fieldIdentifier);
 
         /// Add a field to the branches corresponding to the given tags.
         template <typename T>
-        T* addFieldInBranches(const std::vector<Identifier>& tags, std::unique_ptr<T> f, const Identifier& fieldIdentifier);
+        T* addFieldInBranches(const std::vector<ShortId>& tags, std::unique_ptr<T> f, const ShortId& fieldIdentifier);
 
         /// Select the tag.
-        void selectTag(Identifier tag);
+        void selectTag(ShortId tag);
 
         /// Return the tag which is currently selected.
-        Identifier getSelectedTag() const;
+        ShortId getSelectedTag() const;
 
         /// Return the index of the tag which is currently selected.
         unsigned int getSelectedTagIndex() const;
 
         /// Get the fields which would be removed if the proposedTag was selected.
-        std::vector<Identifier> getFieldsRemovedByChangeOfBranch(Identifier proposedTag) const;
+        std::vector<ShortId> getFieldsRemovedByChangeOfBranch(ShortId proposedTag) const;
 
       protected:
-        void addFieldInBranchesInternal(const std::vector<Identifier>& tags, Field field);
+        void addFieldInBranchesInternal(const std::vector<ShortId>& tags, Field field);
         void doSetToDefault() override;
         void doSetToDefaultNonRecursive() override;
 
@@ -63,8 +63,8 @@ namespace babelwires {
         void selectTagByIndex(unsigned int index);
 
         struct BranchAdjustment {
-            std::vector<Identifier> m_fieldsToRemove;
-            std::vector<Identifier> m_fieldsToAdd;
+            std::vector<ShortId> m_fieldsToRemove;
+            std::vector<ShortId> m_fieldsToAdd;
         };
 
         BranchAdjustment getBranchAdjustment(unsigned int tagIndex) const;
@@ -86,21 +86,21 @@ namespace babelwires {
           std::vector<TagIndexAndIntendedFieldIndex> m_tagsWithIntendedIndices;
         };
 
-        std::unordered_map<Identifier, FieldInfo> m_fieldInfo;
+        std::unordered_map<ShortId, FieldInfo> m_fieldInfo;
 
         /// In tag index order.
-        std::vector<std::vector<Identifier>> m_fieldsInBranches;
+        std::vector<std::vector<ShortId>> m_fieldsInBranches;
     };
 
     template <typename T>
-    T* babelwires::UnionFeature::addFieldInBranch(const Identifier& tag, std::unique_ptr<T> f,
-                                                  const Identifier& fieldIdentifier) {
+    T* babelwires::UnionFeature::addFieldInBranch(const ShortId& tag, std::unique_ptr<T> f,
+                                                  const ShortId& fieldIdentifier) {
         return addFieldInBranches({tag}, std::move(f), fieldIdentifier);
     }
 
     template <typename T>
-    T* babelwires::UnionFeature::addFieldInBranches(const std::vector<Identifier>& tags, std::unique_ptr<T> f,
-                                                  const Identifier& fieldIdentifier) {
+    T* babelwires::UnionFeature::addFieldInBranches(const std::vector<ShortId>& tags, std::unique_ptr<T> f,
+                                                  const ShortId& fieldIdentifier) {
         T* fTPtr = f.get();
         addFieldInBranchesInternal(tags, Field{fieldIdentifier, std::move(f)});
         return fTPtr;

--- a/BabelWiresLib/FileFormat/fileFeature.cpp
+++ b/BabelWiresLib/FileFormat/fileFeature.cpp
@@ -7,10 +7,10 @@
  **/
 #include <BabelWiresLib/FileFormat/fileFeature.hpp>
 
-babelwires::FileFeature::FileFeature(const ProjectContext& projectContext, LongIdentifier fileFormatIdentifier)
+babelwires::FileFeature::FileFeature(const ProjectContext& projectContext, LongId fileFormatIdentifier)
     : RootFeature(projectContext)
     , m_factoryIdentifier(fileFormatIdentifier) {}
 
-babelwires::LongIdentifier babelwires::FileFeature::getFileFormatIdentifier() const {
+babelwires::LongId babelwires::FileFeature::getFileFormatIdentifier() const {
     return m_factoryIdentifier;
 }

--- a/BabelWiresLib/FileFormat/fileFeature.hpp
+++ b/BabelWiresLib/FileFormat/fileFeature.hpp
@@ -18,16 +18,16 @@ namespace babelwires {
     // TODO: abandon this and do all special casing in the UI.
     class FileFeature : public RootFeature {
       public:
-        FileFeature(const ProjectContext& context, LongIdentifier fileFormatIdentifier);
+        FileFeature(const ProjectContext& context, LongId fileFormatIdentifier);
 
         /// Return the identifier of the file format which knows how to load and save this type of feature.
         // TODO No longer used.
-        LongIdentifier getFileFormatIdentifier() const;
+        LongId getFileFormatIdentifier() const;
 
       private:
         /// The file format which knows how to load or save this type of feature.
         // TODO This is no longer used. Everywhere that needs it, can obtain it from the element.
-        LongIdentifier m_factoryIdentifier;
+        LongId m_factoryIdentifier;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/FileFormat/sourceFileFormat.cpp
+++ b/BabelWiresLib/FileFormat/sourceFileFormat.cpp
@@ -10,5 +10,5 @@
 babelwires::SourceFileFormatRegistry::SourceFileFormatRegistry()
     : FileTypeRegistry("File Format Registry") {}
 
-babelwires::SourceFileFormat::SourceFileFormat(LongIdentifier identifier, VersionNumber version, Extensions extensions)
+babelwires::SourceFileFormat::SourceFileFormat(LongId identifier, VersionNumber version, Extensions extensions)
     : FileTypeEntry(identifier, version, std::move(extensions)) {}

--- a/BabelWiresLib/FileFormat/sourceFileFormat.hpp
+++ b/BabelWiresLib/FileFormat/sourceFileFormat.hpp
@@ -26,7 +26,7 @@ namespace babelwires {
     /// Format which can create a feature by loading a file.
     class SourceFileFormat : public FileTypeEntry, ProductInfo {
       public:
-        SourceFileFormat(LongIdentifier identifier, VersionNumber version, Extensions extensions);
+        SourceFileFormat(LongId identifier, VersionNumber version, Extensions extensions);
         virtual std::unique_ptr<babelwires::FileFeature> loadFromFile(DataSource& dataSource, const ProjectContext& projectContext,
                                                                       UserLogger& userLogger) const = 0;
     };

--- a/BabelWiresLib/FileFormat/targetFileFormat.cpp
+++ b/BabelWiresLib/FileFormat/targetFileFormat.cpp
@@ -10,5 +10,5 @@
 babelwires::TargetFileFormatRegistry::TargetFileFormatRegistry()
     : Registry("File Feature Factory Registry"){};
 
-babelwires::TargetFileFormat::TargetFileFormat(LongIdentifier identifier, VersionNumber version, Extensions extensions)
+babelwires::TargetFileFormat::TargetFileFormat(LongId identifier, VersionNumber version, Extensions extensions)
     : FileTypeEntry(identifier, version, std::move(extensions)) {}

--- a/BabelWiresLib/FileFormat/targetFileFormat.hpp
+++ b/BabelWiresLib/FileFormat/targetFileFormat.hpp
@@ -26,7 +26,7 @@ namespace babelwires {
     /// Factories which can create FileFeatures in a default state, and write those features as files.
     class TargetFileFormat : public FileTypeEntry, ProductInfo {
       public:
-        TargetFileFormat(LongIdentifier identifier, VersionNumber version, Extensions extensions);
+        TargetFileFormat(LongId identifier, VersionNumber version, Extensions extensions);
         virtual std::unique_ptr<FileFeature> createNewFeature(const ProjectContext& projectContext) const = 0;
         virtual void writeToFile(const ProjectContext& projectContext, UserLogger& userLogger, const FileFeature& fileFeature, std::ostream& os) const = 0;
     };

--- a/BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp
+++ b/BabelWiresLib/Maps/Helpers/enumValueAdapters.hpp
@@ -13,7 +13,7 @@
 namespace babelwires {
     /// Convert an EnumValue to the identifier it carries.
     struct EnumToIdentifierValueAdapter {
-        babelwires::Identifier operator() (const Value& value) const {
+        babelwires::ShortId operator() (const Value& value) const {
             const auto& enumValue = value.is<EnumValue>();
             return enumValue.get();
         }

--- a/BabelWiresLib/Processors/commonProcessor.hpp
+++ b/BabelWiresLib/Processors/commonProcessor.hpp
@@ -30,7 +30,7 @@ namespace babelwires {
     /// A convenient base class for processor factories.
     template <typename PROCESSOR> class CommonProcessorFactory : public ProcessorFactory {
       public:
-        CommonProcessorFactory(LongIdentifier identifier, VersionNumber version)
+        CommonProcessorFactory(LongId identifier, VersionNumber version)
             : ProcessorFactory(identifier, version) {}
 
         std::unique_ptr<babelwires::Processor> createNewProcessor(const ProjectContext& projectContext) const override {

--- a/BabelWiresLib/Processors/parallelProcessor.hpp
+++ b/BabelWiresLib/Processors/parallelProcessor.hpp
@@ -53,7 +53,7 @@ namespace babelwires {
       protected:
         /// Subclass constructors should call this to add the input/output array. This should almost always
         /// be after all the input features are added.
-        void addArrayFeature(Identifier id) {
+        void addArrayFeature(ShortId id) {
             m_arrayIn = m_inputFeature->addField(std::make_unique<InputArrayFeature>(), id);
             m_arrayOut = m_outputFeature->addField(std::make_unique<OutputArrayFeature>(), id);
         }

--- a/BabelWiresLib/Processors/processorFactory.cpp
+++ b/BabelWiresLib/Processors/processorFactory.cpp
@@ -7,5 +7,5 @@
  **/
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 
-babelwires::ProcessorFactory::ProcessorFactory(LongIdentifier identifier, VersionNumber version)
+babelwires::ProcessorFactory::ProcessorFactory(LongId identifier, VersionNumber version)
     : RegistryEntry(identifier, version) {}

--- a/BabelWiresLib/Processors/processorFactory.hpp
+++ b/BabelWiresLib/Processors/processorFactory.hpp
@@ -20,7 +20,7 @@ namespace babelwires {
     /// Objects which can create processors, and which can be registered in the ProcessFactoryRegistry.
     class ProcessorFactory : public RegistryEntry {
       public:
-        ProcessorFactory(LongIdentifier identifier, VersionNumber version);
+        ProcessorFactory(LongId identifier, VersionNumber version);
 
         /// Return a new processor.
         virtual std::unique_ptr<Processor> createNewProcessor(const ProjectContext& projectContext) const = 0;

--- a/BabelWiresLib/Project/Commands/activateOptionalCommand.cpp
+++ b/BabelWiresLib/Project/Commands/activateOptionalCommand.cpp
@@ -16,7 +16,7 @@
 #include <BabelWiresLib/Features/rootFeature.hpp>
 
 babelwires::ActivateOptionalCommand::ActivateOptionalCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier optional)
+                               ShortId optional)
     : SimpleCommand(commandName)
     , m_elementId(elementId)
     , m_pathToRecord(std::move(featurePath))

--- a/BabelWiresLib/Project/Commands/activateOptionalCommand.hpp
+++ b/BabelWiresLib/Project/Commands/activateOptionalCommand.hpp
@@ -19,7 +19,7 @@ namespace babelwires {
     class ActivateOptionalCommand : public SimpleCommand<Project> {
       public:
         ActivateOptionalCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier optional);
+                               ShortId optional);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
@@ -28,7 +28,7 @@ namespace babelwires {
       private:
         ElementId m_elementId;
         FeaturePath m_pathToRecord;
-        Identifier m_optional;
+        ShortId m_optional;
 
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;

--- a/BabelWiresLib/Project/Commands/deactivateOptionalCommand.cpp
+++ b/BabelWiresLib/Project/Commands/deactivateOptionalCommand.cpp
@@ -17,7 +17,7 @@
 #include <BabelWiresLib/Project/project.hpp>
 
 babelwires::DeactivateOptionalCommand::DeactivateOptionalCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier optional)
+                               ShortId optional)
     : CompoundCommand(commandName)
     , m_elementId(elementId)
     , m_pathToRecord(std::move(featurePath))

--- a/BabelWiresLib/Project/Commands/deactivateOptionalCommand.hpp
+++ b/BabelWiresLib/Project/Commands/deactivateOptionalCommand.hpp
@@ -19,7 +19,7 @@ namespace babelwires {
     class DeactivateOptionalCommand : public CompoundCommand<Project> {
       public:
         DeactivateOptionalCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier optional);
+                               ShortId optional);
 
         virtual bool initializeAndExecute(Project& project) override;
         virtual void execute(Project& project) const override;
@@ -28,7 +28,7 @@ namespace babelwires {
       private:
         ElementId m_elementId;
         FeaturePath m_pathToRecord;
-        Identifier m_optional;
+        ShortId m_optional;
 
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.cpp
@@ -17,7 +17,7 @@
 #include <BabelWiresLib/Features/rootFeature.hpp>
 
 babelwires::SelectUnionBranchCommand::SelectUnionBranchCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier tagToSelect)
+                               ShortId tagToSelect)
     : CompoundCommand(commandName)
     , m_elementId(elementId)
     , m_pathToUnion(std::move(featurePath))

--- a/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
+++ b/BabelWiresLib/Project/Commands/selectUnionBranchCommand.hpp
@@ -20,7 +20,7 @@ namespace babelwires {
     class SelectUnionBranchCommand : public CompoundCommand<Project> {
       public:
         SelectUnionBranchCommand(std::string commandName, ElementId elementId, FeaturePath featurePath,
-                               Identifier tagToSelect);
+                               ShortId tagToSelect);
 
         virtual bool initializeAndExecute(Project& project) override;
         virtual void execute(Project& project) const override;
@@ -29,7 +29,7 @@ namespace babelwires {
       private:
         ElementId m_elementId;
         FeaturePath m_pathToUnion;
-        Identifier m_tagToSelect;
+        ShortId m_tagToSelect;
 
         std::unique_ptr<ModifierData> m_unionModifierToAdd;
         std::unique_ptr<ModifierData> m_unionModifierToRemove;

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -177,7 +177,7 @@ namespace babelwires {
                     const int cacheStartSize = m_rows.size();
                     std::unordered_set<int> outputIndicesHandled;
                     for (int i = 0; i < inputFeature->getNumFeatures(); ++i) {
-                        Identifier stepToChild = inputFeature->getFieldIdentifier(i);
+                        ShortId stepToChild = inputFeature->getFieldIdentifier(i);
                         FeaturePath pathToChild = path;
                         const int outputChildIndex = outputFeature->getChildIndexFromStep(stepToChild);
                         pathToChild.pushStep(PathStep(stepToChild));

--- a/BabelWiresLib/Project/FeatureElements/failedFeature.cpp
+++ b/BabelWiresLib/Project/FeatureElements/failedFeature.cpp
@@ -12,5 +12,5 @@
 babelwires::FailedFeature::FailedFeature(const ProjectContext& projectContext)
     : RootFeature(projectContext) {
     addField(std::make_unique<RootFeature>(projectContext),
-             REGISTERED_ID("Failed", "Failed", "2d9667c0-0829-48ec-a952-5ba96cb5693f"));
+             BW_SHORT_ID("Failed", "Failed", "2d9667c0-0829-48ec-a952-5ba96cb5693f"));
 }

--- a/BabelWiresLib/Project/FeatureElements/featureElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElement.cpp
@@ -87,7 +87,7 @@ void babelwires::FeatureElement::setFactoryName(std::string factoryName) {
     m_factoryName = std::move(factoryName);
 }
 
-void babelwires::FeatureElement::setFactoryName(LongIdentifier identifier) {
+void babelwires::FeatureElement::setFactoryName(LongId identifier) {
     m_factoryName = IdentifierRegistry::read()->getName(identifier);
 }
 

--- a/BabelWiresLib/Project/FeatureElements/featureElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElement.hpp
@@ -160,7 +160,7 @@ namespace babelwires {
         void setInternalFailure(std::string reasonForFailure);
 
         void setFactoryName(std::string factoryName);
-        void setFactoryName(LongIdentifier identifier);
+        void setFactoryName(LongId identifier);
 
         friend Modifier;
         friend ConnectionModifier;

--- a/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData.hpp
@@ -79,7 +79,7 @@ namespace babelwires {
         void visitFilePaths(FilePathVisitor& visitor) override;
 
         /// The factory which creates FeatureElements corresponding to this data.
-        LongIdentifier m_factoryIdentifier = "nofact";
+        LongId m_factoryIdentifier = "nofact";
 
         /// The version of the factory to which these contents relate.
         /// 0 is treated specially, and means that versioning should be ignored, and the data should
@@ -118,7 +118,7 @@ namespace babelwires {
         /// Look up the ID in the reg, and issue a warning if there are version incompatibilities.
         template<typename REGISTRY>
         bool checkFactoryVersionCommon(const REGISTRY& reg, UserLogger& userLogger,
-                                   LongIdentifier factoryIdentifier, VersionNumber& thisVersion);
+                                   LongId factoryIdentifier, VersionNumber& thisVersion);
     };
 } // namespace babelwires
 

--- a/BabelWiresLib/Project/FeatureElements/featureElementData_inl.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData_inl.hpp
@@ -1,7 +1,7 @@
 template<typename REGISTRY>
 bool babelwires::ElementData::checkFactoryVersionCommon(const REGISTRY& reg,
                                                         UserLogger& userLogger,
-                                                        LongIdentifier factoryIdentifier,
+                                                        LongId factoryIdentifier,
                                                         VersionNumber& thisVersion) {
     if (const auto* entry = reg.getEntryByIdentifier(factoryIdentifier)) {
         const VersionNumber registeredVersion = entry->getVersion();

--- a/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.cpp
@@ -20,10 +20,10 @@ void babelwires::ActivateOptionalsModifierData::serializeContents(Serializer& se
 
 void babelwires::ActivateOptionalsModifierData::deserializeContents(Deserializer& deserializer) {
     deserializer.deserializeValue("path", m_pathToFeature);
-    for (auto it = deserializer.deserializeValueArray<Identifier>("optionals", Deserializer::IsOptional::Optional,
+    for (auto it = deserializer.deserializeValueArray<ShortId>("optionals", Deserializer::IsOptional::Optional,
                                                                    "activate");
          it.isValid(); ++it) {
-        Identifier temp("__TEMP");
+        ShortId temp("__TEMP");
         m_selectedOptionals.emplace_back(it.deserializeValue(temp));
         assert((m_selectedOptionals.back() != "__TEMP") && "Problem deserializing optional fields");
     }
@@ -34,15 +34,15 @@ void babelwires::ActivateOptionalsModifierData::apply(Feature* targetFeature) co
     if (!record) {
         throw ModelException() << "Cannot selection optionals from a feature which does not have optionals";
     }
-    std::vector<Identifier> availableOptionals = record->getOptionalFields();
+    std::vector<ShortId> availableOptionals = record->getOptionalFields();
     std::sort(availableOptionals.begin(), availableOptionals.end());
     auto ait = availableOptionals.begin();
 
-    std::vector<Identifier> optionalsToEnsureActivated = m_selectedOptionals;
+    std::vector<ShortId> optionalsToEnsureActivated = m_selectedOptionals;
     std::sort(optionalsToEnsureActivated.begin(), optionalsToEnsureActivated.end());
     auto it = optionalsToEnsureActivated.begin();
 
-    std::vector<Identifier> missingOptionals;
+    std::vector<ShortId> missingOptionals;
 
     while ((ait != availableOptionals.end()) && (it != optionalsToEnsureActivated.end())) {
         if (*ait == *it) {

--- a/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp
@@ -19,6 +19,6 @@ namespace babelwires {
         void deserializeContents(Deserializer& deserializer) override;
         void visitIdentifiers(IdentifierVisitor& visitor) override;
 
-        std::vector<Identifier> m_selectedOptionals;
+        std::vector<ShortId> m_selectedOptionals;
     };
 }

--- a/BabelWiresLib/Project/Modifiers/modifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/modifierData.hpp
@@ -99,6 +99,6 @@ namespace babelwires {
         void deserializeContents(Deserializer& deserializer) override;
         void visitIdentifiers(IdentifierVisitor& visitor) override;
         
-        Identifier m_value = "Fixme";
+        ShortId m_value = "Fixme";
     };
 } // namespace babelwires

--- a/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
+++ b/BabelWiresLib/Project/Modifiers/selectUnionBranchModifierData.hpp
@@ -19,6 +19,6 @@ namespace babelwires {
         void deserializeContents(Deserializer& deserializer) override;
         void visitIdentifiers(IdentifierVisitor& visitor) override;
 
-        Identifier m_tagToSelect;
+        ShortId m_tagToSelect;
     };
 }

--- a/BabelWiresLib/Project/project.cpp
+++ b/BabelWiresLib/Project/project.cpp
@@ -589,7 +589,7 @@ babelwires::ProjectId babelwires::Project::getProjectId() const {
     return m_projectId;
 }
 
-void babelwires::Project::activateOptional(ElementId elementId, const FeaturePath& pathToRecord, Identifier optional, bool ensureModifier) {
+void babelwires::Project::activateOptional(ElementId elementId, const FeaturePath& pathToRecord, ShortId optional, bool ensureModifier) {
     FeatureElement* elementToModify = getFeatureElement(elementId);
     assert (elementToModify);
     
@@ -623,7 +623,7 @@ void babelwires::Project::activateOptional(ElementId elementId, const FeaturePat
     }
 }
 
-void babelwires::Project::deactivateOptional(ElementId elementId, const FeaturePath& pathToRecord, Identifier optional, bool ensureModifier) {
+void babelwires::Project::deactivateOptional(ElementId elementId, const FeaturePath& pathToRecord, ShortId optional, bool ensureModifier) {
     FeatureElement* elementToModify = getFeatureElement(elementId);
     assert (elementToModify);
     

--- a/BabelWiresLib/Project/project.hpp
+++ b/BabelWiresLib/Project/project.hpp
@@ -84,11 +84,11 @@ namespace babelwires {
                                 int numEntriesToRemove, bool ensureModifier);
 
         /// Activate a modifier in a RecordWithOptionalsFeature.
-        void activateOptional(ElementId elementId, const FeaturePath& pathToRecord, Identifier optional, bool ensureModifier);
+        void activateOptional(ElementId elementId, const FeaturePath& pathToRecord, ShortId optional, bool ensureModifier);
 
         /// Deactivate a modifier in a RecordWithOptionalsFeature.
         /// Note that this will not remove modifiers.
-        void deactivateOptional(ElementId elementId, const FeaturePath& pathToRecord, Identifier optional, bool ensureModifier);
+        void deactivateOptional(ElementId elementId, const FeaturePath& pathToRecord, ShortId optional, bool ensureModifier);
 
         /// Set the Ui position of the element.
         void setElementPosition(ElementId elementId, const UiPosition& newPosition);

--- a/BabelWiresLib/Project/projectVisitable.hpp
+++ b/BabelWiresLib/Project/projectVisitable.hpp
@@ -17,7 +17,7 @@ namespace babelwires {
 
     struct IdentifierVisitor {
         virtual ~IdentifierVisitor() = default;
-        virtual void operator()(Identifier& identifier) = 0;
+        virtual void operator()(ShortId& identifier) = 0;
         virtual void operator()(LongIdentifier& identifier) = 0;
 
         /// Allow the visitor to be applied to types in templates which may or may have identifier members.

--- a/BabelWiresLib/Project/projectVisitable.hpp
+++ b/BabelWiresLib/Project/projectVisitable.hpp
@@ -18,6 +18,7 @@ namespace babelwires {
     struct IdentifierVisitor {
         virtual ~IdentifierVisitor() = default;
         virtual void operator()(ShortId& identifier) = 0;
+        virtual void operator()(MediumId& identifier) = 0;
         virtual void operator()(LongId& identifier) = 0;
 
         /// Allow the visitor to be applied to types in templates which may or may have identifier members.

--- a/BabelWiresLib/Project/projectVisitable.hpp
+++ b/BabelWiresLib/Project/projectVisitable.hpp
@@ -18,7 +18,7 @@ namespace babelwires {
     struct IdentifierVisitor {
         virtual ~IdentifierVisitor() = default;
         virtual void operator()(ShortId& identifier) = 0;
-        virtual void operator()(LongIdentifier& identifier) = 0;
+        virtual void operator()(LongId& identifier) = 0;
 
         /// Allow the visitor to be applied to types in templates which may or may have identifier members.
         void operator()(...) {}

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -25,7 +25,7 @@ namespace babelwires {
                 }
             }
 
-            void operator()(babelwires::Identifier& identifier) override { visit(identifier); }
+            void operator()(babelwires::ShortId& identifier) override { visit(identifier); }
             void operator()(babelwires::LongIdentifier& identifier) override { visit(identifier); }
 
             const SOURCE_REG& m_sourceReg;

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -26,7 +26,7 @@ namespace babelwires {
             }
 
             void operator()(babelwires::ShortId& identifier) override { visit(identifier); }
-            void operator()(babelwires::LongIdentifier& identifier) override { visit(identifier); }
+            void operator()(babelwires::LongId& identifier) override { visit(identifier); }
 
             const SOURCE_REG& m_sourceReg;
             TARGET_REG& m_targetReg;

--- a/BabelWiresLib/Serialization/dataBundle_inl.hpp
+++ b/BabelWiresLib/Serialization/dataBundle_inl.hpp
@@ -26,6 +26,7 @@ namespace babelwires {
             }
 
             void operator()(babelwires::ShortId& identifier) override { visit(identifier); }
+            void operator()(babelwires::MediumId& identifier) override { visit(identifier); }
             void operator()(babelwires::LongId& identifier) override { visit(identifier); }
 
             const SOURCE_REG& m_sourceReg;

--- a/BabelWiresLib/Serialization/projectBundle.cpp
+++ b/BabelWiresLib/Serialization/projectBundle.cpp
@@ -40,7 +40,7 @@ void babelwires::ProjectBundle::adaptDataToAdditionalMetadata(const ProjectConte
 namespace {
     struct FactoryInfoPair : babelwires::Serializable {
         SERIALIZABLE(FactoryInfoPair, "factory", void, 1);
-        babelwires::LongIdentifier m_factoryIdentifier = "nofact";
+        babelwires::LongId m_factoryIdentifier = "nofact";
         babelwires::VersionNumber m_factoryVersion;
 
         void serializeContents(babelwires::Serializer& serializer) const override {
@@ -77,7 +77,7 @@ void babelwires::ProjectBundle::visitIdentifiers(IdentifierVisitor& visitor) {
     // Visit the identifiers in the factory metadata.
     decltype(m_factoryMetadata) newMap;
     for (const auto& [k, v] : m_factoryMetadata) {
-        LongIdentifier newKey = k;
+        LongId newKey = k;
         visitor(newKey);
         newMap.insert(std::pair(newKey, v));
     }

--- a/BabelWiresLib/Serialization/projectBundle.hpp
+++ b/BabelWiresLib/Serialization/projectBundle.hpp
@@ -28,7 +28,7 @@ namespace babelwires {
 
       public:
         /// Information about the factories used by the projectData.
-        using FactoryMetadata = std::map<LongIdentifier, VersionNumber>;
+        using FactoryMetadata = std::map<LongId, VersionNumber>;
 
         const FactoryMetadata& getFactoryMetadata() const { return m_factoryMetadata; }
 

--- a/BabelWiresLib/TypeSystem/enumValue.cpp
+++ b/BabelWiresLib/TypeSystem/enumValue.cpp
@@ -15,15 +15,15 @@
 
 babelwires::EnumValue::EnumValue() = default;
 
-babelwires::EnumValue::EnumValue(Identifier value)
+babelwires::EnumValue::EnumValue(ShortId value)
     : m_value(value) {}
 
 /// Get the current value of the feature.
-babelwires::Identifier babelwires::EnumValue::get() const {
+babelwires::ShortId babelwires::EnumValue::get() const {
     return m_value;
 }
 
-void babelwires::EnumValue::set(Identifier value) {
+void babelwires::EnumValue::set(ShortId value) {
     m_value = value;
 }
 

--- a/BabelWiresLib/TypeSystem/enumValue.hpp
+++ b/BabelWiresLib/TypeSystem/enumValue.hpp
@@ -17,13 +17,13 @@ namespace babelwires {
         SERIALIZABLE(EnumValue, "enum", Value, 1);
 
         EnumValue();
-        EnumValue(Identifier value);
+        EnumValue(ShortId value);
 
         /// Get the current value of the feature.
-        Identifier get() const;
+        ShortId get() const;
 
         /// Set the value in the feature.
-        void set(Identifier value);
+        void set(ShortId value);
 
         bool isValid(const Type& type) const override;
         void serializeContents(Serializer& serializer) const override;
@@ -35,6 +35,6 @@ namespace babelwires {
         std::string toString() const override;
 
       private:
-        Identifier m_value;
+        ShortId m_value;
     };
 } // namespace babelwires

--- a/BabelWiresLib/TypeSystem/primitiveType.hpp
+++ b/BabelWiresLib/TypeSystem/primitiveType.hpp
@@ -13,7 +13,7 @@
 
 /// Intended mainly for testing.
 #define PRIMITIVE_TYPE_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                         \
-    static babelwires::LongId getThisIdentifier() { return IDENTIFIER; }                                       \
+    static babelwires::PrimitiveTypeId getThisIdentifier() { return IDENTIFIER; }                                       \
     static babelwires::VersionNumber getVersion() { return VERSION; }                                                  \
     babelwires::TypeRef getTypeRef() const override { return getThisIdentifier(); }
 
@@ -22,4 +22,4 @@
 /// The TypeSystem expects them to support certain functions and methods, which
 /// this macro provides.
 #define PRIMITIVE_TYPE(IDENTIFIER, NAME, UUID, VERSION)                                                                \
-    PRIMITIVE_TYPE_WITH_REGISTERED_ID(BW_LONG_ID(IDENTIFIER, NAME, UUID), VERSION)
+    PRIMITIVE_TYPE_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/TypeSystem/primitiveType.hpp
+++ b/BabelWiresLib/TypeSystem/primitiveType.hpp
@@ -22,4 +22,4 @@
 /// The TypeSystem expects them to support certain functions and methods, which
 /// this macro provides.
 #define PRIMITIVE_TYPE(IDENTIFIER, NAME, UUID, VERSION)                                                                \
-    PRIMITIVE_TYPE_WITH_REGISTERED_ID(REGISTERED_LONGID(IDENTIFIER, NAME, UUID), VERSION)
+    PRIMITIVE_TYPE_WITH_REGISTERED_ID(BW_LONG_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/TypeSystem/primitiveType.hpp
+++ b/BabelWiresLib/TypeSystem/primitiveType.hpp
@@ -13,7 +13,7 @@
 
 /// Intended mainly for testing.
 #define PRIMITIVE_TYPE_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                         \
-    static babelwires::LongIdentifier getThisIdentifier() { return IDENTIFIER; }                                       \
+    static babelwires::LongId getThisIdentifier() { return IDENTIFIER; }                                       \
     static babelwires::VersionNumber getVersion() { return VERSION; }                                                  \
     babelwires::TypeRef getTypeRef() const override { return getThisIdentifier(); }
 

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -26,15 +26,13 @@ namespace babelwires {
       public:
         DOWNCASTABLE_TYPE_HIERARCHY(TypeConstructor);
 
+        static constexpr unsigned int c_arity = N;
+
         /// Get the constructed type from the cache, or construct a new one.
         const Type* getOrConstructType(const TypeSystem& typeSystem, const TypeConstructorArguments<N>& arguments) const;
 
         /// This is supplied by the TYPE_CONSTRUCTOR macro.
         virtual TypeConstructorId getTypeConstructorId() const = 0;
-
-        /// TypeConstructors are expected to have fixed arity.
-        //TODO
-        unsigned int getArity() const { return N; }
 
         /// Are two types constructed by this type constructor related by subtyping?
         /// By default, this returns IsUnrelated.

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -9,34 +9,38 @@
 
 #include <BabelWiresLib/TypeSystem/typeRef.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystemCommon.hpp>
+#include <BabelWiresLib/TypeSystem/type.hpp>
 
 #include <Common/Identifiers/identifier.hpp>
 #include <Common/Identifiers/registeredIdentifier.hpp>
 
 #include <shared_mutex>
+#include <mutex>
 
 namespace babelwires {
 
     /// A TypeConstructor constructs a type from other types.
     /// A mutable cache ensures that each type is only constructed once.
+    template<unsigned int N>
     class TypeConstructor {
       public:
         DOWNCASTABLE_TYPE_HIERARCHY(TypeConstructor);
 
         /// Get the constructed type from the cache, or construct a new one.
-        const Type* getOrConstructType(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments) const;
+        const Type* getOrConstructType(const TypeSystem& typeSystem, const TypeConstructorArguments<N>& arguments) const;
 
         /// This is supplied by the TYPE_CONSTRUCTOR macro.
         virtual TypeConstructorId getTypeConstructorId() const = 0;
 
         /// TypeConstructors are expected to have fixed arity.
-        virtual unsigned int getArity() const = 0;
+        //TODO
+        unsigned int getArity() const { return N; }
 
         /// Are two types constructed by this type constructor related by subtyping?
         /// By default, this returns IsUnrelated.
         virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem,
-                                                  const TypeConstructorArguments& argumentsA,
-                                                  const TypeConstructorArguments& argumentsB) const;
+                                                  const TypeConstructorArguments<N>& argumentsA,
+                                                  const TypeConstructorArguments<N>& argumentsB) const;
 
         /// Is this a type constructed by this type related to the type other?
         /// By default, this returns IsUnrelated.
@@ -44,14 +48,14 @@ namespace babelwires {
         /// type constructors. (Things like distributivity laws would break this assumption, but I doubt they'd be
         /// needed.)
         virtual SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem,
-                                                  const TypeConstructorArguments& arguments,
+                                                  const TypeConstructorArguments<N>& arguments,
                                                   const TypeRef& other) const;
 
       protected:
         /// Construct the new type.
         /// The newTypeRef is provided to allow implementations to move it into the constructed type.
         virtual std::unique_ptr<Type> constructType(TypeRef newTypeRef,
-                                                    const std::vector<const Type*>& arguments) const = 0;
+                                                    const std::array<const Type*, N>& arguments) const = 0;
 
       private:
         /// A mutex which ensures thread-safe access to the cache.
@@ -60,7 +64,7 @@ namespace babelwires {
         mutable std::shared_mutex m_mutexForCache;
 
         /// A cache which stops the system ending up with multiple copies of the same constructed type.
-        mutable std::unordered_map<TypeConstructorArguments, std::unique_ptr<Type>> m_cache;
+        mutable std::unordered_map<TypeConstructorArguments<N>, std::unique_ptr<Type>> m_cache;
     };
 
     /// A convenience class which can used by type constructors for the type they want to construct.
@@ -93,3 +97,5 @@ namespace babelwires {
 /// Regular brackets can be written with "{{" and "}}". Non-positional arguments "{}" are not supported.
 #define TYPE_CONSTRUCTOR(IDENTIFIER, NAME, UUID, VERSION)                                                              \
     TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)
+
+#include <BabelWiresLib/TypeSystem/typeConstructor_inl.hpp>

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -92,4 +92,4 @@ namespace babelwires {
 /// For example, the NAME of the binary product type constructor might be something like "{0} * {1}".
 /// Regular brackets can be written with "{{" and "}}". Non-positional arguments "{}" are not supported.
 #define TYPE_CONSTRUCTOR(IDENTIFIER, NAME, UUID, VERSION)                                                              \
-    TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(REGISTERED_LONGID(IDENTIFIER, NAME, UUID), VERSION)
+    TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(BW_LONG_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -7,8 +7,8 @@
  **/
 #pragma once
 
-#include <BabelWiresLib/TypeSystem/subtypeOrder.hpp>
 #include <BabelWiresLib/TypeSystem/typeRef.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystemCommon.hpp>
 
 #include <Common/Identifiers/identifier.hpp>
 #include <Common/Identifiers/registeredIdentifier.hpp>
@@ -27,7 +27,7 @@ namespace babelwires {
         const Type* getOrConstructType(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments) const;
 
         /// This is supplied by the TYPE_CONSTRUCTOR macro.
-        virtual LongId getTypeConstructorId() const = 0;
+        virtual TypeConstructorId getTypeConstructorId() const = 0;
 
         /// TypeConstructors are expected to have fixed arity.
         virtual unsigned int getArity() const = 0;
@@ -82,9 +82,9 @@ namespace babelwires {
 
 /// Intended mainly for testing.
 #define TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                       \
-    static babelwires::LongId getThisIdentifier() { return IDENTIFIER; }                                       \
+    static babelwires::TypeConstructorId getThisIdentifier() { return IDENTIFIER; }                                             \
     static babelwires::VersionNumber getVersion() { return VERSION; }                                                  \
-    babelwires::LongId getTypeConstructorId() const override { return getThisIdentifier(); }
+    babelwires::TypeConstructorId getTypeConstructorId() const override { return getThisIdentifier(); }
 
 /// Type constructors need to be registered.
 /// For now, assume this is always done statically.
@@ -92,4 +92,4 @@ namespace babelwires {
 /// For example, the NAME of the binary product type constructor might be something like "{0} * {1}".
 /// Regular brackets can be written with "{{" and "}}". Non-positional arguments "{}" are not supported.
 #define TYPE_CONSTRUCTOR(IDENTIFIER, NAME, UUID, VERSION)                                                              \
-    TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(BW_LONG_ID(IDENTIFIER, NAME, UUID), VERSION)
+    TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -27,7 +27,7 @@ namespace babelwires {
         const Type* getOrConstructType(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments) const;
 
         /// This is supplied by the TYPE_CONSTRUCTOR macro.
-        virtual LongIdentifier getTypeConstructorId() const = 0;
+        virtual LongId getTypeConstructorId() const = 0;
 
         /// TypeConstructors are expected to have fixed arity.
         virtual unsigned int getArity() const = 0;
@@ -82,9 +82,9 @@ namespace babelwires {
 
 /// Intended mainly for testing.
 #define TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                       \
-    static babelwires::LongIdentifier getThisIdentifier() { return IDENTIFIER; }                                       \
+    static babelwires::LongId getThisIdentifier() { return IDENTIFIER; }                                       \
     static babelwires::VersionNumber getVersion() { return VERSION; }                                                  \
-    babelwires::LongIdentifier getTypeConstructorId() const override { return getThisIdentifier(); }
+    babelwires::LongId getTypeConstructorId() const override { return getThisIdentifier(); }
 
 /// Type constructors need to be registered.
 /// For now, assume this is always done statically.

--- a/BabelWiresLib/TypeSystem/typeConstructorArguments.cpp
+++ b/BabelWiresLib/TypeSystem/typeConstructorArguments.cpp
@@ -10,13 +10,3 @@
 #include <BabelWiresLib/TypeSystem/typeRef.hpp>
 
 #include <Common/Hash/hash.hpp>
-
-babelwires::TypeConstructorArgumentsOld::~TypeConstructorArgumentsOld() = default;
-
-std::size_t babelwires::TypeConstructorArgumentsOld::getHash() const {
-    std::size_t hash = 0x80235AA2;
-    for (const auto& arg : m_typeArguments) {
-        hash::mixInto(hash, arg);
-    }
-    return hash;
-}

--- a/BabelWiresLib/TypeSystem/typeConstructorArguments.cpp
+++ b/BabelWiresLib/TypeSystem/typeConstructorArguments.cpp
@@ -11,9 +11,9 @@
 
 #include <Common/Hash/hash.hpp>
 
-babelwires::TypeConstructorArguments::~TypeConstructorArguments() = default;
+babelwires::TypeConstructorArgumentsOld::~TypeConstructorArgumentsOld() = default;
 
-std::size_t babelwires::TypeConstructorArguments::getHash() const {
+std::size_t babelwires::TypeConstructorArgumentsOld::getHash() const {
     std::size_t hash = 0x80235AA2;
     for (const auto& arg : m_typeArguments) {
         hash::mixInto(hash, arg);

--- a/BabelWiresLib/TypeSystem/typeConstructorArguments.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructorArguments.hpp
@@ -41,39 +41,11 @@ namespace babelwires {
             return hash;
         }
     };
-
-    class TypeConstructorArgumentsOld {
-      public:
-        ~TypeConstructorArgumentsOld();
-
-        /// The maximum number of arguments a TypeRef can carry.
-        static constexpr std::size_t s_maxNumArguments = 10;
-
-        std::vector<TypeRef> m_typeArguments;
-
-        friend bool operator==(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
-            return a.m_typeArguments == b.m_typeArguments;
-        }
-        friend bool operator!=(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
-            return a.m_typeArguments != b.m_typeArguments;
-        }
-        friend bool operator<(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
-            return a.m_typeArguments < b.m_typeArguments;
-        }
-        /// Get a hash which can be used with std::hash.
-        std::size_t getHash() const;
-    };
 } // namespace babelwires
 
 namespace std {
     template <unsigned int N> struct hash<babelwires::TypeConstructorArguments<N>> {
         inline std::size_t operator()(const babelwires::TypeConstructorArguments<N>& arguments) const {
-            return arguments.getHash();
-        }
-    };
-
-    template <> struct hash<babelwires::TypeConstructorArgumentsOld> {
-        inline std::size_t operator()(const babelwires::TypeConstructorArgumentsOld& arguments) const {
             return arguments.getHash();
         }
     };

--- a/BabelWiresLib/TypeSystem/typeConstructorArguments.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructorArguments.hpp
@@ -7,32 +7,74 @@
  **/
 #pragma once
 
-#include <vector>
+#include <Common/Hash/hash.hpp>
 
+#include <array>
 namespace babelwires {
     class Type;
     class TypeSystem;
     class TypeRef;
 
-    class TypeConstructorArguments {
+    template <unsigned int N> class TypeConstructorArguments {
       public:
-        ~TypeConstructorArguments();
+        /// The maximum number of arguments a TypeRef can carry.
+        static constexpr std::size_t s_maxNumArguments = 10;
+
+        std::array<TypeRef, N> m_typeArguments;
+
+        friend bool operator==(const TypeConstructorArguments& a, const TypeConstructorArguments& b) {
+            return a.m_typeArguments == b.m_typeArguments;
+        }
+        friend bool operator!=(const TypeConstructorArguments& a, const TypeConstructorArguments& b) {
+            return a.m_typeArguments != b.m_typeArguments;
+        }
+        friend bool operator<(const TypeConstructorArguments& a, const TypeConstructorArguments& b) {
+            return a.m_typeArguments < b.m_typeArguments;
+        }
+
+        /// Get a hash which can be used with std::hash.
+        std::size_t getHash() const {
+            std::size_t hash = 0x80235AA2;
+            for (const auto& arg : m_typeArguments) {
+                hash::mixInto(hash, arg);
+            }
+            return hash;
+        }
+    };
+
+    class TypeConstructorArgumentsOld {
+      public:
+        ~TypeConstructorArgumentsOld();
 
         /// The maximum number of arguments a TypeRef can carry.
         static constexpr std::size_t s_maxNumArguments = 10;
 
         std::vector<TypeRef> m_typeArguments;
-        
-        friend bool operator==(const TypeConstructorArguments& a, const TypeConstructorArguments& b) { return a.m_typeArguments == b.m_typeArguments; }
-        friend bool operator!=(const TypeConstructorArguments& a, const TypeConstructorArguments& b) { return a.m_typeArguments != b.m_typeArguments; }
-        friend bool operator<(const TypeConstructorArguments& a, const TypeConstructorArguments& b) { return a.m_typeArguments < b.m_typeArguments; }
+
+        friend bool operator==(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
+            return a.m_typeArguments == b.m_typeArguments;
+        }
+        friend bool operator!=(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
+            return a.m_typeArguments != b.m_typeArguments;
+        }
+        friend bool operator<(const TypeConstructorArgumentsOld& a, const TypeConstructorArgumentsOld& b) {
+            return a.m_typeArguments < b.m_typeArguments;
+        }
         /// Get a hash which can be used with std::hash.
         std::size_t getHash() const;
     };
-}
+} // namespace babelwires
 
 namespace std {
-    template <> struct hash<babelwires::TypeConstructorArguments> {
-        inline std::size_t operator()(const babelwires::TypeConstructorArguments& arguments) const { return arguments.getHash(); }
+    template <unsigned int N> struct hash<babelwires::TypeConstructorArguments<N>> {
+        inline std::size_t operator()(const babelwires::TypeConstructorArguments<N>& arguments) const {
+            return arguments.getHash();
+        }
+    };
+
+    template <> struct hash<babelwires::TypeConstructorArgumentsOld> {
+        inline std::size_t operator()(const babelwires::TypeConstructorArgumentsOld& arguments) const {
+            return arguments.getHash();
+        }
     };
 } // namespace std

--- a/BabelWiresLib/TypeSystem/typeConstructor_inl.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor_inl.hpp
@@ -22,15 +22,13 @@ babelwires::TypeConstructor<N>::getOrConstructType(const TypeSystem& typeSystem,
 
     // Phase 2: Resolve the arguments.
     std::array<const Type*, N> resolvedArguments;
-    TypeConstructorArgumentsOld newTypeRefArguments;
     for (int i = 0; i < N; ++i) {
         const TypeRef& arg = arguments.m_typeArguments[i];
-        newTypeRefArguments.m_typeArguments.emplace_back(arg);
         if (const Type* const argAsType = arg.tryResolve(typeSystem)) {
             resolvedArguments[i] = argAsType;
         }
     }
-    TypeRef newTypeRef(getTypeConstructorId(), std::move(newTypeRefArguments));
+    TypeRef newTypeRef(getTypeConstructorId(), arguments);
 
     {
         // Phase 3: Try the cache again with a write lock.

--- a/BabelWiresLib/TypeSystem/typeConstructor_inl.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor_inl.hpp
@@ -5,19 +5,11 @@
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
-#include <BabelWiresLib/TypeSystem/typeConstructor.hpp>
 
-#include <BabelWiresLib/TypeSystem/type.hpp>
-
-#include <mutex>
-
+template<unsigned int N>
 const babelwires::Type*
-babelwires::TypeConstructor::getOrConstructType(const TypeSystem& typeSystem,
-                                                const TypeConstructorArguments& arguments) const {
-    if (getArity() != arguments.m_typeArguments.size()) {
-        return nullptr;
-    }
-
+babelwires::TypeConstructor<N>::getOrConstructType(const TypeSystem& typeSystem,
+                                                const TypeConstructorArguments<N>& arguments) const {
     {
         // Phase 1: Try cache read-only
         std::shared_lock lock(m_mutexForCache);
@@ -29,13 +21,16 @@ babelwires::TypeConstructor::getOrConstructType(const TypeSystem& typeSystem,
     }
 
     // Phase 2: Resolve the arguments.
-    std::vector<const Type*> resolvedArguments;
-    for (auto arg : arguments.m_typeArguments) {
+    std::array<const Type*, N> resolvedArguments;
+    TypeConstructorArgumentsOld newTypeRefArguments;
+    for (int i = 0; i < N; ++i) {
+        const TypeRef& arg = arguments.m_typeArguments[i];
+        newTypeRefArguments.m_typeArguments.emplace_back(arg);
         if (const Type* const argAsType = arg.tryResolve(typeSystem)) {
-            resolvedArguments.emplace_back(argAsType);
+            resolvedArguments[i] = argAsType;
         }
     }
-    TypeRef newTypeRef(getTypeConstructorId(), arguments);
+    TypeRef newTypeRef(getTypeConstructorId(), std::move(newTypeRefArguments));
 
     {
         // Phase 3: Try the cache again with a write lock.
@@ -54,10 +49,12 @@ babelwires::TypeConstructor::getOrConstructType(const TypeSystem& typeSystem,
     }
 }
 
-babelwires::SubtypeOrder babelwires::TypeConstructor::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& arguments, const TypeRef& other) const {
+template<unsigned int N>
+babelwires::SubtypeOrder babelwires::TypeConstructor<N>::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<N>& arguments, const TypeRef& other) const {
     return SubtypeOrder::IsUnrelated;
 }
 
-babelwires::SubtypeOrder babelwires::TypeConstructor::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments& argumentsA, const TypeConstructorArguments& argumentsB) const {
+template<unsigned int N>
+babelwires::SubtypeOrder babelwires::TypeConstructor<N>::compareSubtypeHelper(const TypeSystem& typeSystem, const TypeConstructorArguments<N>& argumentsA, const TypeConstructorArguments<N>& argumentsB) const {
     return SubtypeOrder::IsUnrelated;
 }

--- a/BabelWiresLib/TypeSystem/typeRef.cpp
+++ b/BabelWiresLib/TypeSystem/typeRef.cpp
@@ -37,7 +37,7 @@ const babelwires::Type* babelwires::TypeRef::tryResolve(const TypeSystem& typeSy
         const babelwires::Type* operator()(std::monostate) { return nullptr; }
         const babelwires::Type* operator()(PrimitiveTypeId typeId) { return m_typeSystem.tryGetPrimitiveType(typeId); }
         const babelwires::Type* operator()(const ConstructedTypeData& higherOrderData) {
-            const LongIdentifier typeConstructorId = std::get<0>(higherOrderData);
+            const LongId typeConstructorId = std::get<0>(higherOrderData);
             if (const TypeConstructor* const typeConstructor = m_typeSystem.tryGetTypeConstructor(typeConstructorId)) {
                 return typeConstructor->getOrConstructType(m_typeSystem, std::get<1>(higherOrderData));
             }
@@ -55,7 +55,7 @@ const babelwires::Type& babelwires::TypeRef::resolve(const TypeSystem& typeSyste
         }
         const babelwires::Type& operator()(PrimitiveTypeId typeId) { return m_typeSystem.getPrimitiveType(typeId); }
         const babelwires::Type& operator()(const ConstructedTypeData& higherOrderData) {
-            const LongIdentifier typeConstructorId = std::get<0>(higherOrderData);
+            const LongId typeConstructorId = std::get<0>(higherOrderData);
             const TypeConstructor& typeConstructor = m_typeSystem.getTypeConstructor(typeConstructorId);
             const Type* type = typeConstructor.getOrConstructType(m_typeSystem, std::get<1>(higherOrderData));
             assert(type);
@@ -204,7 +204,7 @@ std::tuple<babelwires::TypeRef, std::string_view::size_type> babelwires::TypeRef
     if ((IdEnd + 1 < str.size()) && (IdEnd == next) && (str[IdEnd] == openChar) && (str[IdEnd + 1] == closeChar)) {
         return {TypeRef(), IdEnd + 2};
     }
-    const LongIdentifier startId = LongIdentifier::deserializeFromString(str.substr(next, IdEnd));
+    const LongId startId = LongId::deserializeFromString(str.substr(next, IdEnd));
     next = IdEnd;
     if (str[next] != openChar) {
         return {startId, next};
@@ -288,7 +288,7 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
                 return typeSystem.compareSubtypePrimitives(typeIdA, typeIdB);
             },
             [&typeSystem](const ConstructedTypeData& higherOrderDataA, const PrimitiveTypeId& typeIdB) {
-                const LongIdentifier typeConstructorId = std::get<0>(higherOrderDataA);
+                const LongId typeConstructorId = std::get<0>(higherOrderDataA);
                 const TypeConstructor* const typeConstructor = typeSystem.tryGetTypeConstructor(typeConstructorId);
                 if (!typeConstructor) {
                     return SubtypeOrder::IsUnrelated;
@@ -296,7 +296,7 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
                 return typeConstructor->compareSubtypeHelper(typeSystem, std::get<1>(higherOrderDataA), typeIdB);
             },
             [&typeSystem](const PrimitiveTypeId& typeIdA, const ConstructedTypeData& higherOrderDataB) {
-                const LongIdentifier typeConstructorIdA = std::get<0>(higherOrderDataB);
+                const LongId typeConstructorIdA = std::get<0>(higherOrderDataB);
                 const TypeConstructor* const typeConstructorA = typeSystem.tryGetTypeConstructor(typeConstructorIdA);
                 if (!typeConstructorA) {
                     return SubtypeOrder::IsUnrelated;
@@ -306,8 +306,8 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
             },
             [&typeSystem, &typeRefA, &typeRefB](const ConstructedTypeData& higherOrderDataA,
                                                 const ConstructedTypeData& higherOrderDataB) {
-                const LongIdentifier typeConstructorIdA = std::get<0>(higherOrderDataA);
-                const LongIdentifier typeConstructorIdB = std::get<0>(higherOrderDataB);
+                const LongId typeConstructorIdA = std::get<0>(higherOrderDataA);
+                const LongId typeConstructorIdB = std::get<0>(higherOrderDataB);
                 const TypeConstructor* const typeConstructorA = typeSystem.tryGetTypeConstructor(typeConstructorIdA);
                 if (!typeConstructorA) {
                     return SubtypeOrder::IsUnrelated;

--- a/BabelWiresLib/TypeSystem/typeRef.cpp
+++ b/BabelWiresLib/TypeSystem/typeRef.cpp
@@ -203,7 +203,7 @@ std::tuple<babelwires::TypeRef, std::string_view::size_type> babelwires::TypeRef
     std::string_view::size_type next = 0;
     auto IdEnd = str.find_first_of(parseChars, next);
     if (IdEnd == -1) {
-        return {TypeRef{LongIdentifier::deserializeFromString(str)}, str.size()};
+        return {TypeRef(MediumId::deserializeFromString(str)), str.size()};
     }
     if ((IdEnd + 1 < str.size()) && (IdEnd == next) && (str[IdEnd] == openChar) && (str[IdEnd + 1] == closeChar)) {
         return {TypeRef(), IdEnd + 2};

--- a/BabelWiresLib/TypeSystem/typeRef.cpp
+++ b/BabelWiresLib/TypeSystem/typeRef.cpp
@@ -37,7 +37,7 @@ const babelwires::Type* babelwires::TypeRef::tryResolve(const TypeSystem& typeSy
         const babelwires::Type* operator()(std::monostate) { return nullptr; }
         const babelwires::Type* operator()(PrimitiveTypeId typeId) { return m_typeSystem.tryGetPrimitiveType(typeId); }
         const babelwires::Type* operator()(const ConstructedTypeData& higherOrderData) {
-            const LongId typeConstructorId = std::get<0>(higherOrderData);
+            const TypeConstructorId typeConstructorId = std::get<0>(higherOrderData);
             if (const TypeConstructor* const typeConstructor = m_typeSystem.tryGetTypeConstructor(typeConstructorId)) {
                 return typeConstructor->getOrConstructType(m_typeSystem, std::get<1>(higherOrderData));
             }
@@ -55,7 +55,7 @@ const babelwires::Type& babelwires::TypeRef::resolve(const TypeSystem& typeSyste
         }
         const babelwires::Type& operator()(PrimitiveTypeId typeId) { return m_typeSystem.getPrimitiveType(typeId); }
         const babelwires::Type& operator()(const ConstructedTypeData& higherOrderData) {
-            const LongId typeConstructorId = std::get<0>(higherOrderData);
+            const TypeConstructorId typeConstructorId = std::get<0>(higherOrderData);
             const TypeConstructor& typeConstructor = m_typeSystem.getTypeConstructor(typeConstructorId);
             const Type* type = typeConstructor.getOrConstructType(m_typeSystem, std::get<1>(higherOrderData));
             assert(type);
@@ -204,7 +204,7 @@ std::tuple<babelwires::TypeRef, std::string_view::size_type> babelwires::TypeRef
     if ((IdEnd + 1 < str.size()) && (IdEnd == next) && (str[IdEnd] == openChar) && (str[IdEnd + 1] == closeChar)) {
         return {TypeRef(), IdEnd + 2};
     }
-    const LongId startId = LongId::deserializeFromString(str.substr(next, IdEnd));
+    const MediumId startId = MediumId::deserializeFromString(str.substr(next, IdEnd));
     next = IdEnd;
     if (str[next] != openChar) {
         return {startId, next};
@@ -288,7 +288,7 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
                 return typeSystem.compareSubtypePrimitives(typeIdA, typeIdB);
             },
             [&typeSystem](const ConstructedTypeData& higherOrderDataA, const PrimitiveTypeId& typeIdB) {
-                const LongId typeConstructorId = std::get<0>(higherOrderDataA);
+                const TypeConstructorId typeConstructorId = std::get<0>(higherOrderDataA);
                 const TypeConstructor* const typeConstructor = typeSystem.tryGetTypeConstructor(typeConstructorId);
                 if (!typeConstructor) {
                     return SubtypeOrder::IsUnrelated;
@@ -296,7 +296,7 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
                 return typeConstructor->compareSubtypeHelper(typeSystem, std::get<1>(higherOrderDataA), typeIdB);
             },
             [&typeSystem](const PrimitiveTypeId& typeIdA, const ConstructedTypeData& higherOrderDataB) {
-                const LongId typeConstructorIdA = std::get<0>(higherOrderDataB);
+                const TypeConstructorId typeConstructorIdA = std::get<0>(higherOrderDataB);
                 const TypeConstructor* const typeConstructorA = typeSystem.tryGetTypeConstructor(typeConstructorIdA);
                 if (!typeConstructorA) {
                     return SubtypeOrder::IsUnrelated;
@@ -306,8 +306,8 @@ babelwires::SubtypeOrder babelwires::TypeRef::compareSubtypeHelper(const TypeSys
             },
             [&typeSystem, &typeRefA, &typeRefB](const ConstructedTypeData& higherOrderDataA,
                                                 const ConstructedTypeData& higherOrderDataB) {
-                const LongId typeConstructorIdA = std::get<0>(higherOrderDataA);
-                const LongId typeConstructorIdB = std::get<0>(higherOrderDataB);
+                const TypeConstructorId typeConstructorIdA = std::get<0>(higherOrderDataA);
+                const TypeConstructorId typeConstructorIdB = std::get<0>(higherOrderDataB);
                 const TypeConstructor* const typeConstructorA = typeSystem.tryGetTypeConstructor(typeConstructorIdA);
                 if (!typeConstructorA) {
                     return SubtypeOrder::IsUnrelated;

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -33,7 +33,15 @@ namespace babelwires {
 
         /// A TypeRef describing a complex type, constructed by applying the TypeConstructor
         /// to the arguments.
-        TypeRef(TypeConstructorId typeConstructorId, TypeConstructorArgumentsOld arguments);
+        TypeRef(TypeConstructorId typeConstructorId, TypeRef argument)
+            : m_storage(ConstructedStorage<1>{std::make_shared<ConstructedTypeData<1>>(ConstructedTypeData<1>{typeConstructorId, {std::move(argument)}})}) {}
+
+        TypeRef(TypeConstructorId typeConstructorId, TypeRef argument0, TypeRef argument1)
+            : m_storage(ConstructedStorage<2>{std::make_shared<ConstructedTypeData<2>>(ConstructedTypeData<2>{typeConstructorId, {std::move(argument0), std::move(argument1)}})}) {}
+
+        template<unsigned int N>
+        explicit TypeRef(TypeConstructorId typeConstructorId, TypeConstructorArguments<N> arguments)
+            : m_storage(ConstructedStorage<N>{std::make_shared<ConstructedTypeData<N>>(ConstructedTypeData<N>{typeConstructorId, std::move(arguments)})}) {}
 
         /// Attempt to find the type in the TypeSystem that this TypeRef describes.
         const Type* tryResolve(const TypeSystem& typeSystem) const;
@@ -63,7 +71,8 @@ namespace babelwires {
         std::size_t getHash() const;
 
         /// Used by the TypeSystem to compare the type typeRefs using the subtype relationship.
-        static SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeRef& typeRefA, const TypeRef& typeRefB);
+        static SubtypeOrder compareSubtypeHelper(const TypeSystem& typeSystem, const TypeRef& typeRefA,
+                                                 const TypeRef& typeRefB);
 
       private:
         /// Avoids locking the IdentifierRegistry multiple times.
@@ -73,8 +82,40 @@ namespace babelwires {
         static std::tuple<babelwires::TypeRef, std::string_view::size_type> parseHelper(std::string_view str);
 
       private:
-        using ConstructedTypeData = std::tuple<TypeConstructorId, TypeConstructorArgumentsOld>;
-        using Storage = std::variant<std::monostate, PrimitiveTypeId, ConstructedTypeData>;
+        struct CompareSubtypeVisitor;
+
+      private:
+        template <unsigned int N> struct ConstructedTypeData {
+            ConstructedTypeData(TypeConstructorId, TypeConstructorArguments<N>&& args);
+            TypeConstructorId m_typeConstructorId;
+            TypeConstructorArguments<N> m_arguments;
+
+            friend bool operator==(const ConstructedTypeData& a, const ConstructedTypeData& b) {
+                return (a.m_typeConstructorId == b.m_typeConstructorId) && (a.m_arguments == b.m_arguments);
+            }
+            friend bool operator!=(const ConstructedTypeData& a, const ConstructedTypeData& b) { return !(a == b); }
+            friend bool operator<(const ConstructedTypeData& a, const ConstructedTypeData& b) { return a.m_arguments < b.m_arguments; }
+
+        };
+
+        template <unsigned int N> struct ConstructedStorage {
+            ConstructedTypeData<N>* operator->() const {
+              return m_ptr.get();
+            }
+
+            friend bool operator==(const ConstructedStorage& a, const ConstructedStorage& b) {
+                return (a.m_ptr == b.m_ptr) || (*a.m_ptr == *b.m_ptr);
+            }
+            friend bool operator!=(const ConstructedStorage& a, const ConstructedStorage& b) { return !(a == b); }
+            friend bool operator<(const ConstructedStorage& a, const ConstructedStorage& b) 
+            {
+              return (a.m_ptr == b.m_ptr) || (*a.m_ptr < *b.m_ptr);
+            }
+
+            std::shared_ptr<ConstructedTypeData<N>> m_ptr;
+        };
+
+        using Storage = std::variant<std::monostate, PrimitiveTypeId, ConstructedStorage<1>, ConstructedStorage<2>>;
 
       private:
         Storage m_storage;

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -26,8 +26,8 @@ namespace babelwires {
     /// or storing the id of its constructor and its arguments.
     class TypeRef : public ProjectVisitable {
       public:
-        using PrimitiveTypeId = LongIdentifier;
-        using TypeConstructorId = LongIdentifier;
+        using PrimitiveTypeId = LongId;
+        using TypeConstructorId = LongId;
 
         TypeRef();
 

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -33,7 +33,7 @@ namespace babelwires {
 
         /// A TypeRef describing a complex type, constructed by applying the TypeConstructor
         /// to the arguments.
-        TypeRef(TypeConstructorId typeConstructorId, TypeConstructorArguments arguments);
+        TypeRef(TypeConstructorId typeConstructorId, TypeConstructorArgumentsOld arguments);
 
         /// Attempt to find the type in the TypeSystem that this TypeRef describes.
         const Type* tryResolve(const TypeSystem& typeSystem) const;
@@ -73,7 +73,7 @@ namespace babelwires {
         static std::tuple<babelwires::TypeRef, std::string_view::size_type> parseHelper(std::string_view str);
 
       private:
-        using ConstructedTypeData = std::tuple<TypeConstructorId, TypeConstructorArguments>;
+        using ConstructedTypeData = std::tuple<TypeConstructorId, TypeConstructorArgumentsOld>;
         using Storage = std::variant<std::monostate, PrimitiveTypeId, ConstructedTypeData>;
 
       private:

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -23,7 +23,7 @@ namespace babelwires {
     class TypeSystem;
 
     /// A TypeRef describes a type by storing an Id if it is a primitive type,
-    /// or storing the id of its constructor and its arguments.
+    /// or storing the id of its constructor and TypeRefs for its arguments.
     class TypeRef : public ProjectVisitable {
       public:
         TypeRef();
@@ -38,6 +38,7 @@ namespace babelwires {
         /// Construct a TypeRef describing a binary type constructor applied to two arguments.
         TypeRef(TypeConstructorId typeConstructorId, TypeRef argument0, TypeRef argument1);
 
+        /// Constructor for use in templates.
         template <unsigned int N>
         explicit TypeRef(TypeConstructorId typeConstructorId, TypeConstructorArguments<N> arguments)
             : m_storage(ConstructedStorage<N>{std::make_shared<ConstructedTypeData<N>>(
@@ -122,6 +123,7 @@ namespace babelwires {
             std::shared_ptr<ConstructedTypeData<N>> m_ptr;
         };
 
+        static_assert(c_maxNumTypeConstructorArguments == 2);
         using Storage = std::variant<std::monostate, PrimitiveTypeId, ConstructedStorage<1>, ConstructedStorage<2>>;
 
       private:

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -9,7 +9,7 @@
 
 #include <BabelWiresLib/Project/projectVisitable.hpp>
 #include <BabelWiresLib/TypeSystem/typeConstructorArguments.hpp>
-#include <BabelWiresLib/TypeSystem/subtypeOrder.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystemCommon.hpp>
 
 #include <Common/Identifiers/identifier.hpp>
 #include <Common/Identifiers/identifierRegistry.hpp>
@@ -26,9 +26,6 @@ namespace babelwires {
     /// or storing the id of its constructor and its arguments.
     class TypeRef : public ProjectVisitable {
       public:
-        using PrimitiveTypeId = LongId;
-        using TypeConstructorId = LongId;
-
         TypeRef();
 
         /// A TypeRef describing a primitive type.

--- a/BabelWiresLib/TypeSystem/typeSystem.cpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.cpp
@@ -41,29 +41,6 @@ babelwires::Type* babelwires::TypeSystem::addPrimitiveType(LongId typeId, Versio
     return std::get<0>(addResult.first->second).get();
 }
 
-const babelwires::TypeConstructor* babelwires::TypeSystem::tryGetTypeConstructor(TypeConstructorId id) const {
-    auto it = m_typeConstructorRegistry.find(id);
-    if (it != m_typeConstructorRegistry.end()) {
-        return std::get<0>(it->second).get();
-    }
-    return nullptr;
-}
-
-const babelwires::TypeConstructor& babelwires::TypeSystem::getTypeConstructor(TypeConstructorId id) const {
-    auto it = m_typeConstructorRegistry.find(id);
-    assert((it != m_typeConstructorRegistry.end()) && "TypeConstructor not registered in type system");
-    return *std::get<0>(it->second);
-}
-
-babelwires::TypeConstructor*
-babelwires::TypeSystem::addTypeConstructorInternal(TypeConstructorId typeId, VersionNumber version,
-                                                   std::unique_ptr<TypeConstructor> newTypeConstructor) {
-    auto addResult = m_typeConstructorRegistry.emplace(std::pair<TypeConstructorId, TypeConstructorInfo>{
-        typeId, TypeConstructorInfo{std::move(newTypeConstructor), version}});
-    assert(addResult.second && "TypeConstructor with that identifier already registered");
-    return std::get<0>(addResult.first->second).get();
-}
-
 // TODO ALL VERY INEFFICIENT
 
 void babelwires::TypeSystem::addRelatedTypes(PrimitiveTypeId typeId, RelatedTypes relatedTypes) {

--- a/BabelWiresLib/TypeSystem/typeSystem.cpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 namespace {
-    void insertTypeId(babelwires::TypeSystem::TypeIdSet& typeIds, const babelwires::LongIdentifier& typeId) {
+    void insertTypeId(babelwires::TypeSystem::TypeIdSet& typeIds, const babelwires::LongId& typeId) {
         auto it = std::upper_bound(typeIds.begin(), typeIds.end(), typeId);
         typeIds.insert(it, typeId);
     }
@@ -19,7 +19,7 @@ namespace {
 
 babelwires::TypeSystem::~TypeSystem() = default;
 
-const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(LongIdentifier id) const {
+const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(LongId id) const {
     auto it = m_primitiveTypeRegistry.find(id);
     if (it != m_primitiveTypeRegistry.end()) {
         return std::get<0>(it->second).get();
@@ -27,21 +27,21 @@ const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(LongIdentifi
     return nullptr;
 }
 
-const babelwires::Type& babelwires::TypeSystem::getPrimitiveType(LongIdentifier id) const {
+const babelwires::Type& babelwires::TypeSystem::getPrimitiveType(LongId id) const {
     auto it = m_primitiveTypeRegistry.find(id);
     assert((it != m_primitiveTypeRegistry.end()) && "Primitive Type not registered in type system");
     return *std::get<0>(it->second);
 }
 
-babelwires::Type* babelwires::TypeSystem::addPrimitiveType(LongIdentifier typeId, VersionNumber version,
+babelwires::Type* babelwires::TypeSystem::addPrimitiveType(LongId typeId, VersionNumber version,
                                                            std::unique_ptr<Type> newType) {
     auto addResult = m_primitiveTypeRegistry.emplace(
-        std::pair<LongIdentifier, PrimitiveTypeInfo>{typeId, PrimitiveTypeInfo{std::move(newType), version}});
+        std::pair<LongId, PrimitiveTypeInfo>{typeId, PrimitiveTypeInfo{std::move(newType), version}});
     assert(addResult.second && "Type with that identifier already registered");
     return std::get<0>(addResult.first->second).get();
 }
 
-const babelwires::TypeConstructor* babelwires::TypeSystem::tryGetTypeConstructor(LongIdentifier id) const {
+const babelwires::TypeConstructor* babelwires::TypeSystem::tryGetTypeConstructor(LongId id) const {
     auto it = m_typeConstructorRegistry.find(id);
     if (it != m_typeConstructorRegistry.end()) {
         return std::get<0>(it->second).get();
@@ -49,16 +49,16 @@ const babelwires::TypeConstructor* babelwires::TypeSystem::tryGetTypeConstructor
     return nullptr;
 }
 
-const babelwires::TypeConstructor& babelwires::TypeSystem::getTypeConstructor(LongIdentifier id) const {
+const babelwires::TypeConstructor& babelwires::TypeSystem::getTypeConstructor(LongId id) const {
     auto it = m_typeConstructorRegistry.find(id);
     assert((it != m_typeConstructorRegistry.end()) && "TypeConstructor not registered in type system");
     return *std::get<0>(it->second);
 }
 
 babelwires::TypeConstructor*
-babelwires::TypeSystem::addTypeConstructorInternal(LongIdentifier typeId, VersionNumber version,
+babelwires::TypeSystem::addTypeConstructorInternal(LongId typeId, VersionNumber version,
                                                    std::unique_ptr<TypeConstructor> newTypeConstructor) {
-    auto addResult = m_typeConstructorRegistry.emplace(std::pair<LongIdentifier, TypeConstructorInfo>{
+    auto addResult = m_typeConstructorRegistry.emplace(std::pair<LongId, TypeConstructorInfo>{
         typeId, TypeConstructorInfo{std::move(newTypeConstructor), version}});
     assert(addResult.second && "TypeConstructor with that identifier already registered");
     return std::get<0>(addResult.first->second).get();
@@ -66,14 +66,14 @@ babelwires::TypeSystem::addTypeConstructorInternal(LongIdentifier typeId, Versio
 
 // TODO ALL VERY INEFFICIENT
 
-void babelwires::TypeSystem::addRelatedTypes(LongIdentifier typeId, RelatedTypes relatedTypes) {
+void babelwires::TypeSystem::addRelatedTypes(LongId typeId, RelatedTypes relatedTypes) {
 #ifndef NDEBUG
     const Type* const type = tryGetPrimitiveType(typeId);
     assert((type != nullptr) && "typeId is not the id of a registered type");
 #endif
     std::sort(relatedTypes.m_subtypeIds.begin(), relatedTypes.m_subtypeIds.end());
     std::sort(relatedTypes.m_supertypeIds.begin(), relatedTypes.m_supertypeIds.end());
-    for (const LongIdentifier& supertypeId : relatedTypes.m_supertypeIds) {
+    for (const LongId& supertypeId : relatedTypes.m_supertypeIds) {
 #ifndef NDEBUG
         const Type* const supertype = tryGetPrimitiveType(supertypeId);
         assert((supertype != nullptr) && "A supertype Id is not the id of a registered type");
@@ -81,7 +81,7 @@ void babelwires::TypeSystem::addRelatedTypes(LongIdentifier typeId, RelatedTypes
 #endif
         insertTypeId(m_relatedTypes[supertypeId].m_subtypeIds, typeId);
     }
-    for (const LongIdentifier& subtypeId : relatedTypes.m_subtypeIds) {
+    for (const LongId& subtypeId : relatedTypes.m_subtypeIds) {
 #ifndef NDEBUG
         const Type* const subtype = tryGetPrimitiveType(subtypeId);
         assert((subtype != nullptr) && "A subtype ID is not the id of a registered type");
@@ -94,7 +94,7 @@ void babelwires::TypeSystem::addRelatedTypes(LongIdentifier typeId, RelatedTypes
     m_relatedTypes.insert({typeId, std::move(relatedTypes)});
 }
 
-const babelwires::TypeSystem::RelatedTypes& babelwires::TypeSystem::getRelatedTypes(const LongIdentifier& typeId) const {
+const babelwires::TypeSystem::RelatedTypes& babelwires::TypeSystem::getRelatedTypes(const LongId& typeId) const {
     const auto it = m_relatedTypes.find(typeId);
     if (it != m_relatedTypes.end()) {
         return it->second;
@@ -121,7 +121,7 @@ bool babelwires::TypeSystem::isRelatedType(const TypeRef& typeRefA, const TypeRe
     return compareSubtype(typeRefA, typeRefB) != SubtypeOrder::IsUnrelated;
 }
 
-bool babelwires::TypeSystem::isSubTypePrimitives(const LongIdentifier& typeIdA, const LongIdentifier& typeIdB) const {
+bool babelwires::TypeSystem::isSubTypePrimitives(const LongId& typeIdA, const LongId& typeIdB) const {
     if (typeIdA == typeIdB) {
         return true;
     }
@@ -134,8 +134,8 @@ bool babelwires::TypeSystem::isSubTypePrimitives(const LongIdentifier& typeIdA, 
 }
 
 babelwires::SubtypeOrder
-babelwires::TypeSystem::compareSubtypePrimitives(const LongIdentifier& typeIdA,
-                                                         const LongIdentifier& typeIdB) const {
+babelwires::TypeSystem::compareSubtypePrimitives(const LongId& typeIdA,
+                                                         const LongId& typeIdB) const {
     if (typeIdA == typeIdB) {
         return SubtypeOrder::IsEquivalent;
     }
@@ -149,41 +149,41 @@ babelwires::TypeSystem::compareSubtypePrimitives(const LongIdentifier& typeIdA,
 }
 
 
-void babelwires::TypeSystem::addAllSubtypes(const LongIdentifier& typeId, TypeIdSet& subtypes) const {
+void babelwires::TypeSystem::addAllSubtypes(const LongId& typeId, TypeIdSet& subtypes) const {
     subtypes.emplace_back(typeId);
     for (auto subtypeId : getRelatedTypes(typeId).m_subtypeIds) {
         addAllSubtypes(subtypeId, subtypes);
     }
 }
 
-void babelwires::TypeSystem::addAllSupertypes(const LongIdentifier& typeId, TypeIdSet& supertypes) const {
+void babelwires::TypeSystem::addAllSupertypes(const LongId& typeId, TypeIdSet& supertypes) const {
     supertypes.emplace_back(typeId);
     for (auto subtypeId : getRelatedTypes(typeId).m_supertypeIds) {
         addAllSupertypes(subtypeId, supertypes);
     }
 }
 
-void babelwires::TypeSystem::addAllRelatedTypes(const LongIdentifier& typeId, TypeIdSet& typeIdSet) const {
+void babelwires::TypeSystem::addAllRelatedTypes(const LongId& typeId, TypeIdSet& typeIdSet) const {
     typeIdSet.emplace_back(typeId);
     addAllSubtypes(typeId, typeIdSet);
     addAllSupertypes(typeId, typeIdSet);
 }
 
-babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllSubtypes(const LongIdentifier& typeId) const {
+babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllSubtypes(const LongId& typeId) const {
     TypeIdSet subtypes;
     addAllSubtypes(typeId, subtypes);
     removeDuplicates(subtypes);
     return subtypes;
 }
 
-babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllSupertypes(const LongIdentifier& typeId) const {
+babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllSupertypes(const LongId& typeId) const {
     TypeIdSet supertypes;
     addAllSupertypes(typeId, supertypes);
     removeDuplicates(supertypes);
     return supertypes;
 }
 
-babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllRelatedTypes(const LongIdentifier& typeId) const {
+babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllRelatedTypes(const LongId& typeId) const {
     TypeIdSet relatedTypes;
     addAllSubtypes(typeId, relatedTypes);
     addAllSupertypes(typeId, relatedTypes);

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -36,10 +36,10 @@ namespace babelwires {
         const Type* tryGetPrimitiveType(PrimitiveTypeId id) const;
         const Type& getPrimitiveType(PrimitiveTypeId id) const;
 
-        template <unsigned int N, typename TYPE_CONSTRUCTOR, typename... ARGS,
-                  std::enable_if_t<std::is_base_of_v<TypeConstructor<N>, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
+        template <typename TYPE_CONSTRUCTOR, typename... ARGS,
+                  std::enable_if_t<std::is_base_of_v<TypeConstructor<TYPE_CONSTRUCTOR::c_arity>, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
         TYPE_CONSTRUCTOR* addTypeConstructor(ARGS&&... args) {
-            TypeConstructor<N>* newType = addTypeConstructorInternal<N>(TYPE_CONSTRUCTOR::getThisIdentifier(), TYPE_CONSTRUCTOR::getVersion(), std::make_unique<TYPE_CONSTRUCTOR>(std::forward<ARGS>(args)...));
+            TypeConstructor<TYPE_CONSTRUCTOR::c_arity>* newType = addTypeConstructorInternal<TYPE_CONSTRUCTOR::c_arity>(TYPE_CONSTRUCTOR::getThisIdentifier(), TYPE_CONSTRUCTOR::getVersion(), std::make_unique<TYPE_CONSTRUCTOR>(std::forward<ARGS>(args)...));
             return &newType->template is<TYPE_CONSTRUCTOR>();
         }
 

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -10,7 +10,7 @@
 #include <BabelWiresLib/TypeSystem/type.hpp>
 #include <BabelWiresLib/TypeSystem/typeConstructor.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
-#include <BabelWiresLib/TypeSystem/subtypeOrder.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystemCommon.hpp>
 
 #include <Common/Identifiers/identifier.hpp>
 
@@ -33,8 +33,8 @@ namespace babelwires {
             return getPrimitiveType(TYPE::getThisIdentifier()).template is<TYPE>();
         }
 
-        const Type* tryGetPrimitiveType(LongId id) const;
-        const Type& getPrimitiveType(LongId id) const;
+        const Type* tryGetPrimitiveType(PrimitiveTypeId id) const;
+        const Type& getPrimitiveType(PrimitiveTypeId id) const;
 
         template <typename TYPE_CONSTRUCTOR, typename... ARGS,
                   std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
@@ -48,10 +48,10 @@ namespace babelwires {
             return getTypeConstructor(TYPE_CONSTRUCTOR::getThisIdentifier()).template is<TYPE_CONSTRUCTOR>();
         }
 
-        const TypeConstructor* tryGetTypeConstructor(LongId id) const;
-        const TypeConstructor& getTypeConstructor(LongId id) const;
+        const TypeConstructor* tryGetTypeConstructor(TypeConstructorId id) const;
+        const TypeConstructor& getTypeConstructor(TypeConstructorId id) const;
 
-        using TypeIdSet = std::vector<LongId>;
+        using TypeIdSet = std::vector<PrimitiveTypeId>;
 
         struct RelatedTypes {
             TypeIdSet m_supertypeIds;
@@ -61,7 +61,7 @@ namespace babelwires {
         /// All types must be already registered.
         /// Subtyping is managed seperately from the types themselves because a type may not know all its relations at
         /// construction time.
-        void addRelatedTypes(LongId typeId, RelatedTypes relatedTypes);
+        void addRelatedTypes(PrimitiveTypeId typeId, RelatedTypes relatedTypes);
 
         /// Determine whether typeA and typeB are related by the subtype order.
         SubtypeOrder compareSubtype(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
@@ -73,45 +73,45 @@ namespace babelwires {
         bool isRelatedType(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
 
         /// Return all the subtypes of type, including type.
-        TypeIdSet getAllSubtypes(const LongId& typeId) const;
+        TypeIdSet getAllSubtypes(const PrimitiveTypeId& typeId) const;
 
         /// Return all the supertypes, including type.
-        TypeIdSet getAllSupertypes(const LongId& typeId) const;
+        TypeIdSet getAllSupertypes(const PrimitiveTypeId& typeId) const;
 
         /// Return all subtypes and supertypes, including type.
-        TypeIdSet getAllRelatedTypes(const LongId& typeId) const;
+        TypeIdSet getAllRelatedTypes(const PrimitiveTypeId& typeId) const;
 
         /// Add typeId and all its subtypes to the set. Does not remove duplicates.
-        void addAllSubtypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
+        void addAllSubtypes(const PrimitiveTypeId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Add typeId and all its supertypes to the set. Does not remove duplicates.
-        void addAllSupertypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
+        void addAllSupertypes(const PrimitiveTypeId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Add typeId and all its subtypes and super types to the set. Does not remove duplicates.
-        void addAllRelatedTypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
+        void addAllRelatedTypes(const PrimitiveTypeId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Convenience function.
         static void removeDuplicates(TypeIdSet& typeIds);
 
         /// Determine whether primitive typeA and primitive typeB are related by the subtype order.
-        SubtypeOrder compareSubtypePrimitives(const LongId& typeIdA, const LongId& typeIdB) const;
+        SubtypeOrder compareSubtypePrimitives(const PrimitiveTypeId& typeIdA, const PrimitiveTypeId& typeIdB) const;
 
       protected:
         Type* addPrimitiveType(LongId typeId, VersionNumber version, std::unique_ptr<Type> newType);
-        TypeConstructor* addTypeConstructorInternal(LongId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
+        TypeConstructor* addTypeConstructorInternal(TypeConstructorId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
 
-        const RelatedTypes& getRelatedTypes(const LongId& typeId) const;
+        const RelatedTypes& getRelatedTypes(const PrimitiveTypeId& typeId) const;
 
-        bool isSubTypePrimitives(const LongId& typeIdA, const LongId& typeIdB) const;
+        bool isSubTypePrimitives(const PrimitiveTypeId& typeIdA, const PrimitiveTypeId& typeIdB) const;
 
       protected:
         using PrimitiveTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
-        std::unordered_map<LongId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
+        std::unordered_map<PrimitiveTypeId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
 
         using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor>, VersionNumber>;
-        std::unordered_map<LongId, TypeConstructorInfo> m_typeConstructorRegistry;
+        std::unordered_map<TypeConstructorId, TypeConstructorInfo> m_typeConstructorRegistry;
 
-        std::unordered_map<LongId, RelatedTypes> m_relatedTypes;
+        std::unordered_map<PrimitiveTypeId, RelatedTypes> m_relatedTypes;
 
         /// Used for types which have no relations.
         const RelatedTypes m_emptyRelatedTypes;

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -120,6 +120,7 @@ namespace babelwires {
         template<unsigned int N>
         using TypeConstructorRegistry = std::unordered_map<TypeConstructorId, TypeConstructorInfo<N>>;
 
+        static_assert(c_maxNumTypeConstructorArguments == 2);
         std::tuple<TypeConstructorRegistry<1>, TypeConstructorRegistry<2>> m_typeConstructorRegistry;
 
         std::unordered_map<PrimitiveTypeId, RelatedTypes> m_relatedTypes;

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -33,8 +33,8 @@ namespace babelwires {
             return getPrimitiveType(TYPE::getThisIdentifier()).template is<TYPE>();
         }
 
-        const Type* tryGetPrimitiveType(LongIdentifier id) const;
-        const Type& getPrimitiveType(LongIdentifier id) const;
+        const Type* tryGetPrimitiveType(LongId id) const;
+        const Type& getPrimitiveType(LongId id) const;
 
         template <typename TYPE_CONSTRUCTOR, typename... ARGS,
                   std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
@@ -48,10 +48,10 @@ namespace babelwires {
             return getTypeConstructor(TYPE_CONSTRUCTOR::getThisIdentifier()).template is<TYPE_CONSTRUCTOR>();
         }
 
-        const TypeConstructor* tryGetTypeConstructor(LongIdentifier id) const;
-        const TypeConstructor& getTypeConstructor(LongIdentifier id) const;
+        const TypeConstructor* tryGetTypeConstructor(LongId id) const;
+        const TypeConstructor& getTypeConstructor(LongId id) const;
 
-        using TypeIdSet = std::vector<LongIdentifier>;
+        using TypeIdSet = std::vector<LongId>;
 
         struct RelatedTypes {
             TypeIdSet m_supertypeIds;
@@ -61,7 +61,7 @@ namespace babelwires {
         /// All types must be already registered.
         /// Subtyping is managed seperately from the types themselves because a type may not know all its relations at
         /// construction time.
-        void addRelatedTypes(LongIdentifier typeId, RelatedTypes relatedTypes);
+        void addRelatedTypes(LongId typeId, RelatedTypes relatedTypes);
 
         /// Determine whether typeA and typeB are related by the subtype order.
         SubtypeOrder compareSubtype(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
@@ -73,45 +73,45 @@ namespace babelwires {
         bool isRelatedType(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
 
         /// Return all the subtypes of type, including type.
-        TypeIdSet getAllSubtypes(const LongIdentifier& typeId) const;
+        TypeIdSet getAllSubtypes(const LongId& typeId) const;
 
         /// Return all the supertypes, including type.
-        TypeIdSet getAllSupertypes(const LongIdentifier& typeId) const;
+        TypeIdSet getAllSupertypes(const LongId& typeId) const;
 
         /// Return all subtypes and supertypes, including type.
-        TypeIdSet getAllRelatedTypes(const LongIdentifier& typeId) const;
+        TypeIdSet getAllRelatedTypes(const LongId& typeId) const;
 
         /// Add typeId and all its subtypes to the set. Does not remove duplicates.
-        void addAllSubtypes(const LongIdentifier& typeId, TypeIdSet& typeIdSet) const;
+        void addAllSubtypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Add typeId and all its supertypes to the set. Does not remove duplicates.
-        void addAllSupertypes(const LongIdentifier& typeId, TypeIdSet& typeIdSet) const;
+        void addAllSupertypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Add typeId and all its subtypes and super types to the set. Does not remove duplicates.
-        void addAllRelatedTypes(const LongIdentifier& typeId, TypeIdSet& typeIdSet) const;
+        void addAllRelatedTypes(const LongId& typeId, TypeIdSet& typeIdSet) const;
 
         /// Convenience function.
         static void removeDuplicates(TypeIdSet& typeIds);
 
         /// Determine whether primitive typeA and primitive typeB are related by the subtype order.
-        SubtypeOrder compareSubtypePrimitives(const LongIdentifier& typeIdA, const LongIdentifier& typeIdB) const;
+        SubtypeOrder compareSubtypePrimitives(const LongId& typeIdA, const LongId& typeIdB) const;
 
       protected:
-        Type* addPrimitiveType(LongIdentifier typeId, VersionNumber version, std::unique_ptr<Type> newType);
-        TypeConstructor* addTypeConstructorInternal(LongIdentifier typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
+        Type* addPrimitiveType(LongId typeId, VersionNumber version, std::unique_ptr<Type> newType);
+        TypeConstructor* addTypeConstructorInternal(LongId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
 
-        const RelatedTypes& getRelatedTypes(const LongIdentifier& typeId) const;
+        const RelatedTypes& getRelatedTypes(const LongId& typeId) const;
 
-        bool isSubTypePrimitives(const LongIdentifier& typeIdA, const LongIdentifier& typeIdB) const;
+        bool isSubTypePrimitives(const LongId& typeIdA, const LongId& typeIdB) const;
 
       protected:
         using PrimitiveTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
-        std::unordered_map<LongIdentifier, PrimitiveTypeInfo> m_primitiveTypeRegistry;
+        std::unordered_map<LongId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
 
         using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor>, VersionNumber>;
-        std::unordered_map<LongIdentifier, TypeConstructorInfo> m_typeConstructorRegistry;
+        std::unordered_map<LongId, TypeConstructorInfo> m_typeConstructorRegistry;
 
-        std::unordered_map<LongIdentifier, RelatedTypes> m_relatedTypes;
+        std::unordered_map<LongId, RelatedTypes> m_relatedTypes;
 
         /// Used for types which have no relations.
         const RelatedTypes m_emptyRelatedTypes;

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -36,20 +36,24 @@ namespace babelwires {
         const Type* tryGetPrimitiveType(PrimitiveTypeId id) const;
         const Type& getPrimitiveType(PrimitiveTypeId id) const;
 
-        template <typename TYPE_CONSTRUCTOR, typename... ARGS,
-                  std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
+        template <unsigned int N, typename TYPE_CONSTRUCTOR, typename... ARGS,
+                  std::enable_if_t<std::is_base_of_v<TypeConstructor<N>, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
         TYPE_CONSTRUCTOR* addTypeConstructor(ARGS&&... args) {
-            TypeConstructor* newType = addTypeConstructorInternal(TYPE_CONSTRUCTOR::getThisIdentifier(), TYPE_CONSTRUCTOR::getVersion(), std::make_unique<TYPE_CONSTRUCTOR>(std::forward<ARGS>(args)...));
-            return &newType->is<TYPE_CONSTRUCTOR>();
+            TypeConstructor<N>* newType = addTypeConstructorInternal<N>(TYPE_CONSTRUCTOR::getThisIdentifier(), TYPE_CONSTRUCTOR::getVersion(), std::make_unique<TYPE_CONSTRUCTOR>(std::forward<ARGS>(args)...));
+            return &newType->template is<TYPE_CONSTRUCTOR>();
         }
 
-        template <typename TYPE_CONSTRUCTOR, std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
+        // TODO Should be able to pick up N from TYPE_CONSTRUCTOR
+        template <unsigned int N, typename TYPE_CONSTRUCTOR, std::enable_if_t<std::is_base_of_v<TypeConstructor<N>, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
         const TYPE_CONSTRUCTOR& getTypeConstructorByType() const {
-            return getTypeConstructor(TYPE_CONSTRUCTOR::getThisIdentifier()).template is<TYPE_CONSTRUCTOR>();
+            return getTypeConstructor<N>(TYPE_CONSTRUCTOR::getThisIdentifier()).template is<TYPE_CONSTRUCTOR>();
         }
 
-        const TypeConstructor* tryGetTypeConstructor(TypeConstructorId id) const;
-        const TypeConstructor& getTypeConstructor(TypeConstructorId id) const;
+        template<unsigned int N>
+        const TypeConstructor<N>* tryGetTypeConstructor(TypeConstructorId id) const;
+
+        template<unsigned int N>
+        const TypeConstructor<N>& getTypeConstructor(TypeConstructorId id) const;
 
         using TypeIdSet = std::vector<PrimitiveTypeId>;
 
@@ -98,7 +102,9 @@ namespace babelwires {
 
       protected:
         Type* addPrimitiveType(LongId typeId, VersionNumber version, std::unique_ptr<Type> newType);
-        TypeConstructor* addTypeConstructorInternal(TypeConstructorId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
+
+        template<unsigned int N>
+        TypeConstructor<N>* addTypeConstructorInternal(TypeConstructorId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor<N>> newTypeConstructor);
 
         const RelatedTypes& getRelatedTypes(const PrimitiveTypeId& typeId) const;
 
@@ -108,8 +114,13 @@ namespace babelwires {
         using PrimitiveTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
         std::unordered_map<PrimitiveTypeId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
 
-        using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor>, VersionNumber>;
-        std::unordered_map<TypeConstructorId, TypeConstructorInfo> m_typeConstructorRegistry;
+        template<unsigned int N>
+        using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor<N>>, VersionNumber>;
+
+        template<unsigned int N>
+        using TypeConstructorRegistry = std::unordered_map<TypeConstructorId, TypeConstructorInfo<N>>;
+
+        std::tuple<TypeConstructorRegistry<1>, TypeConstructorRegistry<2>> m_typeConstructorRegistry;
 
         std::unordered_map<PrimitiveTypeId, RelatedTypes> m_relatedTypes;
 
@@ -118,3 +129,5 @@ namespace babelwires {
     };
 
 } // namespace babelwires
+
+#include <BabelWiresLib/TypeSystem/typeSystem_inl.hpp>

--- a/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
@@ -13,6 +13,8 @@ namespace babelwires {
     using PrimitiveTypeId = MediumId;
     using TypeConstructorId = MediumId;
 
+    static constexpr unsigned int s_maxNumTypeConstructorArguments = 2;
+
     enum class SubtypeOrder { IsSubtype, IsSupertype, IsEquivalent, IsUnrelated };
 
     /// Swap IsSubtype and IsSupertype.

--- a/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
@@ -13,7 +13,7 @@ namespace babelwires {
     using PrimitiveTypeId = MediumId;
     using TypeConstructorId = MediumId;
 
-    static constexpr unsigned int s_maxNumTypeConstructorArguments = 2;
+    static constexpr unsigned int c_maxNumTypeConstructorArguments = 2;
 
     enum class SubtypeOrder { IsSubtype, IsSupertype, IsEquivalent, IsUnrelated };
 

--- a/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
@@ -7,7 +7,12 @@
  **/
 #pragma once
 
+#include <Common/Identifiers/identifier.hpp>
+
 namespace babelwires {
+    using PrimitiveTypeId = MediumId;
+    using TypeConstructorId = MediumId;
+
     enum class SubtypeOrder { IsSubtype, IsSupertype, IsEquivalent, IsUnrelated };
 
     /// Swap IsSubtype and IsSupertype.

--- a/BabelWiresLib/TypeSystem/typeSystem_inl.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem_inl.hpp
@@ -1,0 +1,34 @@
+/**
+ * The TypeSystem manages the set of types and the relationship between them.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+template<unsigned int N>
+const babelwires::TypeConstructor<N>* babelwires::TypeSystem::tryGetTypeConstructor(TypeConstructorId id) const {
+    auto it = std::get<N-1>(m_typeConstructorRegistry).find(id);
+    if (it != std::get<N-1>(m_typeConstructorRegistry).end()) {
+        return std::get<0>(it->second).get();
+    }
+    return nullptr;
+}
+
+template<unsigned int N>
+const babelwires::TypeConstructor<N>& babelwires::TypeSystem::getTypeConstructor(TypeConstructorId id) const {
+    auto it = std::get<N-1>(m_typeConstructorRegistry).find(id);
+    assert((it != std::get<N-1>(m_typeConstructorRegistry).end()) && "TypeConstructor not registered in type system");
+    return *std::get<0>(it->second);
+}
+
+template<unsigned int N>
+babelwires::TypeConstructor<N>*
+babelwires::TypeSystem::addTypeConstructorInternal(TypeConstructorId typeId, VersionNumber version,
+                                                   std::unique_ptr<TypeConstructor<N>> newTypeConstructor) {
+    auto addResult = std::get<N-1>(m_typeConstructorRegistry).emplace(std::pair<TypeConstructorId, TypeConstructorInfo<N>>{
+        typeId, TypeConstructorInfo<N>{std::move(newTypeConstructor), version}});
+    assert(addResult.second && "TypeConstructor with that identifier already registered");
+    return std::get<0>(addResult.first->second).get();
+}

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -14,5 +14,5 @@
 
 void babelwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<IntType>();
-    context.m_typeSystem.addTypeConstructor<1, AddBlankToEnum>();
+    context.m_typeSystem.addTypeConstructor<AddBlankToEnum>();
 }

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -14,5 +14,5 @@
 
 void babelwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<IntType>();
-    context.m_typeSystem.addTypeConstructor<AddBlankToEnum>();
+    context.m_typeSystem.addTypeConstructor<1, AddBlankToEnum>();
 }

--- a/BabelWiresQtUi/ComplexValueEditors/ValueModels/enumValueModel.cpp
+++ b/BabelWiresQtUi/ComplexValueEditors/ValueModels/enumValueModel.cpp
@@ -28,7 +28,7 @@ QWidget* babelwires::EnumValueModel::createEditor(const QModelIndex& index, QWid
 
 void babelwires::EnumValueModel::setEditorData(QWidget* editor) const {
     const EnumValue* enumValue = m_value->as<EnumValue>();
-    const Identifier value = enumValue->get();
+    const ShortId value = enumValue->get();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
     const Enum* const e = m_type->as<Enum>();
@@ -44,11 +44,11 @@ std::unique_ptr<babelwires::Value> babelwires::EnumValueModel::createValueFromEd
     const int newIndex = dropDownBox->currentIndex();
     assert(newIndex >= 0);
     assert(newIndex < values.size());
-    const Identifier newValue = values[newIndex];
+    const ShortId newValue = values[newIndex];
 
     const EnumValue* const enumValue = m_value->as<EnumValue>();
     assert(enumValue && "Expecting an enum value here");
-    const Identifier currentValue = enumValue->get();
+    const ShortId currentValue = enumValue->get();
 
     if (newValue != currentValue) {
         auto newEnumValue = std::make_unique<babelwires::EnumValue>();

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/optionalActivationAction.cpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/optionalActivationAction.cpp
@@ -16,7 +16,7 @@
 #include <Common/Identifiers/identifierRegistry.hpp>
 
 babelwires::OptionalActivationAction::OptionalActivationAction(babelwires::FeaturePath pathToRecord,
-                                                               Identifier optional, bool isActivated)
+                                                               ShortId optional, bool isActivated)
     : FeatureContextMenuAction(IdentifierRegistry::read()->getName(optional).c_str())
     , m_pathToRecord(std::move(pathToRecord))
     , m_optional(optional)

--- a/BabelWiresQtUi/ModelBridge/ContextMenu/optionalActivationAction.hpp
+++ b/BabelWiresQtUi/ModelBridge/ContextMenu/optionalActivationAction.hpp
@@ -16,13 +16,13 @@ namespace babelwires {
     /// QAction for activating or deactivating an optional.
     class OptionalActivationAction : public babelwires::FeatureContextMenuAction {
       public:
-        OptionalActivationAction(babelwires::FeaturePath pathToRecord, Identifier optional, bool isActivated);
+        OptionalActivationAction(babelwires::FeaturePath pathToRecord, ShortId optional, bool isActivated);
 
         virtual void actionTriggered(babelwires::FeatureModel& model, const QModelIndex& index) const override;
 
       private:
         babelwires::FeaturePath m_pathToRecord;
-        Identifier m_optional;
+        ShortId m_optional;
         bool m_isActivated;
     };
 }

--- a/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/enumRowModel.cpp
@@ -28,7 +28,7 @@ const babelwires::EnumFeature& babelwires::EnumRowModel::getEnumFeature() const 
 
 QVariant babelwires::EnumRowModel::getValueDisplayData() const {
     const babelwires::EnumFeature& enumFeature = getEnumFeature();
-    const Identifier value = enumFeature.get();
+    const ShortId value = enumFeature.get();
     return QString(IdentifierRegistry::read()->getName(value).c_str());
 }
 
@@ -46,7 +46,7 @@ QWidget* babelwires::EnumRowModel::createEditor(QWidget* parent, const QModelInd
 
 void babelwires::EnumRowModel::setEditorData(QWidget* editor) const {
     const babelwires::EnumFeature& enumFeature = getEnumFeature();
-    const Identifier value = enumFeature.get();
+    const ShortId value = enumFeature.get();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
     unsigned int currentIndex = enumFeature.getEnum().getIndexFromIdentifier(value);
@@ -57,13 +57,13 @@ std::unique_ptr<babelwires::Command<babelwires::Project>>
 babelwires::EnumRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::EnumFeature& enumFeature = getEnumFeature();
     const babelwires::Enum::EnumValues& values = enumFeature.getEnum().getEnumValues();
-    const Identifier value = enumFeature.get();
+    const ShortId value = enumFeature.get();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
     const int newIndex = dropDownBox->currentIndex();
     assert(newIndex >= 0);
     assert(newIndex < values.size());
-    const Identifier newValue = values[newIndex];
+    const ShortId newValue = values[newIndex];
     if (value != newValue) {
         auto modifier = std::make_unique<babelwires::EnumValueAssignmentData>();
         modifier->m_pathToFeature = babelwires::FeaturePath(&enumFeature);

--- a/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
+++ b/BabelWiresQtUi/ModelBridge/RowModels/unionRowModel.cpp
@@ -27,7 +27,7 @@ const babelwires::UnionFeature& babelwires::UnionRowModel::getUnionFeature() con
 
 QVariant babelwires::UnionRowModel::getValueDisplayData() const {
     const babelwires::UnionFeature& unionFeature = getUnionFeature();
-    const Identifier value = unionFeature.getSelectedTag();
+    const ShortId value = unionFeature.getSelectedTag();
     return QString(IdentifierRegistry::read()->getName(value).c_str());
 }
 
@@ -45,7 +45,7 @@ QWidget* babelwires::UnionRowModel::createEditor(QWidget* parent, const QModelIn
 
 void babelwires::UnionRowModel::setEditorData(QWidget* editor) const {
     const babelwires::UnionFeature& unionFeature = getUnionFeature();
-    const Identifier value = unionFeature.getSelectedTag();
+    const ShortId value = unionFeature.getSelectedTag();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
     dropDownBox->setCurrentIndex(unionFeature.getSelectedTagIndex());
@@ -54,13 +54,13 @@ void babelwires::UnionRowModel::setEditorData(QWidget* editor) const {
 std::unique_ptr<babelwires::Command<babelwires::Project>> babelwires::UnionRowModel::createCommandFromEditor(QWidget* editor) const {
     const babelwires::UnionFeature& unionFeature = getUnionFeature();
     const auto& tags = unionFeature.getTags();
-    const Identifier value = unionFeature.getSelectedTag();
+    const ShortId value = unionFeature.getSelectedTag();
     auto dropDownBox = qobject_cast<DropDownValueEditor*>(editor);
     assert(dropDownBox && "Unexpected editor");
     const int newIndex = dropDownBox->currentIndex();
     assert(newIndex >= 0);
     assert(newIndex < tags.size());
-    const Identifier newValue = tags[newIndex];
+    const ShortId newValue = tags[newIndex];
     if (value != newValue) {
         return std::make_unique<SelectUnionBranchCommand>("Select union branch", m_featureElement->getElementId(), babelwires::FeaturePath(&unionFeature), newValue);
     } else {

--- a/Common/Audio/audioInterface.cpp
+++ b/Common/Audio/audioInterface.cpp
@@ -13,7 +13,7 @@
 
 #include <sstream>
 
-babelwires::AudioInterface::AudioInterface(LongIdentifier identifier, VersionNumber version)
+babelwires::AudioInterface::AudioInterface(LongId identifier, VersionNumber version)
     : RegistryEntry(identifier, version) {}
 
 babelwires::AudioInterfaceRegistry::AudioInterfaceRegistry()

--- a/Common/Audio/audioInterface.hpp
+++ b/Common/Audio/audioInterface.hpp
@@ -17,7 +17,7 @@ namespace babelwires {
     /// A given audio interface (e.g. Alsa) must provide an implementation of this interface.
     class AudioInterface : public RegistryEntry {
       public:
-        AudioInterface(LongIdentifier identifier, VersionNumber version);
+        AudioInterface(LongId identifier, VersionNumber version);
 
         virtual std::vector<std::string> getDestinationNames() const = 0;
         virtual std::unique_ptr<babelwires::AudioDest> getDestination(std::string_view destinationName) const = 0;

--- a/Common/Audio/fileAudioDest.cpp
+++ b/Common/Audio/fileAudioDest.cpp
@@ -59,7 +59,7 @@ namespace {
     };
 
     struct SndFileAudioDestFactory : babelwires::FileAudioDestFactory {
-        SndFileAudioDestFactory(babelwires::LongIdentifier id, const char* ext, std::uint32_t code)
+        SndFileAudioDestFactory(babelwires::LongId id, const char* ext, std::uint32_t code)
             : FileAudioDestFactory(id, 1, Extensions{ext})
             , m_formatCode(code) {}
 
@@ -73,7 +73,7 @@ namespace {
 
 } // namespace
 
-babelwires::FileAudioDestFactory::FileAudioDestFactory(LongIdentifier identifier, VersionNumber version,
+babelwires::FileAudioDestFactory::FileAudioDestFactory(LongId identifier, VersionNumber version,
                                                        Extensions extensions)
     : FileTypeEntry(identifier, version, std::move(extensions)) {}
 

--- a/Common/Audio/fileAudioDest.cpp
+++ b/Common/Audio/fileAudioDest.cpp
@@ -79,11 +79,11 @@ babelwires::FileAudioDestFactory::FileAudioDestFactory(LongId identifier, Versio
 
 babelwires::FileAudioDestRegistry::FileAudioDestRegistry()
     : FileTypeRegistry<FileAudioDestFactory>("File Audio Dest Registry") {
-    addEntry(std::make_unique<SndFileAudioDestFactory>(REGISTERED_LONGID("WAV", "WAV file", "c2b2f468-2826-4ba9-bc6b-706833c0ed69"), "wav", (SF_FORMAT_WAV | SF_FORMAT_PCM_16)));
+    addEntry(std::make_unique<SndFileAudioDestFactory>(BW_LONG_ID("WAV", "WAV file", "c2b2f468-2826-4ba9-bc6b-706833c0ed69"), "wav", (SF_FORMAT_WAV | SF_FORMAT_PCM_16)));
     addEntry(
-        std::make_unique<SndFileAudioDestFactory>(REGISTERED_LONGID("AIFF", "Aiff file", "b3bdca68-28ad-449c-a7a0-362686f7a5fc"), "aiff", (SF_FORMAT_AIFF | SF_FORMAT_PCM_16)));
-    addEntry(std::make_unique<SndFileAudioDestFactory>(REGISTERED_LONGID("FLAC", "FLAC file", "fe9b3901-e63d-4719-a695-8a08473cf061"), "flac", SF_FORMAT_FLAC));
-    addEntry(std::make_unique<SndFileAudioDestFactory>(REGISTERED_LONGID("OGG", "OGG file", "479f13ab-4830-49f0-9559-9a96233616ff"), "ogg", SF_FORMAT_OGG));
+        std::make_unique<SndFileAudioDestFactory>(BW_LONG_ID("AIFF", "Aiff file", "b3bdca68-28ad-449c-a7a0-362686f7a5fc"), "aiff", (SF_FORMAT_AIFF | SF_FORMAT_PCM_16)));
+    addEntry(std::make_unique<SndFileAudioDestFactory>(BW_LONG_ID("FLAC", "FLAC file", "fe9b3901-e63d-4719-a695-8a08473cf061"), "flac", SF_FORMAT_FLAC));
+    addEntry(std::make_unique<SndFileAudioDestFactory>(BW_LONG_ID("OGG", "OGG file", "479f13ab-4830-49f0-9559-9a96233616ff"), "ogg", SF_FORMAT_OGG));
 }
 
 std::unique_ptr<babelwires::AudioDest>

--- a/Common/Audio/fileAudioDest.hpp
+++ b/Common/Audio/fileAudioDest.hpp
@@ -20,7 +20,7 @@ namespace babelwires {
     /// its format, so we associate some reasonable settings with each file extension using factories.
     class FileAudioDestFactory : public FileTypeEntry {
       public:
-        FileAudioDestFactory(LongIdentifier identifier, VersionNumber version, Extensions extensions);
+        FileAudioDestFactory(LongId identifier, VersionNumber version, Extensions extensions);
 
         virtual std::unique_ptr<AudioDest> createFileAudioDest(const char* fileName,
                                                                unsigned int numChannels) const = 0;

--- a/Common/Identifiers/identifier.hpp
+++ b/Common/Identifiers/identifier.hpp
@@ -223,8 +223,8 @@ namespace babelwires {
     };
 
     using ShortId = IdentifierBase<1>;
-
-    using LongIdentifier = IdentifierBase<3>;
+    using MediumId = IdentifierBase<2>;
+    using LongId = IdentifierBase<3>;
 
 } // namespace babelwires
 

--- a/Common/Identifiers/identifier.hpp
+++ b/Common/Identifiers/identifier.hpp
@@ -222,7 +222,7 @@ namespace babelwires {
         static_assert(sizeof(Data) == sizeof(m_code));
     };
 
-    using Identifier = IdentifierBase<1>;
+    using ShortId = IdentifierBase<1>;
 
     using LongIdentifier = IdentifierBase<3>;
 

--- a/Common/Identifiers/identifier.hpp
+++ b/Common/Identifiers/identifier.hpp
@@ -35,7 +35,7 @@ namespace babelwires {
     /// the identifier to act as a key for look-up in a global registry.
     ///
     /// Global uniqueness is achieved by registering the identifier with the IdentifierRegistry.
-    /// The most convenient way of registering an identifier is to use the REGISTERED_ID macro.
+    /// The most convenient way of registering an identifier is to use the BW_SHORT_ID macro.
     ///
     /// Data is arranged so the bit pattern can never be confused for array indices, when
     /// considering FeaturePaths. On little-endian architectures, the string is stored in

--- a/Common/Identifiers/identifierRegistry.cpp
+++ b/Common/Identifiers/identifierRegistry.cpp
@@ -21,7 +21,7 @@ babelwires::IdentifierRegistry::InstanceData::InstanceData()
     : m_identifier("Invald")
     , m_authority(Authority::isProvisional) {}
 
-babelwires::IdentifierRegistry::InstanceData::InstanceData(std::string fieldName, Uuid uuid, LongIdentifier identifier,
+babelwires::IdentifierRegistry::InstanceData::InstanceData(std::string fieldName, Uuid uuid, LongId identifier,
                                                            Authority authority)
     : m_fieldName(std::move(fieldName))
     , m_uuid(std::move(uuid))
@@ -41,8 +41,8 @@ void babelwires::IdentifierRegistry::InstanceData::deserializeContents(Deseriali
     m_authority = Authority::isProvisional;
 }
 
-babelwires::LongIdentifier babelwires::IdentifierRegistry::addLongIdentifierWithMetadata(
-    babelwires::LongIdentifier identifier, const std::string& name, const Uuid& uuid, Authority authority) {
+babelwires::LongId babelwires::IdentifierRegistry::addLongIdentifierWithMetadata(
+    babelwires::LongId identifier, const std::string& name, const Uuid& uuid, Authority authority) {
     const ShortId::Discriminator discriminator = identifier.getDiscriminator();
     assert((discriminator == 0) && "The identifier already has a discriminator: Did you already register it?");
 
@@ -103,7 +103,7 @@ babelwires::ShortId babelwires::IdentifierRegistry::addShortIdentifierWithMetada
 }
 
 const babelwires::IdentifierRegistry::InstanceData*
-babelwires::IdentifierRegistry::getInstanceData(LongIdentifier identifier) const {
+babelwires::IdentifierRegistry::getInstanceData(LongId identifier) const {
     const babelwires::ShortId::Discriminator index = identifier.getDiscriminator();
     if (index > 0) {
         identifier.setDiscriminator(0);
@@ -119,7 +119,7 @@ babelwires::IdentifierRegistry::getInstanceData(LongIdentifier identifier) const
 }
 
 babelwires::IdentifierRegistry::ValueType
-babelwires::IdentifierRegistry::getDeserializedIdentifierData(LongIdentifier identifier) const {
+babelwires::IdentifierRegistry::getDeserializedIdentifierData(LongId identifier) const {
     if (const babelwires::IdentifierRegistry::InstanceData* data = getInstanceData(identifier)) {
         return ValueType{identifier, &data->m_fieldName, &data->m_uuid};
     }
@@ -128,7 +128,7 @@ babelwires::IdentifierRegistry::getDeserializedIdentifierData(LongIdentifier ide
                               "discriminator) are allowed";
 }
 
-std::string babelwires::IdentifierRegistry::getName(LongIdentifier identifier) const {
+std::string babelwires::IdentifierRegistry::getName(LongId identifier) const {
     if (const InstanceData* data = getInstanceData(identifier)) {
         return data->m_fieldName;
     }
@@ -212,8 +212,8 @@ void babelwires::IdentifierRegistry::serializeContents(Serializer& serializer) c
     // We'd like the table sorted by identifier.
     // The default ordering for identifiers is unaware of disciminators.
     std::sort(contents.begin(), contents.end(), [](const auto* a, const auto* b) {
-        const babelwires::LongIdentifier idA = a->m_identifier;
-        const babelwires::LongIdentifier idB = b->m_identifier;
+        const babelwires::LongId idA = a->m_identifier;
+        const babelwires::LongId idB = b->m_identifier;
         if (idA < idB) {
             return true;
         } else if (idB < idA) {

--- a/Common/Identifiers/identifierRegistry.cpp
+++ b/Common/Identifiers/identifierRegistry.cpp
@@ -43,7 +43,7 @@ void babelwires::IdentifierRegistry::InstanceData::deserializeContents(Deseriali
 
 babelwires::LongIdentifier babelwires::IdentifierRegistry::addLongIdentifierWithMetadata(
     babelwires::LongIdentifier identifier, const std::string& name, const Uuid& uuid, Authority authority) {
-    const Identifier::Discriminator discriminator = identifier.getDiscriminator();
+    const ShortId::Discriminator discriminator = identifier.getDiscriminator();
     assert((discriminator == 0) && "The identifier already has a discriminator: Did you already register it?");
 
     const auto it = m_uuidToInstanceDataMap.find(uuid);
@@ -60,7 +60,7 @@ babelwires::LongIdentifier babelwires::IdentifierRegistry::addLongIdentifierWith
 
         const int newDiscriminator = data.m_instanceDatas.size() + 1;
         // I could fail safe here, but it seems very unlikely to happen. If it does, then the system needs a rethink.
-        assert((newDiscriminator <= Identifier::c_maxDiscriminator) && "Too many duplicate identifiers");
+        assert((newDiscriminator <= ShortId::c_maxDiscriminator) && "Too many duplicate identifiers");
         data.m_instanceDatas.emplace_back(uit->second.get());
         identifier.setDiscriminator(newDiscriminator);
         uit->second->m_identifier = identifier;
@@ -87,14 +87,14 @@ babelwires::LongIdentifier babelwires::IdentifierRegistry::addLongIdentifierWith
     return identifier;
 }
 
-babelwires::Identifier babelwires::IdentifierRegistry::addShortIdentifierWithMetadata(babelwires::Identifier identifier,
+babelwires::ShortId babelwires::IdentifierRegistry::addShortIdentifierWithMetadata(babelwires::ShortId identifier,
                                                                                       const std::string& name,
                                                                                       const Uuid& uuid,
                                                                                       Authority authority) {
 #ifndef NDEBUG
     try {
 #endif
-        return Identifier(addLongIdentifierWithMetadata(identifier, name, uuid, authority));
+        return ShortId(addLongIdentifierWithMetadata(identifier, name, uuid, authority));
 #ifndef NDEBUG
     } catch (const ParseException&) {
         assert(false && "A long identifier was previously registered with this uuid");
@@ -104,7 +104,7 @@ babelwires::Identifier babelwires::IdentifierRegistry::addShortIdentifierWithMet
 
 const babelwires::IdentifierRegistry::InstanceData*
 babelwires::IdentifierRegistry::getInstanceData(LongIdentifier identifier) const {
-    const babelwires::Identifier::Discriminator index = identifier.getDiscriminator();
+    const babelwires::ShortId::Discriminator index = identifier.getDiscriminator();
     if (index > 0) {
         identifier.setDiscriminator(0);
         const auto& it = m_instanceDatasFromIdentifier.find(identifier);
@@ -231,7 +231,7 @@ void babelwires::IdentifierRegistry::deserializeContents(Deserializer& deseriali
         std::unique_ptr<InstanceData> instanceDataPtr = it.getObject();
         InstanceData* instanceData = instanceDataPtr.get();
 
-        const Identifier::Discriminator discriminator = instanceDataPtr->m_identifier.getDiscriminator();
+        const ShortId::Discriminator discriminator = instanceDataPtr->m_identifier.getDiscriminator();
         if (discriminator == 0) {
             throw ParseException() << "An identifier in the identifier metadata had no discriminator";
         }

--- a/Common/Identifiers/identifierRegistry.cpp
+++ b/Common/Identifiers/identifierRegistry.cpp
@@ -41,8 +41,9 @@ void babelwires::IdentifierRegistry::InstanceData::deserializeContents(Deseriali
     m_authority = Authority::isProvisional;
 }
 
-babelwires::LongId babelwires::IdentifierRegistry::addLongIdWithMetadata(
-    babelwires::LongId identifier, const std::string& name, const Uuid& uuid, Authority authority) {
+babelwires::LongId babelwires::IdentifierRegistry::addLongIdWithMetadata(babelwires::LongId identifier,
+                                                                         const std::string& name, const Uuid& uuid,
+                                                                         Authority authority) {
     const ShortId::Discriminator discriminator = identifier.getDiscriminator();
     assert((discriminator == 0) && "The identifier already has a discriminator: Did you already register it?");
 
@@ -87,17 +88,30 @@ babelwires::LongId babelwires::IdentifierRegistry::addLongIdWithMetadata(
     return identifier;
 }
 
+babelwires::MediumId babelwires::IdentifierRegistry::addMediumIdWithMetadata(babelwires::MediumId identifier,
+                                                                             const std::string& name, const Uuid& uuid,
+                                                                             Authority authority) {
+#ifndef NDEBUG
+    try {
+#endif
+        return MediumId(addLongIdWithMetadata(identifier, name, uuid, authority));
+#ifndef NDEBUG
+    } catch (const ParseException&) {
+        assert(false && "Another identifier was previously registered with this uuid");
+    }
+#endif
+}
+
 babelwires::ShortId babelwires::IdentifierRegistry::addShortIdWithMetadata(babelwires::ShortId identifier,
-                                                                                      const std::string& name,
-                                                                                      const Uuid& uuid,
-                                                                                      Authority authority) {
+                                                                           const std::string& name, const Uuid& uuid,
+                                                                           Authority authority) {
 #ifndef NDEBUG
     try {
 #endif
         return ShortId(addLongIdWithMetadata(identifier, name, uuid, authority));
 #ifndef NDEBUG
     } catch (const ParseException&) {
-        assert(false && "A long identifier was previously registered with this uuid");
+        assert(false && "Another identifier was previously registered with this uuid");
     }
 #endif
 }

--- a/Common/Identifiers/identifierRegistry.cpp
+++ b/Common/Identifiers/identifierRegistry.cpp
@@ -41,7 +41,7 @@ void babelwires::IdentifierRegistry::InstanceData::deserializeContents(Deseriali
     m_authority = Authority::isProvisional;
 }
 
-babelwires::LongId babelwires::IdentifierRegistry::addLongIdentifierWithMetadata(
+babelwires::LongId babelwires::IdentifierRegistry::addLongIdWithMetadata(
     babelwires::LongId identifier, const std::string& name, const Uuid& uuid, Authority authority) {
     const ShortId::Discriminator discriminator = identifier.getDiscriminator();
     assert((discriminator == 0) && "The identifier already has a discriminator: Did you already register it?");
@@ -87,14 +87,14 @@ babelwires::LongId babelwires::IdentifierRegistry::addLongIdentifierWithMetadata
     return identifier;
 }
 
-babelwires::ShortId babelwires::IdentifierRegistry::addShortIdentifierWithMetadata(babelwires::ShortId identifier,
+babelwires::ShortId babelwires::IdentifierRegistry::addShortIdWithMetadata(babelwires::ShortId identifier,
                                                                                       const std::string& name,
                                                                                       const Uuid& uuid,
                                                                                       Authority authority) {
 #ifndef NDEBUG
     try {
 #endif
-        return ShortId(addLongIdentifierWithMetadata(identifier, name, uuid, authority));
+        return ShortId(addLongIdWithMetadata(identifier, name, uuid, authority));
 #ifndef NDEBUG
     } catch (const ParseException&) {
         assert(false && "A long identifier was previously registered with this uuid");

--- a/Common/Identifiers/identifierRegistry.hpp
+++ b/Common/Identifiers/identifierRegistry.hpp
@@ -47,17 +47,22 @@ namespace babelwires {
 
         /// Give the Identifier a unique index so it can be later used to look-up the name.
         /// Returns a Identifier with a modified discriminator.
-        LongId addLongIdWithMetadata(LongId identifier, const std::string& name,
-                                                     const Uuid& uuid, Authority authority);
+        LongId addLongIdWithMetadata(LongId identifier, const std::string& name, const Uuid& uuid, Authority authority);
+        MediumId addMediumIdWithMetadata(MediumId identifier, const std::string& name, const Uuid& uuid,
+                                       Authority authority);
         ShortId addShortIdWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
-                                             Authority authority);
+                                       Authority authority);
 
         LongId addIdentifierWithMetadata(LongId identifier, const std::string& name, const Uuid& uuid,
-                                                 Authority authority) {
+                                         Authority authority) {
             return addLongIdWithMetadata(identifier, name, uuid, authority);
         }
+        MediumId addIdentifierWithMetadata(MediumId identifier, const std::string& name, const Uuid& uuid,
+                                         Authority authority) {
+            return addMediumIdWithMetadata(identifier, name, uuid, authority);
+        }
         ShortId addIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
-                                             Authority authority) {
+                                          Authority authority) {
             return addShortIdWithMetadata(identifier, name, uuid, authority);
         }
 

--- a/Common/Identifiers/identifierRegistry.hpp
+++ b/Common/Identifiers/identifierRegistry.hpp
@@ -47,12 +47,12 @@ namespace babelwires {
 
         /// Give the Identifier a unique index so it can be later used to look-up the name.
         /// Returns a Identifier with a modified discriminator.
-        LongIdentifier addLongIdentifierWithMetadata(LongIdentifier identifier, const std::string& name,
+        LongId addLongIdentifierWithMetadata(LongId identifier, const std::string& name,
                                                      const Uuid& uuid, Authority authority);
         ShortId addShortIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
                                              Authority authority);
 
-        LongIdentifier addIdentifierWithMetadata(LongIdentifier identifier, const std::string& name, const Uuid& uuid,
+        LongId addIdentifierWithMetadata(LongId identifier, const std::string& name, const Uuid& uuid,
                                                  Authority authority) {
             return addLongIdentifierWithMetadata(identifier, name, uuid, authority);
         }
@@ -62,7 +62,7 @@ namespace babelwires {
         }
 
         /// Get the name from the given identifier.
-        std::string getName(LongIdentifier identifier) const;
+        std::string getName(LongId identifier) const;
 
       public:
         // For use during serialization/deserialization:
@@ -71,11 +71,11 @@ namespace babelwires {
         void deserializeContents(Deserializer& deserializer) override;
 
         /// Information stored about an identifier.
-        using ValueType = std::tuple<LongIdentifier, const std::string*, const Uuid*>;
+        using ValueType = std::tuple<LongId, const std::string*, const Uuid*>;
 
         /// Extract the information about an identifier from a local IdentifierRegistry.
         /// This can throw a ParseException if the contents are invalid.
-        ValueType getDeserializedIdentifierData(LongIdentifier identifier) const;
+        ValueType getDeserializedIdentifierData(LongId identifier) const;
 
       public:
         // Singleton stuff:
@@ -127,19 +127,19 @@ namespace babelwires {
         struct InstanceData : Serializable {
             SERIALIZABLE(InstanceData, "identifier", void, 1);
             InstanceData();
-            InstanceData(std::string fieldName, Uuid uuid, LongIdentifier identifier, Authority authority);
+            InstanceData(std::string fieldName, Uuid uuid, LongId identifier, Authority authority);
 
             void serializeContents(Serializer& serializer) const override;
             void deserializeContents(Deserializer& deserializer) override;
 
             std::string m_fieldName;
             Uuid m_uuid;
-            LongIdentifier m_identifier;
+            LongId m_identifier;
             Authority m_authority;
         };
 
         ///
-        const InstanceData* getInstanceData(LongIdentifier identifier) const;
+        const InstanceData* getInstanceData(LongId identifier) const;
 
       private:
         friend const_iterator;
@@ -152,7 +152,7 @@ namespace babelwires {
         };
 
         /// For each identifier, we can index associated data.
-        std::unordered_map<LongIdentifier, Data> m_instanceDatasFromIdentifier;
+        std::unordered_map<LongId, Data> m_instanceDatasFromIdentifier;
 
       private:
         /// Lifetime of this is managed externally.

--- a/Common/Identifiers/identifierRegistry.hpp
+++ b/Common/Identifiers/identifierRegistry.hpp
@@ -49,14 +49,14 @@ namespace babelwires {
         /// Returns a Identifier with a modified discriminator.
         LongIdentifier addLongIdentifierWithMetadata(LongIdentifier identifier, const std::string& name,
                                                      const Uuid& uuid, Authority authority);
-        Identifier addShortIdentifierWithMetadata(Identifier identifier, const std::string& name, const Uuid& uuid,
+        ShortId addShortIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
                                              Authority authority);
 
         LongIdentifier addIdentifierWithMetadata(LongIdentifier identifier, const std::string& name, const Uuid& uuid,
                                                  Authority authority) {
             return addLongIdentifierWithMetadata(identifier, name, uuid, authority);
         }
-        Identifier addIdentifierWithMetadata(Identifier identifier, const std::string& name, const Uuid& uuid,
+        ShortId addIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
                                              Authority authority) {
             return addShortIdentifierWithMetadata(identifier, name, uuid, authority);
         }

--- a/Common/Identifiers/identifierRegistry.hpp
+++ b/Common/Identifiers/identifierRegistry.hpp
@@ -47,18 +47,18 @@ namespace babelwires {
 
         /// Give the Identifier a unique index so it can be later used to look-up the name.
         /// Returns a Identifier with a modified discriminator.
-        LongId addLongIdentifierWithMetadata(LongId identifier, const std::string& name,
+        LongId addLongIdWithMetadata(LongId identifier, const std::string& name,
                                                      const Uuid& uuid, Authority authority);
-        ShortId addShortIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
+        ShortId addShortIdWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
                                              Authority authority);
 
         LongId addIdentifierWithMetadata(LongId identifier, const std::string& name, const Uuid& uuid,
                                                  Authority authority) {
-            return addLongIdentifierWithMetadata(identifier, name, uuid, authority);
+            return addLongIdWithMetadata(identifier, name, uuid, authority);
         }
         ShortId addIdentifierWithMetadata(ShortId identifier, const std::string& name, const Uuid& uuid,
                                              Authority authority) {
-            return addShortIdentifierWithMetadata(identifier, name, uuid, authority);
+            return addShortIdWithMetadata(identifier, name, uuid, authority);
         }
 
         /// Get the name from the given identifier.

--- a/Common/Identifiers/registeredIdentifier.hpp
+++ b/Common/Identifiers/registeredIdentifier.hpp
@@ -27,24 +27,35 @@ namespace babelwires {
 /// This expression evaluates to a Identifier which has the data from the given IDENTIFIER and a discriminator
 /// which allows the name to be looked up in the IdentifierRegistry. The registration happens only the first time it is
 /// called.
-#define BW_SHORT_ID(IDENTIFIER, NAME, UUID)                                                                          \
+#define BW_SHORT_ID(IDENTIFIER, NAME, UUID)                                                                            \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(     \
+        static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(                \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \
-            "Each usage of this macro should register a single fieldIdentifier."                                       \
+            "Each usage of this macro should register a single identifier."                                            \
             " Do not use it in cases where the same code can be called a second time with a different identifier.");   \
         return f;                                                                                                      \
     }(IDENTIFIER, NAME, UUID))
 
-#define BW_LONG_ID(IDENTIFIER, NAME, UUID)                                                                      \
+#define BW_MEDIUM_ID(IDENTIFIER, NAME, UUID)                                                                           \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(  \
+        static babelwires::MediumId f = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(              \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \
-            "Each usage of this macro should register a single fieldIdentifier."                                       \
+            "Each usage of this macro should register a single identifier."                                            \
+            " Do not use it in cases where the same code can be called a second time with a different identifier.");   \
+        return f;                                                                                                      \
+    }(IDENTIFIER, NAME, UUID))
+
+#define BW_LONG_ID(IDENTIFIER, NAME, UUID)                                                                             \
+    ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
+        static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(                  \
+            id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
+        assert(                                                                                                        \
+            (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \
+            "Each usage of this macro should register a single identifier."                                            \
             " Do not use it in cases where the same code can be called a second time with a different identifier.");   \
         return f;                                                                                                      \
     }(IDENTIFIER, NAME, UUID))

--- a/Common/Identifiers/registeredIdentifier.hpp
+++ b/Common/Identifiers/registeredIdentifier.hpp
@@ -40,7 +40,7 @@ namespace babelwires {
 
 #define REGISTERED_LONGID(IDENTIFIER, NAME, UUID)                                                                      \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::LongIdentifier f = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(  \
+        static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(  \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \

--- a/Common/Identifiers/registeredIdentifier.hpp
+++ b/Common/Identifiers/registeredIdentifier.hpp
@@ -29,7 +29,7 @@ namespace babelwires {
 /// called.
 #define REGISTERED_ID(IDENTIFIER, NAME, UUID)                                                                          \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(     \
+        static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(     \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \
@@ -40,7 +40,7 @@ namespace babelwires {
 
 #define REGISTERED_LONGID(IDENTIFIER, NAME, UUID)                                                                      \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(  \
+        static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(  \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \

--- a/Common/Identifiers/registeredIdentifier.hpp
+++ b/Common/Identifiers/registeredIdentifier.hpp
@@ -12,10 +12,10 @@
 
 namespace babelwires {
     /// See the REGISTERED_ID_VECTOR macro.
-    using IdentifiersSource = std::vector<std::tuple<const babelwires::Identifier, std::string, Uuid>>;
+    using IdentifiersSource = std::vector<std::tuple<const babelwires::ShortId, std::string, Uuid>>;
 
     /// See the REGISTERED_ID_VECTOR macro.
-    using RegisteredIdentifiers = std::vector<babelwires::Identifier>;
+    using RegisteredIdentifiers = std::vector<babelwires::ShortId>;
 
     namespace detail {
         RegisteredIdentifiers getIdentifiers(const IdentifiersSource& source);
@@ -29,7 +29,7 @@ namespace babelwires {
 /// called.
 #define REGISTERED_ID(IDENTIFIER, NAME, UUID)                                                                          \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
-        static babelwires::Identifier f = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(     \
+        static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(     \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
         assert(                                                                                                        \
             (babelwires::IdentifierRegistry::read()->getName(f) == name) &&                                            \

--- a/Common/Identifiers/registeredIdentifier.hpp
+++ b/Common/Identifiers/registeredIdentifier.hpp
@@ -27,7 +27,7 @@ namespace babelwires {
 /// This expression evaluates to a Identifier which has the data from the given IDENTIFIER and a discriminator
 /// which allows the name to be looked up in the IdentifierRegistry. The registration happens only the first time it is
 /// called.
-#define REGISTERED_ID(IDENTIFIER, NAME, UUID)                                                                          \
+#define BW_SHORT_ID(IDENTIFIER, NAME, UUID)                                                                          \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
         static babelwires::ShortId f = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(     \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \
@@ -38,7 +38,7 @@ namespace babelwires {
         return f;                                                                                                      \
     }(IDENTIFIER, NAME, UUID))
 
-#define REGISTERED_LONGID(IDENTIFIER, NAME, UUID)                                                                      \
+#define BW_LONG_ID(IDENTIFIER, NAME, UUID)                                                                      \
     ([](auto&& id, auto&& name, auto&& uuid) {                                                                         \
         static babelwires::LongId f = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(  \
             id, name, uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);                               \

--- a/Common/Registry/fileTypeRegistry.cpp
+++ b/Common/Registry/fileTypeRegistry.cpp
@@ -9,7 +9,7 @@
 
 #include <cctype>
 
-babelwires::FileTypeEntry::FileTypeEntry(LongIdentifier identifier, VersionNumber version,
+babelwires::FileTypeEntry::FileTypeEntry(LongId identifier, VersionNumber version,
                                          Extensions extensions)
     : RegistryEntry(identifier, version)
     , m_extensions(std::move(extensions)) {

--- a/Common/Registry/fileTypeRegistry.hpp
+++ b/Common/Registry/fileTypeRegistry.hpp
@@ -18,7 +18,7 @@ namespace babelwires {
 
         /// Extensions are stored in lower case, regardless of what is passed in.
         /// Extensions should not include the ".".
-        FileTypeEntry(LongIdentifier identifier, VersionNumber version, Extensions extensions);
+        FileTypeEntry(LongId identifier, VersionNumber version, Extensions extensions);
 
         const Extensions& getFileExtensions() const { return m_extensions; }
 

--- a/Common/Registry/registry.cpp
+++ b/Common/Registry/registry.cpp
@@ -9,7 +9,7 @@
 
 #include <Common/Identifiers/identifierRegistry.hpp>
 
-babelwires::RegistryEntry::RegistryEntry(LongIdentifier identifier, VersionNumber version)
+babelwires::RegistryEntry::RegistryEntry(LongId identifier, VersionNumber version)
     : m_identifier(identifier)
     , m_version(version) {
     assert((version > 0) && "0 is not a valid version");
@@ -17,7 +17,7 @@ babelwires::RegistryEntry::RegistryEntry(LongIdentifier identifier, VersionNumbe
 
 babelwires::RegistryEntry::~RegistryEntry() = default;
 
-babelwires::LongIdentifier babelwires::RegistryEntry::getIdentifier() const {
+babelwires::LongId babelwires::RegistryEntry::getIdentifier() const {
     return m_identifier;
 }
 
@@ -33,7 +33,7 @@ babelwires::UntypedRegistry::UntypedRegistry(std::string registryName)
     : m_registryName(std::move(registryName)) {}
 
 babelwires::RegistryEntry* babelwires::UntypedRegistry::addEntry(std::unique_ptr<RegistryEntry> newEntry) {
-    LongIdentifier id = newEntry->getIdentifier();
+    LongId id = newEntry->getIdentifier();
     assert((newEntry->getIdentifier().getDiscriminator() != 0) &&
            "A registered entry must have a registered identifier");
     assert((getEntryByIdentifier(id) == nullptr) && "Format with that identifier already registered.");
@@ -44,7 +44,7 @@ babelwires::RegistryEntry* babelwires::UntypedRegistry::addEntry(std::unique_ptr
 }
 
 const babelwires::RegistryEntry*
-babelwires::UntypedRegistry::getEntryByIdentifier(const LongIdentifier& identifier) const {
+babelwires::UntypedRegistry::getEntryByIdentifier(const LongId& identifier) const {
     const auto& it = m_entries.find(identifier);
     if (it != m_entries.end()) {
         // resolve the identifier if it is currently unresolved.
@@ -55,7 +55,7 @@ babelwires::UntypedRegistry::getEntryByIdentifier(const LongIdentifier& identifi
 }
 
 babelwires::RegistryEntry*
-babelwires::UntypedRegistry::getEntryByIdentifierNonConst(const LongIdentifier& identifier) const {
+babelwires::UntypedRegistry::getEntryByIdentifierNonConst(const LongId& identifier) const {
     const auto& it = m_entries.find(identifier);
     if (it != m_entries.end()) {
         // resolve the identifier if it is currently unresolved.
@@ -76,7 +76,7 @@ const babelwires::RegistryEntry* babelwires::UntypedRegistry::getEntryByName(std
 }
 
 const babelwires::RegistryEntry&
-babelwires::UntypedRegistry::getRegisteredEntry(const LongIdentifier& identifier) const {
+babelwires::UntypedRegistry::getRegisteredEntry(const LongId& identifier) const {
     const RegistryEntry* const entry = getEntryByIdentifier(identifier);
     if (!entry) {
         throw RegistryException() << "No entry called \"" << identifier << "\" was found in the " << m_registryName;

--- a/Common/Registry/registry.hpp
+++ b/Common/Registry/registry.hpp
@@ -25,12 +25,12 @@ namespace babelwires {
       public:
         /// An identifier is used to uniquely identify the entry.
         /// Typically, it will be obtained via the REGISTERED_LONGID macro.
-        RegistryEntry(LongIdentifier identifier, VersionNumber version);
+        RegistryEntry(LongId identifier, VersionNumber version);
         virtual ~RegistryEntry();
 
         /// Return an identifier which uniquely identifies the entry.
         /// The identifier should never be changed.
-        LongIdentifier getIdentifier() const;
+        LongId getIdentifier() const;
 
         /// The name of the entry, which can be displayed to the user and is permitted to change
         /// over time.
@@ -41,7 +41,7 @@ namespace babelwires {
         VersionNumber getVersion() const;
 
       private:
-        LongIdentifier m_identifier;
+        LongId m_identifier;
         VersionNumber m_version;
     };
 
@@ -64,23 +64,23 @@ namespace babelwires {
         /// Find an entry by an internal key which should be stable between versions of the program.
         /// If the provided identifier is unresolved, it will be resolved by setting its (mutable) discriminator to
         /// match that of the registered entry. Care should be taken to ensure the reference is not a temporary.
-        const RegistryEntry* getEntryByIdentifier(const LongIdentifier& identifier) const;
+        const RegistryEntry* getEntryByIdentifier(const LongId& identifier) const;
 
         /// Find an entry which is expected to be present.
         /// Will throw an RegistryException if the entry is not found.
         /// If the provided identifier is unresolved, it will be resolved by setting its (mutable) discriminator to
         /// match that of the registered entry. Care should be taken to ensure the reference is not a temporary.
-        const RegistryEntry& getRegisteredEntry(const LongIdentifier& identifier) const;
+        const RegistryEntry& getRegisteredEntry(const LongId& identifier) const;
 
       protected:
         const RegistryEntry* getEntryByName(std::string_view name) const;
 
         /// Protected non-const version available to subclasses.
-        RegistryEntry* getEntryByIdentifierNonConst(const LongIdentifier& identifier) const;
+        RegistryEntry* getEntryByIdentifierNonConst(const LongId& identifier) const;
 
       protected:
         std::string m_registryName;
-        std::unordered_map<LongIdentifier, std::unique_ptr<RegistryEntry>> m_entries;
+        std::unordered_map<LongId, std::unique_ptr<RegistryEntry>> m_entries;
 
       protected:
         template <typename ENTRY> friend class Registry;
@@ -108,13 +108,13 @@ namespace babelwires {
         /// versions of the program.
         /// If the provided identifier is unresolved, it will be resolved by setting its (mutable) discriminator to
         /// match that of the registered entry. Care should be taken to ensure the reference is not a temporary.
-        const ENTRY* getEntryByIdentifier(const LongIdentifier& identifier) const;
+        const ENTRY* getEntryByIdentifier(const LongId& identifier) const;
 
         /// Find an entry which is expected to be present.
         /// Will throw an RegistryException if the entry is not found.
         /// If the provided identifier is unresolved, it will be resolved by setting its (mutable) discriminator to
         /// match that of the registered entry. Care should be taken to ensure the reference is not a temporary.
-        const ENTRY& getRegisteredEntry(const LongIdentifier& identifier) const;
+        const ENTRY& getRegisteredEntry(const LongId& identifier) const;
 
         /// If ENTRY_SUBTYPE has the common static method "getThisIdentifier", then you can look it up by type
         /// and get a typed reference back.

--- a/Common/Registry/registry.hpp
+++ b/Common/Registry/registry.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
     class RegistryEntry {
       public:
         /// An identifier is used to uniquely identify the entry.
-        /// Typically, it will be obtained via the REGISTERED_LONGID macro.
+        /// Typically, it will be obtained via the BW_LONG_ID macro.
         RegistryEntry(LongId identifier, VersionNumber version);
         virtual ~RegistryEntry();
 

--- a/Common/Registry/registry_inl.hpp
+++ b/Common/Registry/registry_inl.hpp
@@ -24,12 +24,12 @@ ENTRY_SUBTYPE* babelwires::Registry<ENTRY>::addEntry(ARGS&&... args) {
 }
 
 template <typename ENTRY>
-const ENTRY* babelwires::Registry<ENTRY>::getEntryByIdentifier(const LongIdentifier& identifier) const {
+const ENTRY* babelwires::Registry<ENTRY>::getEntryByIdentifier(const LongId& identifier) const {
     return static_cast<const ENTRY*>(m_untypedRegistry.getEntryByIdentifier(identifier));
 }
 
 template <typename ENTRY>
-const ENTRY& babelwires::Registry<ENTRY>::getRegisteredEntry(const LongIdentifier& identifier) const {
+const ENTRY& babelwires::Registry<ENTRY>::getRegisteredEntry(const LongId& identifier) const {
     return static_cast<const ENTRY&>(m_untypedRegistry.getRegisteredEntry(identifier));
 }
 

--- a/Tests/BabelWiresLib/TestUtils/testEnum.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testEnum.hpp
@@ -28,7 +28,7 @@ namespace testUtils {
 
 // Foo, Bar, Erm, Oom, Boo
     struct TestEnum : babelwires::Enum {
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("TestEnum"), 1);
+        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("Enum"), 1);
         TestEnum();
 
         /// Expose a C++ enum which matches the Enum.
@@ -37,19 +37,19 @@ namespace testUtils {
 
     // Bar, Erm, Oom
     struct TestSubEnum : babelwires::Enum {
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("TestSubEnum"), 1);
+        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("SubEnum"), 1);
         TestSubEnum();
     };
 
     // Bar, Erm
     struct TestSubSubEnum1 : babelwires::Enum {
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("TestSubSubEnum1"), 1);
+        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("SubSubEnum1"), 1);
         TestSubSubEnum1();
     };
 
     // Erm, Oom
     struct TestSubSubEnum2 : babelwires::Enum {
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("TestSubSubEnum2"), 1);
+        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("SubSubEnum2"), 1);
         TestSubSubEnum2();
     };
 

--- a/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
@@ -4,7 +4,7 @@
 
 testUtils::TestFailedFeature::TestFailedFeature(const babelwires::ProjectContext& context)
     : RootFeature(context) {
-    addField(std::make_unique<RecordFeature>(), babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    addField(std::make_unique<RecordFeature>(), babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
                                                     "Failed", "Failed", "00000000-1111-2222-3333-800000000888",
                                                     babelwires::IdentifierRegistry::Authority::isAuthoritative));
 }

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.cpp
@@ -18,15 +18,15 @@ const babelwires::FeaturePath testUtils::TestFeatureWithOptionals::s_pathToOp1_I
 
 testUtils::TestFeatureWithOptionals::TestFeatureWithOptionals(const babelwires::ProjectContext& context)
     : RootFeature(context)
-    , m_subrecordId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_subrecordId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_subrecordIdInitializer, s_subrecordFieldName, s_subrecordUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_ff0IdInitializer, s_ff0FieldName, s_ff0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_ff1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_ff1Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_ff1IdInitializer, s_ff1FieldName, s_ff1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_op0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_op0Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_op0IdInitializer, s_op0FieldName, s_op0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_op1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_op1Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_op1IdInitializer, s_op1FieldName, s_op1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
     {
         auto testRecordWithOptionalsFeaturePtr = std::make_unique<babelwires::RecordWithOptionalsFeature>();

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithOptionals.hpp
@@ -32,11 +32,11 @@ namespace testUtils {
         static constexpr char s_op0Uuid[] = "00000000-1111-2222-3333-880000000003";
         static constexpr char s_op1Uuid[] = "00000000-1111-2222-3333-880000000004";
 
-        babelwires::Identifier m_subrecordId;
-        babelwires::Identifier m_ff0Id;
-        babelwires::Identifier m_ff1Id;
-        babelwires::Identifier m_op0Id;
-        babelwires::Identifier m_op1Id;
+        babelwires::ShortId m_subrecordId;
+        babelwires::ShortId m_ff0Id;
+        babelwires::ShortId m_ff1Id;
+        babelwires::ShortId m_op0Id;
+        babelwires::ShortId m_op1Id;
 
         babelwires::RecordWithOptionalsFeature* m_subrecord;
         babelwires::IntFeature* m_ff0Feature;

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.cpp
@@ -24,27 +24,27 @@ const babelwires::FeaturePath testUtils::TestFeatureWithUnion::s_pathToFieldB0_I
 
 testUtils::TestFeatureWithUnion::TestFeatureWithUnion(const babelwires::ProjectContext& context)
     : RootFeature(context)
-    , m_tagAId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_tagAId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_tagAIdInitializer, s_tagAFieldName, s_tagAUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_tagBId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_tagBId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_tagBIdInitializer, s_tagBFieldName, s_tagBUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_tagCId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_tagCId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_tagCIdInitializer, s_tagCFieldName, s_tagCUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_unionFeatureId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_unionFeatureId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_unionFeatureIdInitializer, s_unionFeatureFieldName, s_unionFeatureUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_ff0Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_ff0IdInitializer, s_ff0FieldName, s_ff0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_ff1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_ff1Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_ff1IdInitializer, s_ff1FieldName, s_ff1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_fieldA0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_fieldA0Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_fieldA0IdInitializer, s_fieldA0FieldName, s_fieldA0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_fieldA1Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_fieldA1Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_fieldA1IdInitializer, s_fieldA1FieldName, s_fieldA1Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_fieldB0Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_fieldB0Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_fieldB0IdInitializer, s_fieldB0FieldName, s_fieldB0Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_fieldABId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_fieldABId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_fieldABIdInitializer, s_fieldABFieldName, s_fieldABUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_fieldBCId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_fieldBCId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_fieldBCIdInitializer, s_fieldBCFieldName, s_fieldBCUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
     {
         auto testUnionFeaturePtr = std::make_unique<babelwires::UnionFeature>(babelwires::UnionFeature::TagValues{m_tagAId, m_tagBId, m_tagCId}, 1);

--- a/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureWithUnion.hpp
@@ -51,17 +51,17 @@ namespace testUtils {
         static constexpr char s_fieldBCUuid[] = "00000000-1111-2222-3333-8800000000BC";
 
         // Note: tagB is the default.
-        babelwires::Identifier m_tagAId;
-        babelwires::Identifier m_tagBId;
-        babelwires::Identifier m_tagCId;
-        babelwires::Identifier m_unionFeatureId;
-        babelwires::Identifier m_ff0Id;
-        babelwires::Identifier m_ff1Id;
-        babelwires::Identifier m_fieldA0Id;
-        babelwires::Identifier m_fieldA1Id;
-        babelwires::Identifier m_fieldB0Id;
-        babelwires::Identifier m_fieldABId;
-        babelwires::Identifier m_fieldBCId;
+        babelwires::ShortId m_tagAId;
+        babelwires::ShortId m_tagBId;
+        babelwires::ShortId m_tagCId;
+        babelwires::ShortId m_unionFeatureId;
+        babelwires::ShortId m_ff0Id;
+        babelwires::ShortId m_ff1Id;
+        babelwires::ShortId m_fieldA0Id;
+        babelwires::ShortId m_fieldA1Id;
+        babelwires::ShortId m_fieldB0Id;
+        babelwires::ShortId m_fieldABId;
+        babelwires::ShortId m_fieldBCId;
 
         babelwires::UnionFeature* m_unionFeature;
         babelwires::IntFeature* m_ff0Feature;

--- a/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
@@ -27,7 +27,7 @@ testUtils::TestFileFeature::TestFileFeature(const babelwires::ProjectContext& co
         addField(std::make_unique<babelwires::HasStaticRange<babelwires::IntFeature, 0, 255>>(), m_intChildId);
 }
 
-babelwires::LongIdentifier testUtils::TestSourceFileFormat::getThisIdentifier() {
+babelwires::LongId testUtils::TestSourceFileFormat::getThisIdentifier() {
     return s_fileFormatId;
 }
 
@@ -95,7 +95,7 @@ testUtils::TestTargetFileFormat::TestTargetFileFormat()
                            babelwires::IdentifierRegistry::Authority::isAuthoritative),
                        3, {s_fileFormatId}) {}
 
-babelwires::LongIdentifier testUtils::TestTargetFileFormat::getThisIdentifier() {
+babelwires::LongId testUtils::TestTargetFileFormat::getThisIdentifier() {
     return s_factoryFormatId;
 }
 

--- a/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
@@ -20,7 +20,7 @@ namespace {
 
 testUtils::TestFileFeature::TestFileFeature(const babelwires::ProjectContext& context)
     : babelwires::FileFeature(context, s_fileFormatId)
-    , m_intChildId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_intChildId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_intChildInitializer, s_intChildFieldName, s_intChildUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative)) {
     m_intChildFeature =
@@ -36,7 +36,7 @@ std::string testUtils::TestSourceFileFormat::getFileExtension() {
 }
 
 testUtils::TestSourceFileFormat::TestSourceFileFormat()
-    : SourceFileFormat(babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    : SourceFileFormat(babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
                            s_fileFormatId, s_fileFormatId, "f557b89a-2499-465a-a605-5ef7f69284c4",
                            babelwires::IdentifierRegistry::Authority::isAuthoritative),
                        1, {s_fileFormatId}) {}
@@ -90,7 +90,7 @@ void testUtils::TestSourceFileFormat::writeToTestFile(const std::filesystem::pat
 }
 
 testUtils::TestTargetFileFormat::TestTargetFileFormat()
-    : TargetFileFormat(babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    : TargetFileFormat(babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
                            s_factoryFormatId, s_factoryFormatId, "a9a603aa-9d83-4f12-ac35-de0056d5a568",
                            babelwires::IdentifierRegistry::Authority::isAuthoritative),
                        3, {s_fileFormatId}) {}

--- a/Tests/BabelWiresLib/TestUtils/testFileFormats.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFileFormats.hpp
@@ -20,7 +20,7 @@ namespace testUtils {
 
         static constexpr char s_intChildUuid[] = "00000000-1111-2222-3333-800000000BBB";
 
-        babelwires::Identifier m_intChildId;
+        babelwires::ShortId m_intChildId;
 
         /// A shortcut for accessing at the child feature.
         babelwires::IntFeature* m_intChildFeature;

--- a/Tests/BabelWiresLib/TestUtils/testFileFormats.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testFileFormats.hpp
@@ -32,7 +32,7 @@ namespace testUtils {
     /// The serialized format is just the identifier followed by a single byte which carries the value of
     /// intChildFeature. This has version 1.
     struct TestSourceFileFormat : babelwires::SourceFileFormat {
-        static babelwires::LongIdentifier getThisIdentifier();
+        static babelwires::LongId getThisIdentifier();
         static std::string getFileExtension();
 
         TestSourceFileFormat();
@@ -49,7 +49,7 @@ namespace testUtils {
     /// A factor for construction new file features.
     /// This is given version 3, to allow version testing.
     struct TestTargetFileFormat : babelwires::TargetFileFormat {
-        static babelwires::LongIdentifier getThisIdentifier();
+        static babelwires::LongId getThisIdentifier();
 
         TestTargetFileFormat();
         std::string getManufacturerName() const override;

--- a/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
@@ -34,7 +34,7 @@ testUtils::TestProcessorFactory::TestProcessorFactory()
                            babelwires::IdentifierRegistry::Authority::isAuthoritative),
                        2) {}
 
-babelwires::LongIdentifier testUtils::TestProcessorFactory::getThisIdentifier() {
+babelwires::LongId testUtils::TestProcessorFactory::getThisIdentifier() {
     return "testProcessor";
 }
 

--- a/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
@@ -29,7 +29,7 @@ babelwires::RootFeature* testUtils::TestProcessor::getOutputFeature() {
 }
 
 testUtils::TestProcessorFactory::TestProcessorFactory()
-    : ProcessorFactory(babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    : ProcessorFactory(babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
                            "testProcessor", "Test processor", "714b6684-ad20-43e6-abda-c0d308586bf4",
                            babelwires::IdentifierRegistry::Authority::isAuthoritative),
                        2) {}

--- a/Tests/BabelWiresLib/TestUtils/testProcessor.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testProcessor.hpp
@@ -31,7 +31,7 @@ namespace testUtils {
     struct TestProcessorFactory : babelwires::ProcessorFactory {
         TestProcessorFactory();
 
-        static babelwires::LongIdentifier getThisIdentifier();
+        static babelwires::LongId getThisIdentifier();
 
         std::unique_ptr<babelwires::Processor> createNewProcessor(const babelwires::ProjectContext& projectContext) const override;
     };

--- a/Tests/BabelWiresLib/TestUtils/testRecord.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecord.cpp
@@ -27,17 +27,17 @@ namespace {
 } // namespace
 
 testUtils::TestRecordFeature::TestRecordFeature(int intValueLimit, bool addExtraInt)
-    : m_intId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    : m_intId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_intIdInitializer, s_intFieldName, s_intUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_arrayId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_arrayId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_arrayIdInitializer, s_arrayFieldName, s_arrayUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_recordId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_recordId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_recordIdInitializer, s_recordFieldName, s_recordUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_int2Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_int2Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_int2IdInitializer, s_int2FieldName, s_int2Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_extraIntId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_extraIntId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_extraIntIdInitializer, s_extraIntFieldName, s_extraIntUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_intValueLimit(intValueLimit) {

--- a/Tests/BabelWiresLib/TestUtils/testRecord.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecord.hpp
@@ -34,11 +34,11 @@ namespace testUtils {
         static constexpr char s_int2Uuid[] = "00000000-1111-2222-3333-800000000004";
         static constexpr char s_extraIntUuid[] = "00000000-1111-2222-3333-800000000005";
 
-        babelwires::Identifier m_intId;
-        babelwires::Identifier m_arrayId;
-        babelwires::Identifier m_recordId;
-        babelwires::Identifier m_int2Id;
-        babelwires::Identifier m_extraIntId;
+        babelwires::ShortId m_intId;
+        babelwires::ShortId m_arrayId;
+        babelwires::ShortId m_recordId;
+        babelwires::ShortId m_int2Id;
+        babelwires::ShortId m_extraIntId;
 
         babelwires::IntFeature* m_intFeature;
         // This has a min and default size of 2.

--- a/Tests/BabelWiresLib/TestUtils/testRootFeature.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRootFeature.cpp
@@ -56,17 +56,17 @@ namespace {
 
 testUtils::TestRootFeature::TestRootFeature(const babelwires::ProjectContext& context, int intValueLimit, bool addExtraInt)
     : RootFeature(context)
-    , m_intId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_intId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_intIdInitializer, s_intFieldName, s_intUuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_arrayId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_arrayId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_arrayIdInitializer, s_arrayFieldName, s_arrayUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_recordId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_recordId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_recordIdInitializer, s_recordFieldName, s_recordUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_int2Id(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_int2Id(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_int2IdInitializer, s_int2FieldName, s_int2Uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative))
-    , m_extraIntId(babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+    , m_extraIntId(babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
           s_extraIntIdInitializer, s_extraIntFieldName, s_extraIntUuid,
           babelwires::IdentifierRegistry::Authority::isAuthoritative))
     , m_intValueLimit(intValueLimit) {

--- a/Tests/BabelWiresLib/TestUtils/testRootFeature.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testRootFeature.hpp
@@ -35,11 +35,11 @@ namespace testUtils {
         static constexpr char s_int2Uuid[] = "00000000-1111-2222-3333-800000000004";
         static constexpr char s_extraIntUuid[] = "00000000-1111-2222-3333-800000000005";
 
-        babelwires::Identifier m_intId;
-        babelwires::Identifier m_arrayId;
-        babelwires::Identifier m_recordId;
-        babelwires::Identifier m_int2Id;
-        babelwires::Identifier m_extraIntId;
+        babelwires::ShortId m_intId;
+        babelwires::ShortId m_arrayId;
+        babelwires::ShortId m_recordId;
+        babelwires::ShortId m_int2Id;
+        babelwires::ShortId m_extraIntId;
 
         babelwires::IntFeature* m_intFeature;
         // This has a min and default size of 2.

--- a/Tests/BabelWiresLib/TestUtils/testTypeConstructor.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testTypeConstructor.cpp
@@ -2,26 +2,22 @@
 
 std::unique_ptr<babelwires::Type>
 testUtils::TestUnaryTypeConstructor::constructType(babelwires::TypeRef newTypeRef,
-                                                   const std::vector<const babelwires::Type*>& arguments) const {
-    assert(arguments.size() == 1);
+                                                   const std::array<const babelwires::Type*, 1>& arguments) const {
     // Remember the typeRef, since there's no way to reconstruct it.
     return std::make_unique<babelwires::ConstructedType<TestType>>(std::move(newTypeRef));
 }
 
 /// A < B => UNARY<A> < UNARY<B>
 babelwires::SubtypeOrder testUtils::TestUnaryTypeConstructor::compareSubtypeHelper(
-    const babelwires::TypeSystem& typeSystem, const babelwires::TypeConstructorArguments& argumentsA,
-    const babelwires::TypeConstructorArguments& argumentsB) const {
-    assert(argumentsA.m_typeArguments.size() == 1);
-    assert(argumentsB.m_typeArguments.size() == 1);
+    const babelwires::TypeSystem& typeSystem, const babelwires::TypeConstructorArguments<1>& argumentsA,
+    const babelwires::TypeConstructorArguments<1>& argumentsB) const {
     return typeSystem.compareSubtype(argumentsA.m_typeArguments[0], argumentsB.m_typeArguments[0]);
 }
 
 babelwires::SubtypeOrder
 testUtils::TestUnaryTypeConstructor::compareSubtypeHelper(const babelwires::TypeSystem& typeSystem,
-                                                          const babelwires::TypeConstructorArguments& arguments,
+                                                          const babelwires::TypeConstructorArguments<1>& arguments,
                                                           const babelwires::TypeRef& other) const {
-    assert(arguments.m_typeArguments.size() == 1);
     const babelwires::SubtypeOrder argOrder = typeSystem.compareSubtype(arguments.m_typeArguments[0], other);
     if ((argOrder == babelwires::SubtypeOrder::IsEquivalent) || (argOrder == babelwires::SubtypeOrder::IsSupertype)) {
         return babelwires::SubtypeOrder::IsSupertype;
@@ -31,17 +27,14 @@ testUtils::TestUnaryTypeConstructor::compareSubtypeHelper(const babelwires::Type
 
 std::unique_ptr<babelwires::Type>
 testUtils::TestBinaryTypeConstructor::constructType(babelwires::TypeRef newTypeRef,
-                                                    const std::vector<const babelwires::Type*>& arguments) const {
-    assert(arguments.size() == 2);
+                                                    const std::array<const babelwires::Type*, 2>& arguments) const {
     // Remember the typeRef, since there's no way to reconstruct it.
     return std::make_unique<babelwires::ConstructedType<TestType>>(std::move(newTypeRef));
 }
 
 babelwires::SubtypeOrder testUtils::TestBinaryTypeConstructor::compareSubtypeHelper(
-    const babelwires::TypeSystem& typeSystem, const babelwires::TypeConstructorArguments& argumentsA,
-    const babelwires::TypeConstructorArguments& argumentsB) const {
-    assert(argumentsA.m_typeArguments.size() == 2);
-    assert(argumentsB.m_typeArguments.size() == 2);
+    const babelwires::TypeSystem& typeSystem, const babelwires::TypeConstructorArguments<2>& argumentsA,
+    const babelwires::TypeConstructorArguments<2>& argumentsB) const {
     const auto compare0 = typeSystem.compareSubtype(argumentsA.m_typeArguments[0], argumentsB.m_typeArguments[0]);
     const auto compare1 = typeSystem.compareSubtype(argumentsA.m_typeArguments[1], argumentsB.m_typeArguments[1]);
     if ((compare0 == babelwires::SubtypeOrder::IsEquivalent) && (compare1 == babelwires::SubtypeOrder::IsEquivalent)) {

--- a/Tests/BabelWiresLib/TestUtils/testTypeConstructor.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testTypeConstructor.hpp
@@ -12,7 +12,7 @@ namespace testUtils {
     /// Always returns a TestType.
     class TestUnaryTypeConstructor : public babelwires::TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("Unary"), 1);
+        TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("Unary"), 1);
 
         unsigned int getArity() const override { return 1; }
 
@@ -33,7 +33,7 @@ namespace testUtils {
 
     class TestBinaryTypeConstructor : public babelwires::TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("Binary"), 1);
+        TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("Binary"), 1);
         unsigned int getArity() const override { return 2; }
 
         std::unique_ptr<babelwires::Type>

--- a/Tests/BabelWiresLib/TestUtils/testTypeConstructor.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testTypeConstructor.hpp
@@ -10,41 +10,39 @@
 
 namespace testUtils {
     /// Always returns a TestType.
-    class TestUnaryTypeConstructor : public babelwires::TypeConstructor {
+    class TestUnaryTypeConstructor : public babelwires::TypeConstructor<1> {
       public:
         TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("Unary"), 1);
 
-        unsigned int getArity() const override { return 1; }
-
         std::unique_ptr<babelwires::Type>
         constructType(babelwires::TypeRef newTypeRef,
-                      const std::vector<const babelwires::Type*>& arguments) const override;
+                      const std::array<const babelwires::Type*, 1>& arguments) const override;
+
         /// A < B => Unary<A> < Unary<B>
         babelwires::SubtypeOrder compareSubtypeHelper(const babelwires::TypeSystem& typeSystem,
-                                                      const babelwires::TypeConstructorArguments& argumentsA,
-                                                      const babelwires::TypeConstructorArguments& argumentsB) const;
+                                                      const babelwires::TypeConstructorArguments<1>& argumentsA,
+                                                      const babelwires::TypeConstructorArguments<1>& argumentsB) const;
 
         /// Same as AddBlankToEnum.
         /// B < A => B < Unary<A>
         babelwires::SubtypeOrder compareSubtypeHelper(const babelwires::TypeSystem& typeSystem,
-                                                      const babelwires::TypeConstructorArguments& arguments,
+                                                      const babelwires::TypeConstructorArguments<1>& arguments,
                                                       const babelwires::TypeRef& other) const;
     };
 
-    class TestBinaryTypeConstructor : public babelwires::TypeConstructor {
+    class TestBinaryTypeConstructor : public babelwires::TypeConstructor<2> {
       public:
         TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("Binary"), 1);
-        unsigned int getArity() const override { return 2; }
 
         std::unique_ptr<babelwires::Type>
         constructType(babelwires::TypeRef newTypeRef,
-                      const std::vector<const babelwires::Type*>& arguments) const override;
+                      const std::array<const babelwires::Type*, 2>& arguments) const override;
 
         /// Similar to a function type constructor.
         /// (B < A) && (C < D) => Binary<A, C> < Binary<B, D>
         babelwires::SubtypeOrder compareSubtypeHelper(const babelwires::TypeSystem& typeSystem,
-                                                      const babelwires::TypeConstructorArguments& argumentsA,
-                                                      const babelwires::TypeConstructorArguments& argumentsB) const;
+                                                      const babelwires::TypeConstructorArguments<2>& argumentsA,
+                                                      const babelwires::TypeConstructorArguments<2>& argumentsB) const;
     };
 
 } // namespace testUtils

--- a/Tests/BabelWiresLib/TestUtils/testValueAndType.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testValueAndType.hpp
@@ -27,7 +27,7 @@ namespace testUtils {
     /// The Type of TestValues.
     class TestType : public babelwires::Type {
       public:
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredLongIdentifier("TestType"), 1);
+        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("TestType"), 1);
 
         std::unique_ptr<babelwires::Value> createValue() const override;
     };

--- a/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
@@ -67,7 +67,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
 TEST(ActivateOptionalsCommandTest, failSafelyNoElement) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::ActivateOptionalCommand command("Test command", 51,
                                                testUtils::TestFeatureWithOptionals::s_pathToSubrecord, opId);
@@ -79,7 +79,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoElement) {
 TEST(ActivateOptionalsCommandTest, failSafelyNoRecord) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::ActivateOptionalCommand command("Test command", 51,
                                                babelwires::FeaturePath::deserializeFromString("qqq/zzz"), opId);
@@ -104,7 +104,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoOptional) {
         testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::ActivateOptionalCommand command("Test command", elementId,
                                                testUtils::TestFeatureWithOptionals::s_pathToSubrecord, opId);

--- a/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
@@ -18,19 +18,19 @@ TEST(ActivateOptionalsModifierDataTest, apply) {
 
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
-    babelwires::Identifier op2("op2");
+    babelwires::ShortId op2("op2");
     op2.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature2 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op2);
 
@@ -52,19 +52,19 @@ TEST(ActivateOptionalsModifierDataTest, apply1) {
 
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
-    babelwires::Identifier op2("op2");
+    babelwires::ShortId op2("op2");
     op2.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature2 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op2);
 
@@ -85,11 +85,11 @@ TEST(ActivateOptionalsModifierDataTest, failureNotOptionals) {
 
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -131,7 +131,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
 TEST(DeactivateOptionalsCommandTest, failSafelyNoElement) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::DeactivateOptionalCommand command("Test command", 51,
                                                   testUtils::TestFeatureWithOptionals::s_pathToSubrecord, opId);
@@ -143,7 +143,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoElement) {
 TEST(DeactivateOptionalsCommandTest, failSafelyNoRecord) {
     babelwires::IdentifierRegistryScope identifierRegistry;
     testUtils::TestEnvironment testEnvironment;
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::DeactivateOptionalCommand command("Test command", 51,
                                                   babelwires::FeaturePath::deserializeFromString("qqq/zzz"), opId);
@@ -168,7 +168,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoOptional) {
     const auto* element = testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithOptionals>();
     ASSERT_NE(element, nullptr);
 
-    babelwires::Identifier opId("flerm");
+    babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
     babelwires::DeactivateOptionalCommand command("Test command", elementId,
                                                   testUtils::TestFeatureWithOptionals::s_pathToSubrecord, opId);

--- a/Tests/BabelWiresLib/editTreeTest.cpp
+++ b/Tests/BabelWiresLib/editTreeTest.cpp
@@ -679,7 +679,7 @@ TEST(EditTreeTest, treeIteration) {
 
     auto it = tree.begin();
     EXPECT_NE(it, tree.end());
-    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::Identifier("aa")));
+    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("aa")));
     EXPECT_EQ(it.getModifier(), nullptr);
     {
         auto cit = it.childrenBegin();
@@ -692,7 +692,7 @@ TEST(EditTreeTest, treeIteration) {
     }
     it.nextSibling();
     EXPECT_NE(it, tree.end());
-    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::Identifier("bb")));
+    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("bb")));
     ASSERT_NE(it.getModifier(), nullptr);
     EXPECT_EQ(it.getModifier()->getModifierData().m_pathToFeature, path3);
     {
@@ -710,7 +710,7 @@ TEST(EditTreeTest, treeIteration) {
     }
     it.nextSibling();
     EXPECT_NE(it, tree.end());
-    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::Identifier("cc")));
+    EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("cc")));
     ASSERT_EQ(it.getModifier(), nullptr);
     {
         auto cit = it.childrenBegin();

--- a/Tests/BabelWiresLib/enumTest.cpp
+++ b/Tests/BabelWiresLib/enumTest.cpp
@@ -51,7 +51,7 @@ TEST(EnumTest, enumWithCppEnum) {
             : Enum(ENUM_IDENTIFIER_VECTOR(TEST_ENUM_VALUES), 1) {}
 
         static babelwires::LongId getThisIdentifier() {
-            return babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+            return babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
                                            "TestEnum", "TestEnum", "aaaaaaaa-1111-2222-3333-444444444444",
                                            babelwires::IdentifierRegistry::Authority::isAuthoritative);
         }

--- a/Tests/BabelWiresLib/enumTest.cpp
+++ b/Tests/BabelWiresLib/enumTest.cpp
@@ -50,8 +50,8 @@ TEST(EnumTest, enumWithCppEnum) {
         TestEnum()
             : Enum(ENUM_IDENTIFIER_VECTOR(TEST_ENUM_VALUES), 1) {}
 
-        static babelwires::LongId getThisIdentifier() {
-            return babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+        static babelwires::PrimitiveTypeId getThisIdentifier() {
+            return babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
                                            "TestEnum", "TestEnum", "aaaaaaaa-1111-2222-3333-444444444444",
                                            babelwires::IdentifierRegistry::Authority::isAuthoritative);
         }

--- a/Tests/BabelWiresLib/enumTest.cpp
+++ b/Tests/BabelWiresLib/enumTest.cpp
@@ -50,7 +50,7 @@ TEST(EnumTest, enumWithCppEnum) {
         TestEnum()
             : Enum(ENUM_IDENTIFIER_VECTOR(TEST_ENUM_VALUES), 1) {}
 
-        static babelwires::LongIdentifier getThisIdentifier() {
+        static babelwires::LongId getThisIdentifier() {
             return babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
                                            "TestEnum", "TestEnum", "aaaaaaaa-1111-2222-3333-444444444444",
                                            babelwires::IdentifierRegistry::Authority::isAuthoritative);

--- a/Tests/BabelWiresLib/featurePathTest.cpp
+++ b/Tests/BabelWiresLib/featurePathTest.cpp
@@ -16,9 +16,9 @@
 #include <Common/exceptions.hpp>
 
 TEST(FeaturePathTest, pathStepOps) {
-    babelwires::Identifier hello("Hello");
-    babelwires::Identifier hello1("Hello");
-    babelwires::Identifier goodbye("Byebye");
+    babelwires::ShortId hello("Hello");
+    babelwires::ShortId hello1("Hello");
+    babelwires::ShortId goodbye("Byebye");
 
     babelwires::PathStep helloStep(hello);
     babelwires::PathStep hello1Step(hello1);
@@ -48,7 +48,7 @@ TEST(FeaturePathTest, pathStepOps) {
 }
 
 TEST(FeaturePathTest, pathStepDiscriminator) {
-    babelwires::PathStep helloStep(babelwires::Identifier("Hello"));
+    babelwires::PathStep helloStep(babelwires::ShortId("Hello"));
 
     helloStep.asField()->setDiscriminator(12);
     EXPECT_EQ(helloStep.asField()->getDiscriminator(), 12);
@@ -73,13 +73,13 @@ TEST(FeaturePathTest, pathStepDeserialization) {
     babelwires::PathStep step(0);
     EXPECT_NO_THROW(step = babelwires::PathStep::deserializeFromString("Hello"));
     EXPECT_TRUE(step.isField());
-    EXPECT_EQ(step.getField(), babelwires::Identifier("Hello"));
+    EXPECT_EQ(step.getField(), babelwires::ShortId("Hello"));
     EXPECT_EQ(step.getField().getDiscriminator(), 0);
 
     babelwires::PathStep step1(0);
     EXPECT_NO_THROW(step1 = babelwires::PathStep::deserializeFromString("Hello'2"));
     EXPECT_TRUE(step1.isField());
-    EXPECT_EQ(step1.getField(), babelwires::Identifier("Hello"));
+    EXPECT_EQ(step1.getField(), babelwires::ShortId("Hello"));
     EXPECT_EQ(step1.getField().getDiscriminator(), 2);
 
     babelwires::PathStep step2("Erm");

--- a/Tests/BabelWiresLib/featureTest.cpp
+++ b/Tests/BabelWiresLib/featureTest.cpp
@@ -212,7 +212,7 @@ TEST(FeatureTest, recordFeature) {
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     hello.setDiscriminator(17);
 
     auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
@@ -221,21 +221,21 @@ TEST(FeatureTest, recordFeature) {
     EXPECT_EQ(recordFeature.getFeature(0), intFeature);
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 1);
-    babelwires::Identifier hello0 = recordFeature.getFieldIdentifier(0);
+    babelwires::ShortId hello0 = recordFeature.getFieldIdentifier(0);
     EXPECT_EQ(hello0, hello);
     babelwires::PathStep helloStep(hello);
     // This will set the descriminator (which is mutable) to match the one in the record.
     EXPECT_EQ(recordFeature.tryGetChildFromStep(helloStep), intFeature);
     EXPECT_EQ(hello.getDiscriminator(), helloStep.getField().getDiscriminator());
 
-    const babelwires::Identifier hello1("Hello");
+    const babelwires::ShortId hello1("Hello");
     EXPECT_EQ(hello1.getDiscriminator(), 0);
     // This will set the descriminator (which is mutable) to match the one in the record.
     EXPECT_EQ(recordFeature.getChildIndexFromStep(hello1), 0);
     EXPECT_EQ(hello, hello1);
     EXPECT_EQ(hello.getDiscriminator(), hello1.getDiscriminator());
 
-    const babelwires::Identifier hello2("Hello");
+    const babelwires::ShortId hello2("Hello");
     hello2.setDiscriminator(86);
     // This time the descriminator is untouched, since it's already set.
     EXPECT_EQ(recordFeature.getChildIndexFromStep(hello2), 0);
@@ -247,7 +247,7 @@ TEST(FeatureTest, recordFeature) {
     EXPECT_EQ(step.getField(), hello);
     EXPECT_EQ(step.getField().getDiscriminator(), hello.getDiscriminator());
 
-    babelwires::Identifier goodbye("Goodby");
+    babelwires::ShortId goodbye("Goodby");
     goodbye.setDiscriminator(109);
 
     auto stringFeaturePtr = std::make_unique<babelwires::StringFeature>();
@@ -255,7 +255,7 @@ TEST(FeatureTest, recordFeature) {
     recordFeature.addField(std::move(stringFeaturePtr), goodbye);
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 2);
-    babelwires::Identifier goodbye0 = recordFeature.getFieldIdentifier(1);
+    babelwires::ShortId goodbye0 = recordFeature.getFieldIdentifier(1);
     EXPECT_EQ(goodbye0, goodbye);
     EXPECT_EQ(recordFeature.tryGetChildFromStep(babelwires::PathStep(goodbye0)), stringFeature);
 
@@ -263,7 +263,7 @@ TEST(FeatureTest, recordFeature) {
     EXPECT_TRUE(step2.isField());
     EXPECT_EQ(step2.getField(), goodbye);
 
-    const babelwires::Identifier goodbye1("Goodby");
+    const babelwires::ShortId goodbye1("Goodby");
     EXPECT_EQ(recordFeature.getChildIndexFromStep(goodbye1), 1);
 }
 
@@ -280,7 +280,7 @@ TEST(FeatureTest, recordFeatureChanges) {
     EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::ValueChanged));
     EXPECT_FALSE(recordFeature.isChanged(babelwires::Feature::Changes::StructureChanged));
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     hello.setDiscriminator(17);
     auto intFeaturePtr = std::make_unique<babelwires::IntFeature>();
     babelwires::IntFeature* intFeature = intFeaturePtr.get();
@@ -311,7 +311,7 @@ TEST(FeatureTest, recordFeatureHash) {
 
     const std::uint32_t hashWhenEmpty = recordFeature.getHash();
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     hello.setDiscriminator(17);
     babelwires::IntFeature* intFeature = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), hello);
 

--- a/Tests/BabelWiresLib/mapDataTest.cpp
+++ b/Tests/BabelWiresLib/mapDataTest.cpp
@@ -15,8 +15,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::LongId testTypeId1 = "TestType1";
-    const babelwires::LongId testTypeId2 = "TestType2";
+    const babelwires::PrimitiveTypeId testTypeId1 = "TestType1";
+    const babelwires::PrimitiveTypeId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapDataTest, types) {

--- a/Tests/BabelWiresLib/mapDataTest.cpp
+++ b/Tests/BabelWiresLib/mapDataTest.cpp
@@ -15,8 +15,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::LongIdentifier testTypeId1 = "TestType1";
-    const babelwires::LongIdentifier testTypeId2 = "TestType2";
+    const babelwires::LongId testTypeId1 = "TestType1";
+    const babelwires::LongId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapDataTest, types) {

--- a/Tests/BabelWiresLib/mapEntryDataTest.cpp
+++ b/Tests/BabelWiresLib/mapEntryDataTest.cpp
@@ -17,8 +17,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::LongIdentifier testTypeId1 = "TestType1";
-    const babelwires::LongIdentifier testTypeId2 = "TestType2";
+    const babelwires::LongId testTypeId1 = "TestType1";
+    const babelwires::LongId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapEntryDataTest, isFallback) {

--- a/Tests/BabelWiresLib/mapFeatureTest.cpp
+++ b/Tests/BabelWiresLib/mapFeatureTest.cpp
@@ -20,8 +20,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::LongId testTypeId1 = "TestType1";
-    const babelwires::LongId testTypeId2 = "TestType2";
+    const babelwires::PrimitiveTypeId testTypeId1 = "TestType1";
+    const babelwires::PrimitiveTypeId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapFeatureTest, construction) {

--- a/Tests/BabelWiresLib/mapFeatureTest.cpp
+++ b/Tests/BabelWiresLib/mapFeatureTest.cpp
@@ -20,8 +20,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::LongIdentifier testTypeId1 = "TestType1";
-    const babelwires::LongIdentifier testTypeId2 = "TestType2";
+    const babelwires::LongId testTypeId1 = "TestType1";
+    const babelwires::LongId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapFeatureTest, construction) {

--- a/Tests/BabelWiresLib/mapHelperTest.cpp
+++ b/Tests/BabelWiresLib/mapHelperTest.cpp
@@ -21,8 +21,8 @@ namespace {
     }
 
     babelwires::MapData setUpTestMapData(const babelwires::TypeSystem& typeSystem,
-                                         babelwires::LongIdentifier sourceTypeId,
-                                         babelwires::LongIdentifier targetTypeId, const babelwires::Value& sourceValue1,
+                                         babelwires::LongId sourceTypeId,
+                                         babelwires::LongId targetTypeId, const babelwires::Value& sourceValue1,
                                          const babelwires::Value& sourceValue2, const babelwires::Value& targetValue1,
                                          const babelwires::Value& targetValue2, const babelwires::Value& targetValue3,
                                          bool allToOneFallback) {

--- a/Tests/BabelWiresLib/mapHelperTest.cpp
+++ b/Tests/BabelWiresLib/mapHelperTest.cpp
@@ -21,8 +21,8 @@ namespace {
     }
 
     babelwires::MapData setUpTestMapData(const babelwires::TypeSystem& typeSystem,
-                                         babelwires::LongId sourceTypeId,
-                                         babelwires::LongId targetTypeId, const babelwires::Value& sourceValue1,
+                                         const babelwires::TypeRef& sourceTypeId,
+                                         const babelwires::TypeRef& targetTypeId, const babelwires::Value& sourceValue1,
                                          const babelwires::Value& sourceValue2, const babelwires::Value& targetValue1,
                                          const babelwires::Value& targetValue2, const babelwires::Value& targetValue3,
                                          bool allToOneFallback) {
@@ -54,7 +54,7 @@ namespace {
     }
 
     babelwires::MapData setUpTestTypeMapData(const babelwires::TypeSystem& typeSystem, babelwires::MapData& mapData,
-                              bool allToOneFallback) {
+                                             bool allToOneFallback) {
         testUtils::TestValue sourceValue1;
         sourceValue1.m_value = "aaa";
 
@@ -70,13 +70,13 @@ namespace {
         testUtils::TestValue targetValue3;
         targetValue3.m_value = "zzz";
 
-        return setUpTestMapData(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier(),
-                         sourceValue1, sourceValue2, targetValue1, targetValue2, targetValue3,
-                         allToOneFallback);
+        return setUpTestMapData(typeSystem, testUtils::TestType::getThisIdentifier(),
+                                testUtils::TestType::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+                                targetValue2, targetValue3, allToOneFallback);
     }
 
     babelwires::MapData setUpTestEnumMapData(const babelwires::TypeSystem& typeSystem, babelwires::MapData& mapData,
-                              bool allToOneFallback) {
+                                             bool allToOneFallback) {
         babelwires::EnumValue sourceValue1;
         sourceValue1.set("Foo");
 
@@ -92,12 +92,13 @@ namespace {
         babelwires::EnumValue targetValue3;
         targetValue3.set("Erm");
 
-        return setUpTestMapData(typeSystem, testUtils::TestEnum::getThisIdentifier(), testUtils::TestEnum::getThisIdentifier(),
-                         sourceValue1, sourceValue2, targetValue1, targetValue2, targetValue3,
-                         allToOneFallback);
+        return setUpTestMapData(typeSystem, testUtils::TestEnum::getThisIdentifier(),
+                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+                                targetValue2, targetValue3, allToOneFallback);
     }
 
-    babelwires::MapData setUpTestTypeTestEnumMapData(const babelwires::TypeSystem& typeSystem, babelwires::MapData& mapData) {
+    babelwires::MapData setUpTestTypeTestEnumMapData(const babelwires::TypeSystem& typeSystem,
+                                                     babelwires::MapData& mapData) {
         testUtils::TestValue sourceValue1;
         sourceValue1.m_value = "aaa";
 
@@ -113,11 +114,13 @@ namespace {
         babelwires::EnumValue targetValue3;
         targetValue3.set("Erm");
 
-        return setUpTestMapData(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestEnum::getThisIdentifier(),
-                         sourceValue1, sourceValue2, targetValue1, targetValue2, targetValue3, true);
+        return setUpTestMapData(typeSystem, testUtils::TestType::getThisIdentifier(),
+                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+                                targetValue2, targetValue3, true);
     }
 
-    babelwires::MapData setUpTestEnumTestTypeMapData(const babelwires::TypeSystem& typeSystem, babelwires::MapData& mapData) {
+    babelwires::MapData setUpTestEnumTestTypeMapData(const babelwires::TypeSystem& typeSystem,
+                                                     babelwires::MapData& mapData) {
         babelwires::EnumValue sourceValue1;
         sourceValue1.set("Foo");
 
@@ -133,9 +136,9 @@ namespace {
         testUtils::TestValue targetValue3;
         targetValue3.m_value = "zzz";
 
-        return setUpTestMapData(typeSystem, testUtils::TestEnum::getThisIdentifier(), testUtils::TestEnum::getThisIdentifier(),
-                         sourceValue1, sourceValue2, targetValue1, targetValue2, targetValue3,
-                         true);
+        return setUpTestMapData(typeSystem, testUtils::TestEnum::getThisIdentifier(),
+                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+                                targetValue2, targetValue3, true);
     }
 } // namespace
 
@@ -238,8 +241,8 @@ TEST(MapHelperTest, enumSourceMapApplicator_differentTypes) {
 
     babelwires::MapData mapData = setUpTestEnumTestTypeMapData(typeSystem, mapData);
 
-    babelwires::EnumSourceMapApplicator<testUtils::TestEnum, std::string> mapApplicator(
-        mapData, testEnum, &testValueAdapter);
+    babelwires::EnumSourceMapApplicator<testUtils::TestEnum, std::string> mapApplicator(mapData, testEnum,
+                                                                                        &testValueAdapter);
 
     EXPECT_EQ(mapApplicator[testUtils::TestEnum::Value::Foo], "xxx");
     EXPECT_EQ(mapApplicator[testUtils::TestEnum::Value::Bar], "yyy");

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -16,8 +16,8 @@
 #include <Tests/TestUtils/equalSets.hpp>
 
 namespace {
-    const babelwires::LongId testTypeId1 = "TestType1";
-    const babelwires::LongId testTypeId2 = "TestType2";
+    const babelwires::PrimitiveTypeId testTypeId1 = "TestType1";
+    const babelwires::PrimitiveTypeId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapProjectTest, mapProjectEntry) {

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -16,8 +16,8 @@
 #include <Tests/TestUtils/equalSets.hpp>
 
 namespace {
-    const babelwires::LongIdentifier testTypeId1 = "TestType1";
-    const babelwires::LongIdentifier testTypeId2 = "TestType2";
+    const babelwires::LongId testTypeId1 = "TestType1";
+    const babelwires::LongId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapProjectTest, mapProjectEntry) {

--- a/Tests/BabelWiresLib/modifierTest.cpp
+++ b/Tests/BabelWiresLib/modifierTest.cpp
@@ -68,12 +68,12 @@ TEST(ModifierTest, clone) {
 TEST(ModifierTest, localApplySuccess) {
     babelwires::RecordFeature recordFeature;
 
-    babelwires::Identifier id0("aa");
+    babelwires::ShortId id0("aa");
     id0.setDiscriminator(1);
     babelwires::RecordFeature* childRecordFeature =
         recordFeature.addField(std::make_unique<babelwires::RecordFeature>(), id0);
 
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(2);
     babelwires::IntFeature* intFeature = childRecordFeature->addField(std::make_unique<babelwires::IntFeature>(), id1);
 
@@ -100,12 +100,12 @@ TEST(ModifierTest, localApplySuccess) {
 TEST(ModifierTest, localApplyFailureWrongType) {
     babelwires::RecordFeature recordFeature;
 
-    babelwires::Identifier id0("aa");
+    babelwires::ShortId id0("aa");
     id0.setDiscriminator(1);
     babelwires::RecordFeature* childRecordFeature =
         recordFeature.addField(std::make_unique<babelwires::RecordFeature>(), id0);
 
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(2);
     babelwires::StringFeature* stringFeature =
         childRecordFeature->addField(std::make_unique<babelwires::StringFeature>(), id1);
@@ -132,7 +132,7 @@ TEST(ModifierTest, localApplyFailureWrongType) {
 TEST(ModifierTest, localApplyFailureNoTarget) {
     babelwires::RecordFeature recordFeature;
 
-    babelwires::Identifier id0("aa");
+    babelwires::ShortId id0("aa");
     id0.setDiscriminator(1);
     babelwires::RecordFeature* childRecordFeature =
         recordFeature.addField(std::make_unique<babelwires::RecordFeature>(), id0);
@@ -162,7 +162,7 @@ TEST(ModifierTest, localApplyFailureNoTarget) {
 TEST(ModifierTest, arraySizeModifierSuccess) {
     babelwires::RecordFeature recordFeature;
 
-    babelwires::Identifier id0("aa");
+    babelwires::ShortId id0("aa");
     id0.setDiscriminator(1);
     babelwires::ArrayFeature* arrayFeature =
         recordFeature.addField(std::make_unique<babelwires::StandardArrayFeature<babelwires::IntFeature>>(), id0);
@@ -212,7 +212,7 @@ TEST(ModifierTest, arraySizeModifierSuccess) {
 TEST(ModifierTest, arraySizeModifierFailure) {
     babelwires::RecordFeature recordFeature;
 
-    babelwires::Identifier id0("aa");
+    babelwires::ShortId id0("aa");
     id0.setDiscriminator(1);
     babelwires::ArrayFeature* arrayFeature =
         recordFeature.addField(std::make_unique<babelwires::StandardArrayFeature<babelwires::IntFeature>>(), id0);
@@ -257,7 +257,7 @@ TEST(ModifierTest, connectionModifierSuccess) {
     const babelwires::ElementId sourceId = projectContext.m_project.addFeatureElement(elementData);
 
     babelwires::RecordFeature targetRecordFeature;
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(1);
     babelwires::IntFeature* targetFeature =
         targetRecordFeature.addField(std::make_unique<babelwires::IntFeature>(), id1);
@@ -285,7 +285,7 @@ TEST(ModifierTest, connectionModifierTargetPathFailure) {
     testUtils::TestEnvironment projectContext;
 
     babelwires::RecordFeature targetRecordFeature;
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(1);
     babelwires::IntFeature* targetFeature =
         targetRecordFeature.addField(std::make_unique<babelwires::IntFeature>(), id1);
@@ -316,7 +316,7 @@ TEST(ModifierTest, connectionModifierSourceIdFailure) {
     testUtils::TestEnvironment projectContext;
 
     babelwires::RecordFeature targetRecordFeature;
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(1);
     babelwires::IntFeature* targetFeature =
         targetRecordFeature.addField(std::make_unique<babelwires::IntFeature>(), id1);
@@ -357,7 +357,7 @@ TEST(ModifierTest, connectionModifierSourcePathFailure) {
     const babelwires::ElementId sourceId = projectContext.m_project.addFeatureElement(elementData);
 
     babelwires::RecordFeature targetRecordFeature;
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(1);
     babelwires::IntFeature* targetFeature =
         targetRecordFeature.addField(std::make_unique<babelwires::IntFeature>(), id1);
@@ -397,7 +397,7 @@ TEST(ModifierTest, connectionModifierApplicationFailure) {
     const babelwires::ElementId sourceId = projectContext.m_project.addFeatureElement(elementData);
 
     babelwires::RecordFeature targetRecordFeature;
-    babelwires::Identifier id1("bb");
+    babelwires::ShortId id1("bb");
     id1.setDiscriminator(1);
     babelwires::StringFeature* targetFeature =
         targetRecordFeature.addField(std::make_unique<babelwires::StringFeature>(), id1);

--- a/Tests/BabelWiresLib/parallelProcessorTest.cpp
+++ b/Tests/BabelWiresLib/parallelProcessorTest.cpp
@@ -15,10 +15,10 @@ namespace {
 
     struct TestParallelProcessor : babelwires::ParallelProcessor<LimitedIntFeature, LimitedIntFeature> {
         TestParallelProcessor(const babelwires::ProjectContext& context) : babelwires::ParallelProcessor<LimitedIntFeature, LimitedIntFeature>(context) {
-            const babelwires::ShortId intId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+            const babelwires::ShortId intId = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
                 "foo", "foo", "ec463f45-098d-4170-9890-d5a2db2e7658",
                 babelwires::IdentifierRegistry::Authority::isAuthoritative);
-            const babelwires::ShortId arrayId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+            const babelwires::ShortId arrayId = babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
                 "array", "array", "d607ccca-7cc3-4d17-940e-3ca87467f064",
                 babelwires::IdentifierRegistry::Authority::isAuthoritative);
             m_intValue = m_inputFeature->addField(std::make_unique<babelwires::IntFeature>(), intId);

--- a/Tests/BabelWiresLib/parallelProcessorTest.cpp
+++ b/Tests/BabelWiresLib/parallelProcessorTest.cpp
@@ -15,10 +15,10 @@ namespace {
 
     struct TestParallelProcessor : babelwires::ParallelProcessor<LimitedIntFeature, LimitedIntFeature> {
         TestParallelProcessor(const babelwires::ProjectContext& context) : babelwires::ParallelProcessor<LimitedIntFeature, LimitedIntFeature>(context) {
-            const babelwires::Identifier intId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+            const babelwires::ShortId intId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
                 "foo", "foo", "ec463f45-098d-4170-9890-d5a2db2e7658",
                 babelwires::IdentifierRegistry::Authority::isAuthoritative);
-            const babelwires::Identifier arrayId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+            const babelwires::ShortId arrayId = babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
                 "array", "array", "d607ccca-7cc3-4d17-940e-3ca87467f064",
                 babelwires::IdentifierRegistry::Authority::isAuthoritative);
             m_intValue = m_inputFeature->addField(std::make_unique<babelwires::IntFeature>(), intId);

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -108,7 +108,7 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
             int unrecognizedEntries = 0;
             for (const auto& v : testRegistry) {
                 ++entries;
-                const babelwires::LongIdentifier& fieldIdentifier = std::get<0>(v);
+                const babelwires::LongId& fieldIdentifier = std::get<0>(v);
                 const std::string& fieldName = *std::get<1>(v);
                 const babelwires::Uuid& uuid = *std::get<2>(v);
                 if (uuid == testUtils::TestRecordFeature::s_intUuid) {

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -22,29 +22,29 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
         testUtils::TestEnvironment testEnvironment;
         
         // Ensure some of the test record's discriminators are not default.
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
                                                              "test int", "41000000-1111-2222-3333-800000000001",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
                                                              "test int 1", "42000000-1111-2222-3333-800000000001",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
                                                              "test int 2", "43000000-1111-2222-3333-800000000001",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
                                                              "test array", "41000000-1111-2222-3333-800000000002",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
                                                              "test array 1", "42000000-1111-2222-3333-800000000002",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
                                                              "test record", "41000000-1111-2222-3333-800000000003",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
         // Also register some irrelevant field names.
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata("Flum", "Flum", "41000000-1111-2222-3333-800000000100",
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata("Flum", "Flum", "41000000-1111-2222-3333-800000000100",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata("Zarg", "Zarg", "41000000-1111-2222-3333-800000000101",
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata("Zarg", "Zarg", "41000000-1111-2222-3333-800000000101",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
         // Confirm that not all the discriminators in a test record are default.
@@ -155,19 +155,19 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
         testUtils::TestEnvironment testEnvironment;
 
         // Slightly different arrangement and UUIDs to the above (not that it should matter)
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_intIdInitializer,
                                                              "test int", "51000000-1111-2222-3333-800000000001",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_arrayIdInitializer,
                                                              "test array", "51000000-1111-2222-3333-800000000002",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
                                                              "test record 1", "51000000-1111-2222-3333-800000000003",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
                                                              "test record 2", "52000000-1111-2222-3333-800000000003",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(testUtils::TestRecordFeature::s_recordIdInitializer,
                                                              "test record 3", "53000000-1111-2222-3333-800000000003",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -175,9 +175,9 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
         testUtils::TestRecordFeature testRecord;
 
         // Also register some irrelevant field names.
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata("Flum", "Flum", "51000000-1111-2222-3333-800000000100",
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata("Flum", "Flum", "51000000-1111-2222-3333-800000000100",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-        babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata("Zarg", "Zarg", "51000000-1111-2222-3333-800000000101",
+        babelwires::IdentifierRegistry::write()->addShortIdWithMetadata("Zarg", "Zarg", "51000000-1111-2222-3333-800000000101",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
         babelwires::ProjectData projectData =
@@ -187,7 +187,7 @@ TEST(ProjectBundleTest, fieldIdsInPaths) {
 
         // Confirm that the resolved data is provisional.
         {
-            babelwires::IdentifierRegistry::write()->addShortIdentifierWithMetadata(
+            babelwires::IdentifierRegistry::write()->addShortIdWithMetadata(
                 testUtils::TestFileFeature::s_intChildInitializer, "Updated field name",
                 testUtils::TestFileFeature::s_intChildUuid,
                 babelwires::IdentifierRegistry::Authority::isAuthoritative);
@@ -316,13 +316,13 @@ TEST(ProjectBundleTest, factoryIdentifiers) {
 
     // Prepopulate the identifierRegistry with clashing factory identifier.
     // I don't expect duplicate factory identifiers, but this will make it easier to test
-    babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(testUtils::TestProcessorFactory::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestProcessorFactory::getThisIdentifier(),
                                                              "Other test processor", "41000000-1111-2222-3333-888888888888",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(testUtils::TestSourceFileFormat::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestSourceFileFormat::getThisIdentifier(),
                                                              "Other test source factory", "41000000-1111-2222-3333-999999999999",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(testUtils::TestTargetFileFormat::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestTargetFileFormat::getThisIdentifier(),
                                                              "Other test target factory", "41000000-1111-2222-3333-aaaaaaaaaaaa",
                                                              babelwires::IdentifierRegistry::Authority::isAuthoritative);
 

--- a/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
+++ b/Tests/BabelWiresLib/recordWithOptionalsFeatureTest.cpp
@@ -17,27 +17,27 @@ TEST(RecordWithOptionalsFeatureTest, fieldOrder) {
 
     EXPECT_EQ(recordFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
-    babelwires::Identifier op2("op2");
+    babelwires::ShortId op2("op2");
     op2.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature2 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op2);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
-    babelwires::Identifier op3("op3");
+    babelwires::ShortId op3("op3");
     op3.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature3 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op3);
 
@@ -130,11 +130,11 @@ TEST(RecordWithOptionalsFeatureTest, fieldOrder) {
 TEST(RecordWithOptionalsFeatureTest, changes) {
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
@@ -158,15 +158,15 @@ TEST(RecordWithOptionalsFeatureTest, changes) {
 TEST(RecordWithOptionalsFeatureTest, hash) {
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
@@ -199,15 +199,15 @@ TEST(RecordWithOptionalsFeatureTest, hash) {
 TEST(RecordWithOptionalsFeatureTest, queries) {
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
@@ -243,15 +243,15 @@ TEST(RecordWithOptionalsFeatureTest, queries) {
 TEST(RecordWithOptionalsFeatureTest, exceptions) {
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op0);
 
-    babelwires::Identifier op1("op1");
+    babelwires::ShortId op1("op1");
     op1.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature1 = recordFeature.addOptionalField(std::make_unique<babelwires::IntFeature>(), op1);
 
@@ -264,11 +264,11 @@ TEST(RecordWithOptionalsFeatureTest, exceptions) {
 TEST(RecordWithOptionalsFeatureTest, setToDefault) {
     babelwires::RecordWithOptionalsFeature recordFeature;
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = recordFeature.addField(std::make_unique<babelwires::HasStaticDefault<babelwires::IntFeature, 12>>(), ff0);
 
-    babelwires::Identifier op0("op0");
+    babelwires::ShortId op0("op0");
     op0.setDiscriminator(1);
     babelwires::IntFeature* optionalFeature0 = recordFeature.addOptionalField(std::make_unique<babelwires::HasStaticDefault<babelwires::IntFeature, 7>>(), op0);
 
@@ -292,8 +292,8 @@ TEST(RecordWithOptionalsFeatureTest, inactiveEnumCanBeDefaulted) {
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
 
     // Confirm that features in branches are in a fully defaulted state when a branch is selected.
-    babelwires::Identifier ff0 = testUtils::getTestRegisteredIdentifier("ff0");
-    babelwires::Identifier op0 = testUtils::getTestRegisteredIdentifier("op0");
+    babelwires::ShortId ff0 = testUtils::getTestRegisteredIdentifier("ff0");
+    babelwires::ShortId op0 = testUtils::getTestRegisteredIdentifier("op0");
 
     babelwires::RecordWithOptionalsFeature* recordWithOptionalFeature = rootFeature.addField(std::make_unique<babelwires::RecordWithOptionalsFeature>(), testUtils::getTestRegisteredIdentifier("recOpt"));
 

--- a/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchCommandTest.cpp
@@ -155,7 +155,7 @@ TEST(SelectUnionBranchCommandTest, failSafelyNoOptional) {
     const auto* element = testEnvironment.m_project.getFeatureElement(elementId)->as<testUtils::TestFeatureElementWithUnion>();
     ASSERT_NE(element, nullptr);
 
-    babelwires::Identifier notATag("notTag");
+    babelwires::ShortId notATag("notTag");
     notATag.setDiscriminator(1);
     babelwires::SelectUnionBranchCommand command("Test command",  51,
                                                testUtils::TestFeatureWithUnion::s_pathToUnionFeature, notATag);

--- a/Tests/BabelWiresLib/selectUnionBranchModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/selectUnionBranchModifierDataTest.cpp
@@ -11,11 +11,11 @@
 #include <Tests/TestUtils/equalSets.hpp>
 
 TEST(SelectUnionBranchModifierDataTest, apply) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::SelectUnionBranchModifierData data;
@@ -23,19 +23,19 @@ TEST(SelectUnionBranchModifierDataTest, apply) {
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier fieldIdC0("fldC0");
+    babelwires::ShortId fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
     babelwires::IntFeature* fieldC0 = unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
@@ -47,11 +47,11 @@ TEST(SelectUnionBranchModifierDataTest, apply) {
 }
 
 TEST(SelectUnionBranchModifierDataTest, failureNotATag) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::SelectUnionBranchModifierData data;
@@ -59,11 +59,11 @@ TEST(SelectUnionBranchModifierDataTest, failureNotATag) {
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 = unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
 
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -15,13 +15,12 @@ TEST(TypeRefTest, equality) {
     babelwires::TypeRef nullTypeRef;
     babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
     babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
-                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+                                            babelwires::PrimitiveTypeId("Flerm"));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
 
     EXPECT_EQ(nullTypeRef, nullTypeRef);
     EXPECT_EQ(primitiveTypeRef1, primitiveTypeRef1);
@@ -55,14 +54,13 @@ TEST(TypeRefTest, lessThan) {
     babelwires::TypeRef nullTypeRef;
     babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Bar"));
     babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Foo"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
-                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+                                            babelwires::PrimitiveTypeId("Flerm"));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::PrimitiveTypeId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
-    babelwires::TypeRef constructedTypeRef4(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Boo")}});
+        babelwires::PrimitiveTypeId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
+    babelwires::TypeRef constructedTypeRef4(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Boo"));
 
     EXPECT_LT(nullTypeRef, primitiveTypeRef1);
     EXPECT_LT(primitiveTypeRef1, primitiveTypeRef2);
@@ -105,7 +103,7 @@ TEST(TypeRefTest, resolve) {
 
     EXPECT_EQ(testEnum, &typeRef.resolve(typeSystem));
     babelwires::TypeRef constructedTypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                           {{testUtils::TestEnum::getThisIdentifier()}});
+                                           testUtils::TestEnum::getThisIdentifier());
     const babelwires::Type& newType = constructedTypeRef.resolve(typeSystem);
     EXPECT_EQ(newType.getTypeRef(), constructedTypeRef);
     EXPECT_EQ(&constructedTypeRef.resolve(typeSystem), &constructedTypeRef.resolve(typeSystem));
@@ -123,7 +121,7 @@ TEST(TypeRefTest, tryResolveSuccess) {
     EXPECT_EQ(testEnum, typeRef.tryResolve(typeSystem));
 
     babelwires::TypeRef constructedTypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                           {{testUtils::TestEnum::getThisIdentifier()}});
+                                           testUtils::TestEnum::getThisIdentifier());
     const babelwires::Type* newType = constructedTypeRef.tryResolve(typeSystem);
     EXPECT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(), constructedTypeRef);
@@ -148,9 +146,9 @@ TEST(TypeRefTest, tryResolveParallel) {
 
     babelwires::TypeRef constructedTypeRef(
         testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-        {{babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                              {{babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                                    {{testUtils::TestEnum::getThisIdentifier()}})}})}});
+        babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
+                            babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
+                                                testUtils::TestEnum::getThisIdentifier())));
 
     std::vector<std::tuple<babelwires::TypeRef, const babelwires::Type*>> vectorOfResolutions;
     for (int i = 0; i < 1000; ++i) {
@@ -181,35 +179,32 @@ TEST(TypeRefTest, toStringSuccess) {
     babelwires::TypeConstructorId unary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary0", "UNARY[{0}]", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "UNARY[Foofoo]");
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[UNARY[Foofoo]]");
+    EXPECT_EQ(babelwires::TypeRef(unary0, foo).toString(), "UNARY[Foofoo]");
+    EXPECT_EQ(babelwires::TypeRef(unary0, babelwires::TypeRef(unary0, foo)).toString(), "UNARY[UNARY[Foofoo]]");
 
     babelwires::TypeConstructorId unary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary1", "{0}++", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "Foofoo++");
-    EXPECT_EQ(babelwires::TypeRef(unary1, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[Foofoo]++");
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary1, {{foo}})}}).toString(), "UNARY[Foofoo++]");
+    EXPECT_EQ(babelwires::TypeRef(unary1, foo).toString(), "Foofoo++");
+    EXPECT_EQ(babelwires::TypeRef(unary1, babelwires::TypeRef(unary0, foo)).toString(), "UNARY[Foofoo]++");
+    EXPECT_EQ(babelwires::TypeRef(unary0, babelwires::TypeRef(unary1, foo)).toString(), "UNARY[Foofoo++]");
 
     babelwires::TypeConstructorId binary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Binary0", "{0} + {1}", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(binary0, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
-              "Foofoo + UNARY[Foofoo]");
-    EXPECT_EQ(babelwires::TypeRef(binary0, {{babelwires::TypeRef(unary0, {{foo}}), foo}}).toString(),
-              "UNARY[Foofoo] + Foofoo");
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(binary0, {{foo, foo}})}}).toString(),
-              "UNARY[Foofoo + Foofoo]");
+    EXPECT_EQ(babelwires::TypeRef(binary0, foo, babelwires::TypeRef(unary0, foo)).toString(), "Foofoo + UNARY[Foofoo]");
+    EXPECT_EQ(babelwires::TypeRef(binary0, babelwires::TypeRef(unary0, foo), foo).toString(), "UNARY[Foofoo] + Foofoo");
+    EXPECT_EQ(babelwires::TypeRef(unary0, babelwires::TypeRef(binary0, foo, foo)).toString(), "UNARY[Foofoo + Foofoo]");
 
     // With some escaped brackets.
     babelwires::TypeConstructorId binary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
-        "Binary0", "}}{1}{{}}{0}{{", "44444444-2222-3333-4444-555566667777",
+        "Binary0", "{1}{0}", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(binary1, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
+    EXPECT_EQ(babelwires::TypeRef(binary1, foo, babelwires::TypeRef(unary0, foo)).toString(),
               "}UNARY[Foofoo]{}Foofoo{");
-    EXPECT_EQ(babelwires::TypeRef(binary1, {{babelwires::TypeRef(unary0, {{foo}}), foo}}).toString(),
+    EXPECT_EQ(babelwires::TypeRef(binary1, babelwires::TypeRef(unary0, foo), foo).toString(),
               "}Foofoo{}UNARY[Foofoo]{");
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(binary1, {{foo, foo}})}}).toString(),
+    EXPECT_EQ(babelwires::TypeRef(unary0, babelwires::TypeRef(binary1, foo, foo)).toString(),
               "UNARY[}Foofoo{}Foofoo{]");
 }
 
@@ -226,18 +221,18 @@ TEST(TypeRefTest, toStringMalformed) {
     babelwires::TypeConstructorId unary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary0", "{", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "MalformedTypeRef{Unary0'1[Foo'1]}");
+    EXPECT_EQ(babelwires::TypeRef(unary0, foo).toString(), "MalformedTypeRef{Unary0'1[Foo'1]}");
 
     babelwires::TypeConstructorId unary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary1", "oo{", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "MalformedTypeRef{Unary1'1[Foo'1]}");
+    EXPECT_EQ(babelwires::TypeRef(unary1, foo).toString(), "MalformedTypeRef{Unary1'1[Foo'1]}");
 
     // This type of format string is not supported.
     babelwires::TypeConstructorId unary2 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary2", "oo{}pp", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    EXPECT_EQ(babelwires::TypeRef(unary2, {{foo}}).toString(), "MalformedTypeRef{Unary2'1[Foo'1]}");
+    EXPECT_EQ(babelwires::TypeRef(unary2, foo).toString(), "MalformedTypeRef{Unary2'1[Foo'1]}");
 
     babelwires::TypeConstructorId unary3 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary3", "UNARY{0}", "44444444-2222-3333-4444-555566667777",
@@ -245,7 +240,7 @@ TEST(TypeRefTest, toStringMalformed) {
     // Not enough arguments
     EXPECT_EQ(babelwires::TypeRef(unary3, {}).toString(), "MalformedTypeRef{Unary3'1[]}");
     // Too many arguments
-    EXPECT_EQ(babelwires::TypeRef(unary3, {{foo, foo}}).toString(), "MalformedTypeRef{Unary3'1[Foo'1,Foo'1]}");
+    EXPECT_EQ(babelwires::TypeRef(unary3, foo, foo).toString(), "MalformedTypeRef{Unary3'1[Foo'1,Foo'1]}");
 }
 
 TEST(TypeRefTest, serializeToStringNoDiscriminators) {
@@ -255,23 +250,22 @@ TEST(TypeRefTest, serializeToStringNoDiscriminators) {
     babelwires::TypeRef primitiveTypeRef(babelwires::PrimitiveTypeId("Foo"));
     EXPECT_EQ(primitiveTypeRef.serializeToString(), "Foo");
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
     EXPECT_EQ(constructedTypeRef1.serializeToString(), "Foo[Bar]");
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
-                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+                                            babelwires::PrimitiveTypeId("Flerm"));
     EXPECT_EQ(constructedTypeRef2.serializeToString(), "Foo[Bar,Flerm]");
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
     EXPECT_EQ(constructedTypeRef3.serializeToString(), "Foo[Bar,Flerm[Erm]]");
 
     babelwires::TypeRef constructedTypeRef4(
         babelwires::TypeConstructorId("Foo"),
-        {{babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}}),
-          babelwires::PrimitiveTypeId("Bar")}});
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")),
+        babelwires::PrimitiveTypeId("Bar"));
     EXPECT_EQ(constructedTypeRef4.serializeToString(), "Foo[Flerm[Erm],Bar]");
 }
 
@@ -280,26 +274,25 @@ TEST(TypeRefTest, serializeToStringWithDiscriminators) {
     EXPECT_EQ(primitiveTypeRef.serializeToString(), "Foo'2");
 
     babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
+                                            testUtils::getTestRegisteredMediumIdentifier("Bar", 4));
     EXPECT_EQ(constructedTypeRef1.serializeToString(), "Foo'2[Bar'4]");
 
     babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-                                              testUtils::getTestRegisteredMediumIdentifier("Flerm", 1)}});
+                                            testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                            testUtils::getTestRegisteredMediumIdentifier("Flerm", 1));
     EXPECT_EQ(constructedTypeRef2.serializeToString(), "Foo'2[Bar'4,Flerm'1]");
 
     babelwires::TypeRef constructedTypeRef3(
-        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-        {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-          babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2), testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+        babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                            testUtils::getTestRegisteredMediumIdentifier("Erm", 13)));
     EXPECT_EQ(constructedTypeRef3.serializeToString(), "Foo'2[Bar'4,Flerm'1[Erm'13]]");
 
     babelwires::TypeRef constructedTypeRef4(
         testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-        {{babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}}),
-          testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
+        babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                            testUtils::getTestRegisteredMediumIdentifier("Erm", 13)),
+        testUtils::getTestRegisteredMediumIdentifier("Bar", 4));
     EXPECT_EQ(constructedTypeRef4.serializeToString(), "Foo'2[Flerm'1[Erm'13],Bar'4]");
 }
 
@@ -307,23 +300,22 @@ TEST(TypeRefTest, deserializeFromStringNoDiscriminatorsSuccess) {
     babelwires::TypeRef primitiveTypeRef(babelwires::TypeConstructorId("Foo"));
     EXPECT_EQ(primitiveTypeRef, babelwires::TypeRef::deserializeFromString("Foo"));
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
     EXPECT_EQ(constructedTypeRef1, babelwires::TypeRef::deserializeFromString("Foo[Bar]"));
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
-                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+                                            babelwires::PrimitiveTypeId("Flerm"));
     EXPECT_EQ(constructedTypeRef2, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm]"));
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
     EXPECT_EQ(constructedTypeRef3, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm[Erm]]"));
 
     babelwires::TypeRef constructedTypeRef4(
         babelwires::TypeConstructorId("Foo"),
-        {{babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}}),
-          babelwires::PrimitiveTypeId("Bar")}});
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")),
+        babelwires::PrimitiveTypeId("Bar"));
     EXPECT_EQ(constructedTypeRef4, babelwires::TypeRef::deserializeFromString("Foo[Flerm[Erm],Bar]"));
 
     // 10 arguments supported
@@ -337,28 +329,24 @@ TEST(TypeRefTest, deserializeFromStringWithDiscriminatorsSuccess) {
     EXPECT_EQ(primitiveTypeRef, babelwires::TypeRef::deserializeFromString("Foo'2"));
 
     babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
+                                            testUtils::getTestRegisteredMediumIdentifier("Bar", 4));
     EXPECT_EQ(constructedTypeRef1, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4]"));
 
     babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-                                              testUtils::getTestRegisteredMediumIdentifier("Flerm", 1)}});
+                                            testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                            testUtils::getTestRegisteredMediumIdentifier("Flerm", 1));
     EXPECT_EQ(constructedTypeRef2, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4,Flerm'1]"));
 
     babelwires::TypeRef constructedTypeRef3(
-        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-        {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-          babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2), testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+        babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                            testUtils::getTestRegisteredMediumIdentifier("Erm", 13)));
     EXPECT_EQ(constructedTypeRef3, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4,Flerm'1[Erm'13]]"));
 
-    babelwires::TypeRef constructedTypeRef4(
-        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-        {{
-            babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
-                                {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}}),
-            testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-        }});
+    babelwires::TypeRef constructedTypeRef4(testUtils::getTestRegisteredMediumIdentifier("Foo", 2), babelwires::TypeRef(
+                                                testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                                                testUtils::getTestRegisteredMediumIdentifier("Erm", 13)),
+                                            testUtils::getTestRegisteredMediumIdentifier("Bar", 4));
     EXPECT_EQ(constructedTypeRef4, babelwires::TypeRef::deserializeFromString("Foo'2[Flerm'1[Erm'13],Bar'4]"));
 }
 
@@ -380,9 +368,9 @@ TEST(TypeRefTest, deserializeFromStringFailure) {
 
 TEST(TypeRefTest, visitIdentifiers) {
     babelwires::TypeRef typeRef(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
-                                {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
-                                  babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
-                                                      {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
+                                testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                                                    testUtils::getTestRegisteredMediumIdentifier("Erm", 13)));
 
     struct Visitor : babelwires::IdentifierVisitor {
         void operator()(babelwires::ShortId& identifier) {
@@ -427,15 +415,13 @@ TEST(TypeRefTest, hash) {
     babelwires::TypeRef nullTypeRef;
     babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
     babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef2(
-        babelwires::TypeConstructorId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"),
-        {{babelwires::PrimitiveTypeId("Bar"),
-          babelwires::TypeRef(babelwires::TypeConstructorId("Oom"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Oom"), babelwires::PrimitiveTypeId("Erm")));
 
     std::hash<babelwires::TypeRef> hasher;
 

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -13,15 +13,15 @@
 
 TEST(TypeRefTest, equality) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
-                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
+                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
 
     EXPECT_EQ(nullTypeRef, nullTypeRef);
     EXPECT_EQ(primitiveTypeRef1, primitiveTypeRef1);
@@ -53,16 +53,16 @@ TEST(TypeRefTest, equality) {
 
 TEST(TypeRefTest, lessThan) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Bar"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Foo"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
-                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Foo"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
+                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
-    babelwires::TypeRef constructedTypeRef4(babelwires::LongId("Foo"), {{babelwires::LongId("Boo")}});
+        babelwires::PrimitiveTypeId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
+    babelwires::TypeRef constructedTypeRef4(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Boo")}});
 
     EXPECT_LT(nullTypeRef, primitiveTypeRef1);
     EXPECT_LT(primitiveTypeRef1, primitiveTypeRef2);
@@ -135,7 +135,7 @@ TEST(TypeRefTest, tryResolveFailure) {
     babelwires::TypeSystem typeSystem;
 
     EXPECT_EQ(nullptr, babelwires::TypeRef().tryResolve(typeSystem));
-    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::LongId("Foo")).tryResolve(typeSystem));
+    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::PrimitiveTypeId("Foo")).tryResolve(typeSystem));
 }
 
 TEST(TypeRefTest, tryResolveParallel) {
@@ -172,26 +172,26 @@ TEST(TypeRefTest, toStringSuccess) {
 
     EXPECT_EQ(babelwires::TypeRef().toString(), "[]");
 
-    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::PrimitiveTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
     EXPECT_EQ(babelwires::TypeRef(foo).toString(), "Foofoo");
 
-    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary0", "UNARY[{0}]", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "UNARY[Foofoo]");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[UNARY[Foofoo]]");
 
-    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary1", "{0}++", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "Foofoo++");
     EXPECT_EQ(babelwires::TypeRef(unary1, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[Foofoo]++");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary1, {{foo}})}}).toString(), "UNARY[Foofoo++]");
 
-    babelwires::LongId binary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId binary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Binary0", "{0} + {1}", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary0, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -202,7 +202,7 @@ TEST(TypeRefTest, toStringSuccess) {
               "UNARY[Foofoo + Foofoo]");
 
     // With some escaped brackets.
-    babelwires::LongId binary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId binary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Binary0", "}}{1}{{}}{0}{{", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary1, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -219,27 +219,27 @@ TEST(TypeRefTest, toStringMalformed) {
     testUtils::TestLog log;
     babelwires::IdentifierRegistryScope identifierRegistry;
 
-    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::PrimitiveTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
-    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary0 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary0", "{", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "MalformedTypeRef{Unary0'1[Foo'1]}");
 
-    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary1 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary1", "oo{", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "MalformedTypeRef{Unary1'1[Foo'1]}");
 
     // This type of format string is not supported.
-    babelwires::LongId unary2 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary2 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary2", "oo{}pp", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary2, {{foo}}).toString(), "MalformedTypeRef{Unary2'1[Foo'1]}");
 
-    babelwires::LongId unary3 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
+    babelwires::TypeConstructorId unary3 = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Unary3", "UNARY{0}", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     // Not enough arguments
@@ -252,78 +252,78 @@ TEST(TypeRefTest, serializeToStringNoDiscriminators) {
     babelwires::TypeRef nullTypeRef;
     EXPECT_EQ(nullTypeRef.serializeToString(), "[]");
 
-    babelwires::TypeRef primitiveTypeRef(babelwires::LongId("Foo"));
+    babelwires::TypeRef primitiveTypeRef(babelwires::PrimitiveTypeId("Foo"));
     EXPECT_EQ(primitiveTypeRef.serializeToString(), "Foo");
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
     EXPECT_EQ(constructedTypeRef1.serializeToString(), "Foo[Bar]");
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
-                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
+                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
     EXPECT_EQ(constructedTypeRef2.serializeToString(), "Foo[Bar,Flerm]");
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
     EXPECT_EQ(constructedTypeRef3.serializeToString(), "Foo[Bar,Flerm[Erm]]");
 
     babelwires::TypeRef constructedTypeRef4(
-        babelwires::LongId("Foo"),
-        {{babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}}),
-          babelwires::LongId("Bar")}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}}),
+          babelwires::PrimitiveTypeId("Bar")}});
     EXPECT_EQ(constructedTypeRef4.serializeToString(), "Foo[Flerm[Erm],Bar]");
 }
 
 TEST(TypeRefTest, serializeToStringWithDiscriminators) {
-    babelwires::TypeRef primitiveTypeRef(testUtils::getTestRegisteredLongIdentifier("Foo", 2));
+    babelwires::TypeRef primitiveTypeRef(testUtils::getTestRegisteredMediumIdentifier("Foo", 2));
     EXPECT_EQ(primitiveTypeRef.serializeToString(), "Foo'2");
 
-    babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredLongIdentifier("Bar", 4)}});
+    babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
     EXPECT_EQ(constructedTypeRef1.serializeToString(), "Foo'2[Bar'4]");
 
-    babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredLongIdentifier("Bar", 4),
-                                              testUtils::getTestRegisteredLongIdentifier("Flerm", 1)}});
+    babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                              testUtils::getTestRegisteredMediumIdentifier("Flerm", 1)}});
     EXPECT_EQ(constructedTypeRef2.serializeToString(), "Foo'2[Bar'4,Flerm'1]");
 
     babelwires::TypeRef constructedTypeRef3(
-        testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-        {{testUtils::getTestRegisteredLongIdentifier("Bar", 4),
-          babelwires::TypeRef(testUtils::getTestRegisteredLongIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}})}});
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+        {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+          babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
     EXPECT_EQ(constructedTypeRef3.serializeToString(), "Foo'2[Bar'4,Flerm'1[Erm'13]]");
 
     babelwires::TypeRef constructedTypeRef4(
-        testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-        {{babelwires::TypeRef(testUtils::getTestRegisteredLongIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}}),
-          testUtils::getTestRegisteredLongIdentifier("Bar", 4)}});
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+        {{babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}}),
+          testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
     EXPECT_EQ(constructedTypeRef4.serializeToString(), "Foo'2[Flerm'1[Erm'13],Bar'4]");
 }
 
 TEST(TypeRefTest, deserializeFromStringNoDiscriminatorsSuccess) {
-    babelwires::TypeRef primitiveTypeRef(babelwires::LongId("Foo"));
+    babelwires::TypeRef primitiveTypeRef(babelwires::TypeConstructorId("Foo"));
     EXPECT_EQ(primitiveTypeRef, babelwires::TypeRef::deserializeFromString("Foo"));
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
     EXPECT_EQ(constructedTypeRef1, babelwires::TypeRef::deserializeFromString("Foo[Bar]"));
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
-                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"),
+                                            {{babelwires::PrimitiveTypeId("Bar"), babelwires::PrimitiveTypeId("Flerm")}});
     EXPECT_EQ(constructedTypeRef2, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm]"));
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
     EXPECT_EQ(constructedTypeRef3, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm[Erm]]"));
 
     babelwires::TypeRef constructedTypeRef4(
-        babelwires::LongId("Foo"),
-        {{babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}}),
-          babelwires::LongId("Bar")}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}}),
+          babelwires::PrimitiveTypeId("Bar")}});
     EXPECT_EQ(constructedTypeRef4, babelwires::TypeRef::deserializeFromString("Foo[Flerm[Erm],Bar]"));
 
     // 10 arguments supported
@@ -333,31 +333,31 @@ TEST(TypeRefTest, deserializeFromStringNoDiscriminatorsSuccess) {
 TEST(TypeRefTest, deserializeFromStringWithDiscriminatorsSuccess) {
     EXPECT_EQ(babelwires::TypeRef(), babelwires::TypeRef::deserializeFromString("[]"));
 
-    babelwires::TypeRef primitiveTypeRef(testUtils::getTestRegisteredLongIdentifier("Foo", 2));
+    babelwires::TypeRef primitiveTypeRef(testUtils::getTestRegisteredMediumIdentifier("Foo", 2));
     EXPECT_EQ(primitiveTypeRef, babelwires::TypeRef::deserializeFromString("Foo'2"));
 
-    babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredLongIdentifier("Bar", 4)}});
+    babelwires::TypeRef constructedTypeRef1(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4)}});
     EXPECT_EQ(constructedTypeRef1, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4]"));
 
-    babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-                                            {{testUtils::getTestRegisteredLongIdentifier("Bar", 4),
-                                              testUtils::getTestRegisteredLongIdentifier("Flerm", 1)}});
+    babelwires::TypeRef constructedTypeRef2(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+                                            {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                              testUtils::getTestRegisteredMediumIdentifier("Flerm", 1)}});
     EXPECT_EQ(constructedTypeRef2, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4,Flerm'1]"));
 
     babelwires::TypeRef constructedTypeRef3(
-        testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-        {{testUtils::getTestRegisteredLongIdentifier("Bar", 4),
-          babelwires::TypeRef(testUtils::getTestRegisteredLongIdentifier("Flerm", 1),
-                              {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}})}});
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+        {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+          babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                              {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
     EXPECT_EQ(constructedTypeRef3, babelwires::TypeRef::deserializeFromString("Foo'2[Bar'4,Flerm'1[Erm'13]]"));
 
     babelwires::TypeRef constructedTypeRef4(
-        testUtils::getTestRegisteredLongIdentifier("Foo", 2),
+        testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
         {{
-            babelwires::TypeRef(testUtils::getTestRegisteredLongIdentifier("Flerm", 1),
-                                {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}}),
-            testUtils::getTestRegisteredLongIdentifier("Bar", 4),
+            babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                                {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}}),
+            testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
         }});
     EXPECT_EQ(constructedTypeRef4, babelwires::TypeRef::deserializeFromString("Foo'2[Flerm'1[Erm'13],Bar'4]"));
 }
@@ -379,19 +379,23 @@ TEST(TypeRefTest, deserializeFromStringFailure) {
 }
 
 TEST(TypeRefTest, visitIdentifiers) {
-    babelwires::TypeRef typeRef(testUtils::getTestRegisteredLongIdentifier("Foo", 2),
-                                {{testUtils::getTestRegisteredLongIdentifier("Bar", 4),
-                                  babelwires::TypeRef(testUtils::getTestRegisteredLongIdentifier("Flerm", 1),
-                                                      {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}})}});
+    babelwires::TypeRef typeRef(testUtils::getTestRegisteredMediumIdentifier("Foo", 2),
+                                {{testUtils::getTestRegisteredMediumIdentifier("Bar", 4),
+                                  babelwires::TypeRef(testUtils::getTestRegisteredMediumIdentifier("Flerm", 1),
+                                                      {{testUtils::getTestRegisteredMediumIdentifier("Erm", 13)}})}});
 
     struct Visitor : babelwires::IdentifierVisitor {
         void operator()(babelwires::ShortId& identifier) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(17);
         }
-        void operator()(babelwires::LongId& identifier) {
+        void operator()(babelwires::MediumId& identifier) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(18);
+        }
+        void operator()(babelwires::LongId& identifier) {
+            m_seen.emplace(identifier);
+            identifier.setDiscriminator(24);
         }
         std::set<babelwires::ShortId> m_seen;
     } visitor1, visitor2;
@@ -421,17 +425,17 @@ TEST(TypeRefTest, visitIdentifiers) {
 
 TEST(TypeRefTest, hash) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), {{babelwires::PrimitiveTypeId("Bar")}});
     babelwires::TypeRef constructedTypeRef2(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), {{babelwires::PrimitiveTypeId("Erm")}})}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongId("Foo"),
-        {{babelwires::LongId("Bar"),
-          babelwires::TypeRef(babelwires::LongId("Oom"), {{babelwires::LongId("Erm")}})}});
+        babelwires::TypeConstructorId("Foo"),
+        {{babelwires::PrimitiveTypeId("Bar"),
+          babelwires::TypeRef(babelwires::TypeConstructorId("Oom"), {{babelwires::PrimitiveTypeId("Erm")}})}});
 
     std::hash<babelwires::TypeRef> hasher;
 

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -13,15 +13,15 @@
 
 TEST(TypeRefTest, equality) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongIdentifier("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongIdentifier("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongIdentifier("Foo"),
-                                            {{babelwires::LongIdentifier("Bar"), babelwires::LongIdentifier("Flerm")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
+                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}})}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
 
     EXPECT_EQ(nullTypeRef, nullTypeRef);
     EXPECT_EQ(primitiveTypeRef1, primitiveTypeRef1);
@@ -53,16 +53,16 @@ TEST(TypeRefTest, equality) {
 
 TEST(TypeRefTest, lessThan) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongIdentifier("Bar"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongIdentifier("Foo"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Bar")}});
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongIdentifier("Foo"),
-                                            {{babelwires::LongIdentifier("Bar"), babelwires::LongIdentifier("Flerm")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Bar"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Foo"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
+                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}})}});
-    babelwires::TypeRef constructedTypeRef4(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Boo")}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
+    babelwires::TypeRef constructedTypeRef4(babelwires::LongId("Foo"), {{babelwires::LongId("Boo")}});
 
     EXPECT_LT(nullTypeRef, primitiveTypeRef1);
     EXPECT_LT(primitiveTypeRef1, primitiveTypeRef2);
@@ -135,7 +135,7 @@ TEST(TypeRefTest, tryResolveFailure) {
     babelwires::TypeSystem typeSystem;
 
     EXPECT_EQ(nullptr, babelwires::TypeRef().tryResolve(typeSystem));
-    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::LongIdentifier("Foo")).tryResolve(typeSystem));
+    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::LongId("Foo")).tryResolve(typeSystem));
 }
 
 TEST(TypeRefTest, tryResolveParallel) {
@@ -172,26 +172,26 @@ TEST(TypeRefTest, toStringSuccess) {
 
     EXPECT_EQ(babelwires::TypeRef().toString(), "[]");
 
-    babelwires::LongIdentifier foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
     EXPECT_EQ(babelwires::TypeRef(foo).toString(), "Foofoo");
 
-    babelwires::LongIdentifier unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary0", "UNARY[{0}]", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "UNARY[Foofoo]");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[UNARY[Foofoo]]");
 
-    babelwires::LongIdentifier unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary1", "{0}++", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "Foofoo++");
     EXPECT_EQ(babelwires::TypeRef(unary1, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[Foofoo]++");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary1, {{foo}})}}).toString(), "UNARY[Foofoo++]");
 
-    babelwires::LongIdentifier binary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId binary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Binary0", "{0} + {1}", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary0, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -202,7 +202,7 @@ TEST(TypeRefTest, toStringSuccess) {
               "UNARY[Foofoo + Foofoo]");
 
     // With some escaped brackets.
-    babelwires::LongIdentifier binary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId binary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Binary0", "}}{1}{{}}{0}{{", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary1, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -219,27 +219,27 @@ TEST(TypeRefTest, toStringMalformed) {
     testUtils::TestLog log;
     babelwires::IdentifierRegistryScope identifierRegistry;
 
-    babelwires::LongIdentifier foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
-    babelwires::LongIdentifier unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary0", "{", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "MalformedTypeRef{Unary0'1[Foo'1]}");
 
-    babelwires::LongIdentifier unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary1", "oo{", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "MalformedTypeRef{Unary1'1[Foo'1]}");
 
     // This type of format string is not supported.
-    babelwires::LongIdentifier unary2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary2", "oo{}pp", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary2, {{foo}}).toString(), "MalformedTypeRef{Unary2'1[Foo'1]}");
 
-    babelwires::LongIdentifier unary3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "Unary3", "UNARY{0}", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     // Not enough arguments
@@ -252,26 +252,26 @@ TEST(TypeRefTest, serializeToStringNoDiscriminators) {
     babelwires::TypeRef nullTypeRef;
     EXPECT_EQ(nullTypeRef.serializeToString(), "[]");
 
-    babelwires::TypeRef primitiveTypeRef(babelwires::LongIdentifier("Foo"));
+    babelwires::TypeRef primitiveTypeRef(babelwires::LongId("Foo"));
     EXPECT_EQ(primitiveTypeRef.serializeToString(), "Foo");
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
     EXPECT_EQ(constructedTypeRef1.serializeToString(), "Foo[Bar]");
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongIdentifier("Foo"),
-                                            {{babelwires::LongIdentifier("Bar"), babelwires::LongIdentifier("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
+                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
     EXPECT_EQ(constructedTypeRef2.serializeToString(), "Foo[Bar,Flerm]");
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}})}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
     EXPECT_EQ(constructedTypeRef3.serializeToString(), "Foo[Bar,Flerm[Erm]]");
 
     babelwires::TypeRef constructedTypeRef4(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}}),
-          babelwires::LongIdentifier("Bar")}});
+        babelwires::LongId("Foo"),
+        {{babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}}),
+          babelwires::LongId("Bar")}});
     EXPECT_EQ(constructedTypeRef4.serializeToString(), "Foo[Flerm[Erm],Bar]");
 }
 
@@ -304,26 +304,26 @@ TEST(TypeRefTest, serializeToStringWithDiscriminators) {
 }
 
 TEST(TypeRefTest, deserializeFromStringNoDiscriminatorsSuccess) {
-    babelwires::TypeRef primitiveTypeRef(babelwires::LongIdentifier("Foo"));
+    babelwires::TypeRef primitiveTypeRef(babelwires::LongId("Foo"));
     EXPECT_EQ(primitiveTypeRef, babelwires::TypeRef::deserializeFromString("Foo"));
 
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Bar")}});
+    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
     EXPECT_EQ(constructedTypeRef1, babelwires::TypeRef::deserializeFromString("Foo[Bar]"));
 
-    babelwires::TypeRef constructedTypeRef2(babelwires::LongIdentifier("Foo"),
-                                            {{babelwires::LongIdentifier("Bar"), babelwires::LongIdentifier("Flerm")}});
+    babelwires::TypeRef constructedTypeRef2(babelwires::LongId("Foo"),
+                                            {{babelwires::LongId("Bar"), babelwires::LongId("Flerm")}});
     EXPECT_EQ(constructedTypeRef2, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm]"));
 
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}})}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
     EXPECT_EQ(constructedTypeRef3, babelwires::TypeRef::deserializeFromString("Foo[Bar,Flerm[Erm]]"));
 
     babelwires::TypeRef constructedTypeRef4(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}}),
-          babelwires::LongIdentifier("Bar")}});
+        babelwires::LongId("Foo"),
+        {{babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}}),
+          babelwires::LongId("Bar")}});
     EXPECT_EQ(constructedTypeRef4, babelwires::TypeRef::deserializeFromString("Foo[Flerm[Erm],Bar]"));
 
     // 10 arguments supported
@@ -389,7 +389,7 @@ TEST(TypeRefTest, visitIdentifiers) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(17);
         }
-        void operator()(babelwires::LongIdentifier& identifier) {
+        void operator()(babelwires::LongId& identifier) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(18);
         }
@@ -421,17 +421,17 @@ TEST(TypeRefTest, visitIdentifiers) {
 
 TEST(TypeRefTest, hash) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::LongIdentifier("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::LongIdentifier("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::LongIdentifier("Foo"), {{babelwires::LongIdentifier("Bar")}});
+    babelwires::TypeRef primitiveTypeRef1(babelwires::LongId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::LongId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::LongId("Foo"), {{babelwires::LongId("Bar")}});
     babelwires::TypeRef constructedTypeRef2(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Flerm"), {{babelwires::LongIdentifier("Erm")}})}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Flerm"), {{babelwires::LongId("Erm")}})}});
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::LongIdentifier("Foo"),
-        {{babelwires::LongIdentifier("Bar"),
-          babelwires::TypeRef(babelwires::LongIdentifier("Oom"), {{babelwires::LongIdentifier("Erm")}})}});
+        babelwires::LongId("Foo"),
+        {{babelwires::LongId("Bar"),
+          babelwires::TypeRef(babelwires::LongId("Oom"), {{babelwires::LongId("Erm")}})}});
 
     std::hash<babelwires::TypeRef> hasher;
 

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -99,7 +99,7 @@ TEST(TypeRefTest, resolve) {
 
     const testUtils::TestEnum* testEnum = typeSystem.addEntry<testUtils::TestEnum>();
     const testUtils::TestUnaryTypeConstructor* unaryConstructor =
-        typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
+        typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef typeRef(testUtils::TestEnum::getThisIdentifier());
 
@@ -117,7 +117,7 @@ TEST(TypeRefTest, tryResolveSuccess) {
 
     const testUtils::TestEnum* testEnum = typeSystem.addEntry<testUtils::TestEnum>();
     const testUtils::TestUnaryTypeConstructor* unaryConstructor =
-        typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
+        typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef typeRef(testUtils::TestEnum::getThisIdentifier());
     EXPECT_EQ(testEnum, typeRef.tryResolve(typeSystem));
@@ -144,7 +144,7 @@ TEST(TypeRefTest, tryResolveParallel) {
 
     const testUtils::TestEnum* testEnum = typeSystem.addEntry<testUtils::TestEnum>();
     const testUtils::TestUnaryTypeConstructor* unaryConstructor =
-        typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
+        typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef constructedTypeRef(
         testUtils::TestUnaryTypeConstructor::getThisIdentifier(),

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -172,26 +172,26 @@ TEST(TypeRefTest, toStringSuccess) {
 
     EXPECT_EQ(babelwires::TypeRef().toString(), "[]");
 
-    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
     EXPECT_EQ(babelwires::TypeRef(foo).toString(), "Foofoo");
 
-    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary0", "UNARY[{0}]", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "UNARY[Foofoo]");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[UNARY[Foofoo]]");
 
-    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary1", "{0}++", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "Foofoo++");
     EXPECT_EQ(babelwires::TypeRef(unary1, {{babelwires::TypeRef(unary0, {{foo}})}}).toString(), "UNARY[Foofoo]++");
     EXPECT_EQ(babelwires::TypeRef(unary0, {{babelwires::TypeRef(unary1, {{foo}})}}).toString(), "UNARY[Foofoo++]");
 
-    babelwires::LongId binary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId binary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Binary0", "{0} + {1}", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary0, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -202,7 +202,7 @@ TEST(TypeRefTest, toStringSuccess) {
               "UNARY[Foofoo + Foofoo]");
 
     // With some escaped brackets.
-    babelwires::LongId binary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId binary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Binary0", "}}{1}{{}}{0}{{", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(binary1, {{foo, babelwires::TypeRef(unary0, {{foo}})}}).toString(),
@@ -219,27 +219,27 @@ TEST(TypeRefTest, toStringMalformed) {
     testUtils::TestLog log;
     babelwires::IdentifierRegistryScope identifierRegistry;
 
-    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId foo = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
-    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary0 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary0", "{", "11111111-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary0, {{foo}}).toString(), "MalformedTypeRef{Unary0'1[Foo'1]}");
 
-    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary1 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary1", "oo{", "22222222-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary1, {{foo}}).toString(), "MalformedTypeRef{Unary1'1[Foo'1]}");
 
     // This type of format string is not supported.
-    babelwires::LongId unary2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary2 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary2", "oo{}pp", "33333333-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(babelwires::TypeRef(unary2, {{foo}}).toString(), "MalformedTypeRef{Unary2'1[Foo'1]}");
 
-    babelwires::LongId unary3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    babelwires::LongId unary3 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "Unary3", "UNARY{0}", "44444444-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     // Not enough arguments

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -385,7 +385,7 @@ TEST(TypeRefTest, visitIdentifiers) {
                                                       {{testUtils::getTestRegisteredLongIdentifier("Erm", 13)}})}});
 
     struct Visitor : babelwires::IdentifierVisitor {
-        void operator()(babelwires::Identifier& identifier) {
+        void operator()(babelwires::ShortId& identifier) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(17);
         }
@@ -393,7 +393,7 @@ TEST(TypeRefTest, visitIdentifiers) {
             m_seen.emplace(identifier);
             identifier.setDiscriminator(18);
         }
-        std::set<babelwires::Identifier> m_seen;
+        std::set<babelwires::ShortId> m_seen;
     } visitor1, visitor2;
 
     typeRef.visitIdentifiers(visitor1);

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -76,13 +76,13 @@ TEST(TypeSystemTest, compareSubtypeUnary) {
     typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef unaryOfSubEnum(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubEnum::getThisIdentifier()}});
+                                       testUtils::TestSubEnum::getThisIdentifier());
 
     babelwires::TypeRef unaryOfSubSubEnum1(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubSubEnum1::getThisIdentifier()}});
+                                       testUtils::TestSubSubEnum1::getThisIdentifier());
 
     babelwires::TypeRef unaryOfSubSubEnum2(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubSubEnum2::getThisIdentifier()}});
+                                       testUtils::TestSubSubEnum2::getThisIdentifier());
     
     EXPECT_EQ(typeSystem.compareSubtype(unaryOfSubEnum, unaryOfSubEnum), babelwires::SubtypeOrder::IsEquivalent);
     EXPECT_EQ(typeSystem.compareSubtype(unaryOfSubEnum, unaryOfSubSubEnum1), babelwires::SubtypeOrder::IsSupertype);
@@ -111,13 +111,13 @@ TEST(TypeSystemTest, compareSubtypeBinary) {
     typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfSubEnumSubEnum(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier()}});
+                                       testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier());
 
     babelwires::TypeRef binaryOfEnumSubSubEnum1(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier()}});
+                                       testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier());
 
     babelwires::TypeRef binaryOfSubEnumSubSubEnum2(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubSubEnum2::getThisIdentifier()}});
+                                       testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubSubEnum2::getThisIdentifier());
 
     EXPECT_EQ(typeSystem.compareSubtype(binaryOfSubEnumSubEnum, binaryOfSubEnumSubEnum), babelwires::SubtypeOrder::IsEquivalent);
     EXPECT_EQ(typeSystem.compareSubtype(binaryOfSubEnumSubEnum, binaryOfEnumSubSubEnum1), babelwires::SubtypeOrder::IsSupertype);
@@ -142,13 +142,13 @@ TEST(TypeSystemTest, compareSubtypeComplex) {
     typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfEnumSubSubEnum1(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier()}});
+                                       testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier());
 
     babelwires::TypeRef unaryOfBinaryOfEnumSubSubEnum1(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
                                        {{binaryOfEnumSubSubEnum1}});
 
     babelwires::TypeRef binaryOfSubEnumSubEnum(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
-                                       {{testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier()}});
+                                       testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier());
 
     babelwires::TypeRef unaryOfBinaryOfSubEnumSubEnum(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
                                        {{binaryOfSubEnumSubEnum}});

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -73,7 +73,7 @@ TEST(TypeSystemTest, compareSubtypeUnary) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
+    typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef unaryOfSubEnum(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
                                        {{testUtils::TestSubEnum::getThisIdentifier()}});
@@ -108,7 +108,7 @@ TEST(TypeSystemTest, compareSubtypeBinary) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<testUtils::TestBinaryTypeConstructor>();
+    typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfSubEnumSubEnum(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
                                        {{testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier()}});
@@ -138,8 +138,8 @@ TEST(TypeSystemTest, compareSubtypeComplex) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
-    typeSystem.addTypeConstructor<testUtils::TestBinaryTypeConstructor>();
+    typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
+    typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfEnumSubSubEnum1(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
                                        {{testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier()}});

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -73,7 +73,7 @@ TEST(TypeSystemTest, compareSubtypeUnary) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
+    typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
 
     babelwires::TypeRef unaryOfSubEnum(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
                                        testUtils::TestSubEnum::getThisIdentifier());
@@ -108,7 +108,7 @@ TEST(TypeSystemTest, compareSubtypeBinary) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
+    typeSystem.addTypeConstructor<testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfSubEnumSubEnum(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
                                        testUtils::TestSubEnum::getThisIdentifier(), testUtils::TestSubEnum::getThisIdentifier());
@@ -138,8 +138,8 @@ TEST(TypeSystemTest, compareSubtypeComplex) {
 
     babelwires::TypeSystem typeSystem;
     addTestTypes(typeSystem);
-    typeSystem.addTypeConstructor<1, testUtils::TestUnaryTypeConstructor>();
-    typeSystem.addTypeConstructor<2, testUtils::TestBinaryTypeConstructor>();
+    typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
+    typeSystem.addTypeConstructor<testUtils::TestBinaryTypeConstructor>();
 
     babelwires::TypeRef binaryOfEnumSubSubEnum1(testUtils::TestBinaryTypeConstructor::getThisIdentifier(),
                                        testUtils::TestEnum::getThisIdentifier(), testUtils::TestSubSubEnum1::getThisIdentifier());

--- a/Tests/BabelWiresLib/unionFeatureTest.cpp
+++ b/Tests/BabelWiresLib/unionFeatureTest.cpp
@@ -13,41 +13,41 @@
 #include <Tests/TestUtils/testIdentifiers.hpp>
 
 TEST(UnionFeatureTest, fieldOrder) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier fieldIdC0("fldC0");
+    babelwires::ShortId fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
     babelwires::IntFeature* fieldC0 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
-    babelwires::Identifier fieldIdA1("fldA1");
+    babelwires::ShortId fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
     babelwires::IntFeature* fieldA1 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
-    babelwires::Identifier fieldIdC1("fldC1");
+    babelwires::ShortId fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
     babelwires::IntFeature* fieldC1 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
@@ -115,26 +115,26 @@ TEST(UnionFeatureTest, fieldOrder) {
 }
 
 TEST(UnionFeatureTest, fieldOrderWithOverlappingBranches) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier fieldIdA0 = testUtils::getTestRegisteredIdentifier("fldA0");
-    babelwires::Identifier ff0 = testUtils::getTestRegisteredIdentifier("ff0");
-    babelwires::Identifier fieldIdAB = testUtils::getTestRegisteredIdentifier("fldAB");
-    babelwires::Identifier fieldIdC0 = testUtils::getTestRegisteredIdentifier("fldC0");
-    babelwires::Identifier fieldIdA1 = testUtils::getTestRegisteredIdentifier("fldA1");
-    babelwires::Identifier ff1 = testUtils::getTestRegisteredIdentifier("ff1");
-    babelwires::Identifier fieldIdBC = testUtils::getTestRegisteredIdentifier("fldBC");
-    babelwires::Identifier fieldIdC1 = testUtils::getTestRegisteredIdentifier("fldC1");
-    babelwires::Identifier fieldIdAC = testUtils::getTestRegisteredIdentifier("fldAC");
+    babelwires::ShortId fieldIdA0 = testUtils::getTestRegisteredIdentifier("fldA0");
+    babelwires::ShortId ff0 = testUtils::getTestRegisteredIdentifier("ff0");
+    babelwires::ShortId fieldIdAB = testUtils::getTestRegisteredIdentifier("fldAB");
+    babelwires::ShortId fieldIdC0 = testUtils::getTestRegisteredIdentifier("fldC0");
+    babelwires::ShortId fieldIdA1 = testUtils::getTestRegisteredIdentifier("fldA1");
+    babelwires::ShortId ff1 = testUtils::getTestRegisteredIdentifier("ff1");
+    babelwires::ShortId fieldIdBC = testUtils::getTestRegisteredIdentifier("fldBC");
+    babelwires::ShortId fieldIdC1 = testUtils::getTestRegisteredIdentifier("fldC1");
+    babelwires::ShortId fieldIdAC = testUtils::getTestRegisteredIdentifier("fldAC");
 
     babelwires::IntFeature* fieldA0 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
@@ -233,8 +233,8 @@ TEST(UnionFeatureTest, fieldOrderWithOverlappingBranches) {
 
 TEST(UnionFeatureTest, defaults) {
     // Confirm that features in branches are in a fully defaulted state when a branch is selected.
-    babelwires::Identifier tagA = testUtils::getTestRegisteredIdentifier("tagA");
-    babelwires::Identifier tagB = testUtils::getTestRegisteredIdentifier("tagB");
+    babelwires::ShortId tagA = testUtils::getTestRegisteredIdentifier("tagA");
+    babelwires::ShortId tagB = testUtils::getTestRegisteredIdentifier("tagB");
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB}, 0);
 
@@ -264,41 +264,41 @@ TEST(UnionFeatureTest, defaults) {
 }
 
 TEST(UnionFeatureTest, changes) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier fieldIdC0("fldC0");
+    babelwires::ShortId fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
     babelwires::IntFeature* fieldC0 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
-    babelwires::Identifier fieldIdA1("fldA1");
+    babelwires::ShortId fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
     babelwires::IntFeature* fieldA1 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
-    babelwires::Identifier fieldIdC1("fldC1");
+    babelwires::ShortId fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
     babelwires::IntFeature* fieldC1 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
@@ -340,41 +340,41 @@ TEST(UnionFeatureTest, changes) {
 }
 
 TEST(UnionFeatureTest, hash) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier fieldIdC0("fldC0");
+    babelwires::ShortId fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
     babelwires::IntFeature* fieldC0 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
-    babelwires::Identifier fieldIdA1("fldA1");
+    babelwires::ShortId fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
     babelwires::IntFeature* fieldA1 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
-    babelwires::Identifier fieldIdC1("fldC1");
+    babelwires::ShortId fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
     babelwires::IntFeature* fieldC1 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
@@ -411,41 +411,41 @@ TEST(UnionFeatureTest, hash) {
 }
 
 TEST(UnionFeatureTest, queries) {
-    babelwires::Identifier tagA("tagA");
+    babelwires::ShortId tagA("tagA");
     tagA.setDiscriminator(1);
-    babelwires::Identifier tagB("tagB");
+    babelwires::ShortId tagB("tagB");
     tagB.setDiscriminator(1);
-    babelwires::Identifier tagC("tagC");
+    babelwires::ShortId tagC("tagC");
     tagC.setDiscriminator(1);
 
     babelwires::UnionFeature unionFeature(babelwires::UnionFeature::TagValues{tagA, tagB, tagC}, 2);
 
     EXPECT_EQ(unionFeature.getNumFeatures(), 0);
 
-    babelwires::Identifier fieldIdA0("fldA0");
+    babelwires::ShortId fieldIdA0("fldA0");
     fieldIdA0.setDiscriminator(1);
     babelwires::IntFeature* fieldA0 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA0);
 
-    babelwires::Identifier ff0("ff0");
+    babelwires::ShortId ff0("ff0");
     ff0.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature0 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff0);
 
-    babelwires::Identifier fieldIdC0("fldC0");
+    babelwires::ShortId fieldIdC0("fldC0");
     fieldIdC0.setDiscriminator(1);
     babelwires::IntFeature* fieldC0 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC0);
 
-    babelwires::Identifier fieldIdA1("fldA1");
+    babelwires::ShortId fieldIdA1("fldA1");
     fieldIdA1.setDiscriminator(1);
     babelwires::IntFeature* fieldA1 =
         unionFeature.addFieldInBranch(tagA, std::make_unique<babelwires::IntFeature>(), fieldIdA1);
 
-    babelwires::Identifier ff1("ff1");
+    babelwires::ShortId ff1("ff1");
     ff1.setDiscriminator(1);
     babelwires::IntFeature* fixedFeature1 = unionFeature.addField(std::make_unique<babelwires::IntFeature>(), ff1);
 
-    babelwires::Identifier fieldIdC1("fldC1");
+    babelwires::ShortId fieldIdC1("fldC1");
     fieldIdC1.setDiscriminator(1);
     babelwires::IntFeature* fieldC1 =
         unionFeature.addFieldInBranch(tagC, std::make_unique<babelwires::IntFeature>(), fieldIdC1);
@@ -497,8 +497,8 @@ TEST(UnionFeatureTest, unselectedEnumCanBeDefaulted) {
     babelwires::RootFeature rootFeature(testEnvironment.m_projectContext);
 
     // Confirm that features in branches are in a fully defaulted state when a branch is selected.
-    babelwires::Identifier tagA = testUtils::getTestRegisteredIdentifier("tagA");
-    babelwires::Identifier tagB = testUtils::getTestRegisteredIdentifier("tagB");
+    babelwires::ShortId tagA = testUtils::getTestRegisteredIdentifier("tagA");
+    babelwires::ShortId tagB = testUtils::getTestRegisteredIdentifier("tagB");
 
     babelwires::UnionFeature* unionFeature = rootFeature.addField(std::make_unique<babelwires::UnionFeature>(babelwires::UnionFeature::TagValues{tagA, tagB}, 0), testUtils::getTestRegisteredIdentifier("union"));
 

--- a/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
+++ b/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
@@ -61,7 +61,7 @@ TEST(AddBlankToEnum, idempotency) {
 
     babelwires::TypeSystem typeSystem;
     const testUtils::TestEnum* const testEnum = typeSystem.addEntry<testUtils::TestEnum>();
-    typeSystem.addTypeConstructor<1, babelwires::AddBlankToEnum>();
+    typeSystem.addTypeConstructor<babelwires::AddBlankToEnum>();
 
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
@@ -89,7 +89,7 @@ TEST(AddBlankToEnum, compareSubtype) {
     testUtils::TestLog log;
     babelwires::TypeSystem typeSystem;
     testUtils::addTestEnumTypes(typeSystem);
-    typeSystem.addTypeConstructor<1, babelwires::AddBlankToEnum>();
+    typeSystem.addTypeConstructor<babelwires::AddBlankToEnum>();
 
     babelwires::TypeRef addBlankToEnumToSubEnum(babelwires::AddBlankToEnum::getThisIdentifier(),
                                           testUtils::TestSubEnum::getThisIdentifier());

--- a/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
+++ b/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
@@ -40,10 +40,10 @@ TEST(AddBlankToEnum, constructType) {
 
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
-        addBlankToEnum.getOrConstructType(typeSystem, {{testUtils::TestEnum::getThisIdentifier()}});
+        addBlankToEnum.getOrConstructType(typeSystem, babelwires::TypeConstructorArguments<1>{testUtils::TestEnum::getThisIdentifier()});
     ASSERT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(), babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                         {{testUtils::TestEnum::getThisIdentifier()}}));
+                                                         testUtils::TestEnum::getThisIdentifier()));
 
     const babelwires::Enum* const newEnum = newType->as<babelwires::Enum>();
     ASSERT_NE(newEnum, nullptr);
@@ -65,14 +65,14 @@ TEST(AddBlankToEnum, idempotency) {
 
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
-        addBlankToEnum.getOrConstructType(typeSystem, {{babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                                      {{testUtils::TestEnum::getThisIdentifier()}})}});
+        addBlankToEnum.getOrConstructType(typeSystem, babelwires::TypeConstructorArguments<1>{babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
+                                                                      testUtils::TestEnum::getThisIdentifier())});
 
     ASSERT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(),
               babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                  {{babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                        {{testUtils::TestEnum::getThisIdentifier()}})}}));
+                                  babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
+                                                        testUtils::TestEnum::getThisIdentifier())));
 
     const babelwires::Enum* const newEnum = newType->as<babelwires::Enum>();
     ASSERT_NE(newEnum, nullptr);
@@ -92,13 +92,13 @@ TEST(AddBlankToEnum, compareSubtype) {
     typeSystem.addTypeConstructor<1, babelwires::AddBlankToEnum>();
 
     babelwires::TypeRef addBlankToEnumToSubEnum(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                          {{testUtils::TestSubEnum::getThisIdentifier()}});
+                                          testUtils::TestSubEnum::getThisIdentifier());
 
     babelwires::TypeRef addBlankToEnumToSubSubEnum1(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                              {{testUtils::TestSubSubEnum1::getThisIdentifier()}});
+                                              testUtils::TestSubSubEnum1::getThisIdentifier());
 
     babelwires::TypeRef addBlankToEnumToSubSubEnum2(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                              {{testUtils::TestSubSubEnum2::getThisIdentifier()}});
+                                              testUtils::TestSubSubEnum2::getThisIdentifier());
 
     EXPECT_EQ(typeSystem.compareSubtype(addBlankToEnumToSubEnum, addBlankToEnumToSubEnum), babelwires::SubtypeOrder::IsEquivalent);
     EXPECT_EQ(typeSystem.compareSubtype(addBlankToEnumToSubEnum, addBlankToEnumToSubSubEnum1),

--- a/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
+++ b/Tests/BabelWiresLibBuiltIns/addBlankToEnumTest.cpp
@@ -61,7 +61,7 @@ TEST(AddBlankToEnum, idempotency) {
 
     babelwires::TypeSystem typeSystem;
     const testUtils::TestEnum* const testEnum = typeSystem.addEntry<testUtils::TestEnum>();
-    typeSystem.addTypeConstructor<babelwires::AddBlankToEnum>();
+    typeSystem.addTypeConstructor<1, babelwires::AddBlankToEnum>();
 
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
@@ -89,7 +89,7 @@ TEST(AddBlankToEnum, compareSubtype) {
     testUtils::TestLog log;
     babelwires::TypeSystem typeSystem;
     testUtils::addTestEnumTypes(typeSystem);
-    typeSystem.addTypeConstructor<babelwires::AddBlankToEnum>();
+    typeSystem.addTypeConstructor<1, babelwires::AddBlankToEnum>();
 
     babelwires::TypeRef addBlankToEnumToSubEnum(babelwires::AddBlankToEnum::getThisIdentifier(),
                                           {{testUtils::TestSubEnum::getThisIdentifier()}});

--- a/Tests/BabelWiresLibBuiltIns/babelWiresBuiltInsTests.cpp
+++ b/Tests/BabelWiresLibBuiltIns/babelWiresBuiltInsTests.cpp
@@ -13,7 +13,7 @@
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     
-    // Since these tests load "real" types which use the REGISTERED_ID macros, they have to work within the same registry singleton.
+    // Since these tests load "real" types which use the BW_SHORT_ID macros, they have to work within the same registry singleton.
     babelwires::IdentifierRegistryScope identifierRegistry;
 
     return RUN_ALL_TESTS();

--- a/Tests/Common/identifierTest.cpp
+++ b/Tests/Common/identifierTest.cpp
@@ -391,7 +391,7 @@ TEST(IdentifierTest, implicitIdentifierRegistration) {
     int discriminator = 0;
     for (int i = 0; i < 3; ++i) {
         // Repeating this line of code should be a NOOP.
-        babelwires::ShortId hello = REGISTERED_ID("hello", "Hello world", "00000000-1111-2222-3333-000000000001");
+        babelwires::ShortId hello = BW_SHORT_ID("hello", "Hello world", "00000000-1111-2222-3333-000000000001");
         EXPECT_EQ(hello, "hello");
         EXPECT_NE(hello.getDiscriminator(), 0);
         if (discriminator != 0) {

--- a/Tests/Common/identifierTest.cpp
+++ b/Tests/Common/identifierTest.cpp
@@ -122,20 +122,20 @@ TEST(IdentifierTest, identifierDeserialization) {
 }
 
 TEST(IdentifierTest, longIdentifiers) {
-    babelwires::LongIdentifier hello("Hello");
+    babelwires::LongId hello("Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
     hello.setDiscriminator(17);
 
     std::string helloStr = "Hello";
-    babelwires::LongIdentifier hello1(helloStr);
+    babelwires::LongId hello1(helloStr);
     hello1.setDiscriminator(27);
 
     // Discriminators are not used to distinguish fields.
     EXPECT_EQ(hello, hello1);
-    std::hash<babelwires::LongIdentifier> fieldHasher;
+    std::hash<babelwires::LongId> fieldHasher;
     EXPECT_EQ(fieldHasher(hello), fieldHasher(hello1));
 
-    babelwires::LongIdentifier goodbye("AMuchLongerIndetifier");
+    babelwires::LongId goodbye("AMuchLongerIndetifier");
     goodbye.setDiscriminator(17);
     EXPECT_NE(hello, goodbye);
 
@@ -148,14 +148,14 @@ TEST(IdentifierTest, longIdentifiers) {
 }
 
 TEST(IdentifierTest, longIdentifierOrder) {
-    babelwires::LongIdentifier zero("A000");
-    babelwires::LongIdentifier ten("A10");
-    babelwires::LongIdentifier ant("ant");
-    babelwires::LongIdentifier antelope("antelopes");
-    babelwires::LongIdentifier Emu("Emu");
-    babelwires::LongIdentifier emu("emu");
-    babelwires::LongIdentifier Ibex("Ibex");
-    babelwires::LongIdentifier zebra("zebra");
+    babelwires::LongId zero("A000");
+    babelwires::LongId ten("A10");
+    babelwires::LongId ant("ant");
+    babelwires::LongId antelope("antelopes");
+    babelwires::LongId Emu("Emu");
+    babelwires::LongId emu("emu");
+    babelwires::LongId Ibex("Ibex");
+    babelwires::LongId zebra("zebra");
 
     EXPECT_LT(zero, ten);
     EXPECT_LT(ten, Emu);
@@ -165,10 +165,10 @@ TEST(IdentifierTest, longIdentifierOrder) {
     EXPECT_LT(antelope, emu);
     EXPECT_LT(emu, zebra);
 
-    babelwires::LongIdentifier hello0("aggggggggggggggggggggg");
-    babelwires::LongIdentifier hello1("ggggggggggaggggggggggg");
-    babelwires::LongIdentifier hello2("ggggggggggggggggggggga");
-    babelwires::LongIdentifier hello3("gggggggggggggggggggggg");
+    babelwires::LongId hello0("aggggggggggggggggggggg");
+    babelwires::LongId hello1("ggggggggggaggggggggggg");
+    babelwires::LongId hello2("ggggggggggggggggggggga");
+    babelwires::LongId hello3("gggggggggggggggggggggg");
 
     EXPECT_LT(hello0, hello1);
     EXPECT_LT(hello1, hello2);
@@ -176,7 +176,7 @@ TEST(IdentifierTest, longIdentifierOrder) {
 }
 
 TEST(IdentifierTest, longIdentifierStringOutput) {
-    babelwires::LongIdentifier hello("Hello_world");
+    babelwires::LongId hello("Hello_world");
     EXPECT_EQ(hello.toString(), "Hello_world");
     {
         std::ostringstream os;
@@ -192,7 +192,7 @@ TEST(IdentifierTest, longIdentifierStringOutput) {
 }
 
 TEST(IdentifierTest, longIdentifierSerialization) {
-    babelwires::LongIdentifier hello("Hello_world");
+    babelwires::LongId hello("Hello_world");
     EXPECT_EQ(hello.serializeToString(), "Hello_world");
 
     hello.setDiscriminator(81);
@@ -201,56 +201,56 @@ TEST(IdentifierTest, longIdentifierSerialization) {
 
 
 TEST(IdentifierTest, longIdentifierDeserialization) {
-    const babelwires::LongIdentifier hello = babelwires::LongIdentifier::deserializeFromString("Hello_world");
+    const babelwires::LongId hello = babelwires::LongId::deserializeFromString("Hello_world");
     EXPECT_EQ(hello, "Hello_world");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
-    const babelwires::LongIdentifier hello1 = babelwires::LongIdentifier::deserializeFromString("Hello_world'12");
+    const babelwires::LongId hello1 = babelwires::LongId::deserializeFromString("Hello_world'12");
     EXPECT_EQ(hello1, "Hello_world");
     EXPECT_EQ(hello1.getDiscriminator(), 12);
 
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("H"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("H'1"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("HE'11"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hel'111"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hell'111"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hello'111"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hell33"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("He_33_'10"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hello'255"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Helloo'65500"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("Hello_incredible_world'65500"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("_"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("_o_o_"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("___EE"));
-    EXPECT_NO_THROW(babelwires::LongIdentifier::deserializeFromString("_o_o_'3"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("H"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("H'1"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("HE'11"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hel'111"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hell'111"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hello'111"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hell33"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("He_33_'10"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hello'255"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Helloo'65500"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("Hello_incredible_world'65500"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("_"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("_o_o_"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("___EE"));
+    EXPECT_NO_THROW(babelwires::LongId::deserializeFromString("_o_o_'3"));
 
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString(""), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("02"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("12"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("'12"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("2Hello"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("Hællo"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("Hello_incredible_world_"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("Hello_incredible_world`111"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("Helloo'65535"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("Hell'100000"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::LongIdentifier::deserializeFromString("^-.-^'3"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString(""), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("02"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("12"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("'12"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("2Hello"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("Hællo"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("Hello_incredible_world_"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("Hello_incredible_world`111"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("Helloo'65535"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("Hell'100000"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::LongId::deserializeFromString("^-.-^'3"), babelwires::ParseException);
 }
 
 TEST(IdentifierTest, shortToLongIdentifiers) {
     const babelwires::ShortId hello = "Hello";
-    const babelwires::LongIdentifier hello1 = hello;
+    const babelwires::LongId hello1 = hello;
     EXPECT_EQ(hello, hello1);
 
     hello.setDiscriminator(12);
-    const babelwires::LongIdentifier hello2 = hello;
+    const babelwires::LongId hello2 = hello;
     EXPECT_EQ(hello, hello2);
     EXPECT_EQ(hello2.getDiscriminator(), 12);
 }
 
 TEST(IdentifierTest, longToShortIdentifiers) {
-    const babelwires::LongIdentifier hello = "Helloo";
+    const babelwires::LongId hello = "Helloo";
     const babelwires::ShortId hello1(hello);
     EXPECT_EQ(hello, hello1);
 
@@ -259,7 +259,7 @@ TEST(IdentifierTest, longToShortIdentifiers) {
     EXPECT_EQ(hello, hello2);
     EXPECT_EQ(hello2.getDiscriminator(), 12);
 
-    const babelwires::LongIdentifier longHello = "Hellooo";
+    const babelwires::LongId longHello = "Hellooo";
     EXPECT_THROW(babelwires::ShortId shortHello(longHello), babelwires::ParseException);
 }
 
@@ -445,21 +445,21 @@ TEST(IdentifierTest, longIdentifierInRegistry) {
 
     babelwires::IdentifierRegistry identifierRegistry;
 
-    babelwires::LongIdentifier hello("Hello_world");
+    babelwires::LongId hello("Hello_world");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
     babelwires::Uuid uuid("00000000-1111-2222-3333-000000000001");
 
-    const babelwires::LongIdentifier id = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::LongId id = identifierRegistry.addIdentifierWithMetadata(
         hello, "Hello World", uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id.getDiscriminator(), 0);
     EXPECT_EQ(identifierRegistry.getName(id), "Hello World");
 
-    babelwires::LongIdentifier hello2("Hello_world");
+    babelwires::LongId hello2("Hello_world");
     babelwires::Uuid uuid2("00000000-1111-2222-3333-000000000002");
 
-    const babelwires::LongIdentifier id2 = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::LongId id2 = identifierRegistry.addIdentifierWithMetadata(
         hello2, "Hello World 2", uuid2, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id2.getDiscriminator(), 0);

--- a/Tests/Common/identifierTest.cpp
+++ b/Tests/Common/identifierTest.cpp
@@ -10,20 +10,20 @@
 #include <Common/exceptions.hpp>
 
 TEST(IdentifierTest, identifiers) {
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
     hello.setDiscriminator(17);
 
     std::string helloStr = "Hello";
-    babelwires::Identifier hello1(helloStr);
+    babelwires::ShortId hello1(helloStr);
     hello1.setDiscriminator(27);
 
     // Discriminators are not used to distinguish fields.
     EXPECT_EQ(hello, hello1);
-    std::hash<babelwires::Identifier> fieldHasher;
+    std::hash<babelwires::ShortId> fieldHasher;
     EXPECT_EQ(fieldHasher(hello), fieldHasher(hello1));
 
-    babelwires::Identifier goodbye("Byebye");
+    babelwires::ShortId goodbye("Byebye");
     goodbye.setDiscriminator(17);
     EXPECT_NE(hello, goodbye);
 
@@ -42,14 +42,14 @@ TEST(IdentifierTest, identifiers) {
 
 // For sanity's sake, the identifiers are ordered alphabetically.
 TEST(IdentifierTest, identifierOrder) {
-    babelwires::Identifier zero("A000");
-    babelwires::Identifier ten("A10");
-    babelwires::Identifier ant("ant");
-    babelwires::Identifier antelope("antlpe");
-    babelwires::Identifier Emu("Emu");
-    babelwires::Identifier emu("emu");
-    babelwires::Identifier Ibex("Ibex");
-    babelwires::Identifier zebra("zebra");
+    babelwires::ShortId zero("A000");
+    babelwires::ShortId ten("A10");
+    babelwires::ShortId ant("ant");
+    babelwires::ShortId antelope("antlpe");
+    babelwires::ShortId Emu("Emu");
+    babelwires::ShortId emu("emu");
+    babelwires::ShortId Ibex("Ibex");
+    babelwires::ShortId zebra("zebra");
 
     EXPECT_LT(zero, ten);
     EXPECT_LT(ten, Emu);
@@ -61,7 +61,7 @@ TEST(IdentifierTest, identifierOrder) {
 }
 
 TEST(IdentifierTest, identifierStringOutput) {
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.toString(), "Hello");
     {
         std::ostringstream os;
@@ -77,7 +77,7 @@ TEST(IdentifierTest, identifierStringOutput) {
 }
 
 TEST(IdentifierTest, identifierSerialization) {
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.serializeToString(), "Hello");
 
     hello.setDiscriminator(81);
@@ -85,40 +85,40 @@ TEST(IdentifierTest, identifierSerialization) {
 }
 
 TEST(IdentifierTest, identifierDeserialization) {
-    const babelwires::Identifier hello = babelwires::Identifier::deserializeFromString("Hello");
+    const babelwires::ShortId hello = babelwires::ShortId::deserializeFromString("Hello");
     EXPECT_EQ(hello, "Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
-    const babelwires::Identifier hello1 = babelwires::Identifier::deserializeFromString("Hello'12");
+    const babelwires::ShortId hello1 = babelwires::ShortId::deserializeFromString("Hello'12");
     EXPECT_EQ(hello1, "Hello");
     EXPECT_EQ(hello1.getDiscriminator(), 12);
 
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("H"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("H'1"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("HE'11"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Hel'111"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Hell'111"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Hello'111"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Hell33"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("He_33_'10"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Hello'255"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("Helloo'65500"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("_"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("_o_o_"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("___EE"));
-    EXPECT_NO_THROW(babelwires::Identifier::deserializeFromString("_o_o_'3"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("H"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("H'1"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("HE'11"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Hel'111"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Hell'111"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Hello'111"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Hell33"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("He_33_'10"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Hello'255"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("Helloo'65500"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("_"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("_o_o_"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("___EE"));
+    EXPECT_NO_THROW(babelwires::ShortId::deserializeFromString("_o_o_'3"));
 
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString(""), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("02"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("12"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("'12"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("2Hello"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("Hællo"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("Hello`111"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("Helloooo"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("Helloo'65535"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("Hell'100000"), babelwires::ParseException);
-    EXPECT_THROW(babelwires::Identifier::deserializeFromString("^-.-^'3"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString(""), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("02"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("12"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("'12"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("2Hello"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("Hællo"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("Hello`111"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("Helloooo"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("Helloo'65535"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("Hell'100000"), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId::deserializeFromString("^-.-^'3"), babelwires::ParseException);
 }
 
 TEST(IdentifierTest, longIdentifiers) {
@@ -239,7 +239,7 @@ TEST(IdentifierTest, longIdentifierDeserialization) {
 }
 
 TEST(IdentifierTest, shortToLongIdentifiers) {
-    const babelwires::Identifier hello = "Hello";
+    const babelwires::ShortId hello = "Hello";
     const babelwires::LongIdentifier hello1 = hello;
     EXPECT_EQ(hello, hello1);
 
@@ -251,16 +251,16 @@ TEST(IdentifierTest, shortToLongIdentifiers) {
 
 TEST(IdentifierTest, longToShortIdentifiers) {
     const babelwires::LongIdentifier hello = "Helloo";
-    const babelwires::Identifier hello1(hello);
+    const babelwires::ShortId hello1(hello);
     EXPECT_EQ(hello, hello1);
 
     hello.setDiscriminator(12);
-    const babelwires::Identifier hello2(hello);
+    const babelwires::ShortId hello2(hello);
     EXPECT_EQ(hello, hello2);
     EXPECT_EQ(hello2.getDiscriminator(), 12);
 
     const babelwires::LongIdentifier longHello = "Hellooo";
-    EXPECT_THROW(babelwires::Identifier shortHello(longHello), babelwires::ParseException);
+    EXPECT_THROW(babelwires::ShortId shortHello(longHello), babelwires::ParseException);
 }
 
 TEST(IdentifierTest, identifierRegistrySameNames) {
@@ -268,21 +268,21 @@ TEST(IdentifierTest, identifierRegistrySameNames) {
 
     babelwires::IdentifierRegistry identifierRegistry;
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
     babelwires::Uuid uuid("00000000-1111-2222-3333-000000000001");
 
-    const babelwires::Identifier id = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id = identifierRegistry.addIdentifierWithMetadata(
         hello, "Hello World", uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id.getDiscriminator(), 0);
     EXPECT_EQ(identifierRegistry.getName(id), "Hello World");
 
-    babelwires::Identifier hello2("Hello");
+    babelwires::ShortId hello2("Hello");
     babelwires::Uuid uuid2("00000000-1111-2222-3333-000000000002");
 
-    const babelwires::Identifier id2 = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id2 = identifierRegistry.addIdentifierWithMetadata(
         hello2, "Hello World 2", uuid2, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id2.getDiscriminator(), 0);
@@ -295,21 +295,21 @@ TEST(IdentifierTest, identifierRegistryAuthoritativeFirst) {
 
     babelwires::IdentifierRegistry identifierRegistry;
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
     babelwires::Uuid uuid("00000000-1111-2222-3333-000000000001");
 
-    const babelwires::Identifier id = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id = identifierRegistry.addIdentifierWithMetadata(
         hello, "Hello World", uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id.getDiscriminator(), 0);
     EXPECT_EQ(identifierRegistry.getName(id), "Hello World");
 
     // A provisional name updates to match an authoritative one.
-    babelwires::Identifier hello1("Hello");
+    babelwires::ShortId hello1("Hello");
     EXPECT_EQ(hello, hello1);
-    const babelwires::Identifier id1 = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id1 = identifierRegistry.addIdentifierWithMetadata(
         hello1, "Hello World 1", uuid, babelwires::IdentifierRegistry::Authority::isProvisional);
     EXPECT_EQ(id1, hello1);
     EXPECT_EQ(id1.getDiscriminator(), id.getDiscriminator());
@@ -321,21 +321,21 @@ TEST(IdentifierTest, identifierRegistryProvisionalFirst) {
 
     babelwires::IdentifierRegistry identifierRegistry;
 
-    babelwires::Identifier hello("Hello");
+    babelwires::ShortId hello("Hello");
     EXPECT_EQ(hello.getDiscriminator(), 0);
 
     babelwires::Uuid uuid("00000000-1111-2222-3333-000000000001");
 
-    const babelwires::Identifier id = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id = identifierRegistry.addIdentifierWithMetadata(
         hello, "Hello World", uuid, babelwires::IdentifierRegistry::Authority::isProvisional);
     EXPECT_EQ(hello, id);
     EXPECT_NE(id.getDiscriminator(), 0);
     EXPECT_EQ(identifierRegistry.getName(id), "Hello World");
 
     // A provisional name updates to match an authorative one.
-    babelwires::Identifier hello1("Hello");
+    babelwires::ShortId hello1("Hello");
     EXPECT_EQ(hello, hello1);
-    const babelwires::Identifier id1 = identifierRegistry.addIdentifierWithMetadata(
+    const babelwires::ShortId id1 = identifierRegistry.addIdentifierWithMetadata(
         hello1, "Hello World 2", uuid, babelwires::IdentifierRegistry::Authority::isAuthoritative);
     EXPECT_EQ(id1, hello1);
     EXPECT_EQ(id1.getDiscriminator(), id.getDiscriminator());
@@ -348,8 +348,8 @@ TEST(IdentifierTest, identifierRegistrySerializationDeserialization) {
     testUtils::TestLog log;
     std::string serializedContents;
 
-    babelwires::Identifier id0("hello");
-    babelwires::Identifier id1("byebye");
+    babelwires::ShortId id0("hello");
+    babelwires::ShortId id1("byebye");
     const std::string name0 = "Name 0";
     const std::string name1 = "Name 1";
     {
@@ -391,7 +391,7 @@ TEST(IdentifierTest, implicitIdentifierRegistration) {
     int discriminator = 0;
     for (int i = 0; i < 3; ++i) {
         // Repeating this line of code should be a NOOP.
-        babelwires::Identifier hello = REGISTERED_ID("hello", "Hello world", "00000000-1111-2222-3333-000000000001");
+        babelwires::ShortId hello = REGISTERED_ID("hello", "Hello world", "00000000-1111-2222-3333-000000000001");
         EXPECT_EQ(hello, "hello");
         EXPECT_NE(hello.getDiscriminator(), 0);
         if (discriminator != 0) {
@@ -420,7 +420,7 @@ TEST(IdentifierTest, implicitIdentifierRegistrationVector) {
         babelwires::RegisteredIdentifiers ids = REGISTERED_ID_VECTOR(source);
         EXPECT_EQ(ids.size(), 2);
 
-        babelwires::Identifier hello = ids[0];
+        babelwires::ShortId hello = ids[0];
         EXPECT_EQ(hello, "hello");
         EXPECT_NE(hello.getDiscriminator(), 0);
         if (hello_discriminator != 0) {
@@ -429,7 +429,7 @@ TEST(IdentifierTest, implicitIdentifierRegistrationVector) {
         hello_discriminator = hello.getDiscriminator();
         EXPECT_EQ(babelwires::IdentifierRegistry::read()->getName(hello), "Hello world");
 
-        babelwires::Identifier goodbye = ids[1];
+        babelwires::ShortId goodbye = ids[1];
         EXPECT_EQ(goodbye, "byebye");
         EXPECT_NE(goodbye.getDiscriminator(), 0);
         if (goodbye_discriminator != 0) {

--- a/Tests/Common/registryTest.cpp
+++ b/Tests/Common/registryTest.cpp
@@ -39,7 +39,7 @@ TEST(RegistryTest, base) {
 
     EXPECT_EQ(registry.getEntryByIdentifier("test"), nullptr);
 
-    const babelwires::LongId entryId = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "test", "Test", "00000000-1111-2222-3333-444444444444",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -60,7 +60,7 @@ TEST(RegistryTest, base) {
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2"), nullptr);
     EXPECT_EQ(registry.getEntryByFileName("foo.test2"), nullptr);
 
-    const babelwires::LongId entryId2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId2 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "test2", "Test2", "00000000-1111-2222-3333-555555555555",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -82,7 +82,7 @@ TEST(RegistryTest, base) {
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2")->getName(), "Test2");
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2")->m_payload, -144);
 
-    const babelwires::LongId entryId3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId3 = babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
         "test3", "Test3", "00000000-1111-2222-3333-666666666666",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 

--- a/Tests/Common/registryTest.cpp
+++ b/Tests/Common/registryTest.cpp
@@ -9,7 +9,7 @@
 namespace {
     struct TestRegistryEntry : public babelwires::FileTypeEntry {
       public:
-        TestRegistryEntry(babelwires::LongIdentifier identifier, babelwires::VersionNumber version,
+        TestRegistryEntry(babelwires::LongId identifier, babelwires::VersionNumber version,
                           Extensions extensions, int payload)
             : FileTypeEntry(identifier, version, std::move(extensions))
             , m_payload(payload) {}
@@ -39,7 +39,7 @@ TEST(RegistryTest, base) {
 
     EXPECT_EQ(registry.getEntryByIdentifier("test"), nullptr);
 
-    const babelwires::LongIdentifier entryId = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "test", "Test", "00000000-1111-2222-3333-444444444444",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -60,7 +60,7 @@ TEST(RegistryTest, base) {
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2"), nullptr);
     EXPECT_EQ(registry.getEntryByFileName("foo.test2"), nullptr);
 
-    const babelwires::LongIdentifier entryId2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId2 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "test2", "Test2", "00000000-1111-2222-3333-555555555555",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -82,7 +82,7 @@ TEST(RegistryTest, base) {
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2")->getName(), "Test2");
     EXPECT_EQ(registry.getEntryByFileName("oom.test.test2")->m_payload, -144);
 
-    const babelwires::LongIdentifier entryId3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
+    const babelwires::LongId entryId3 = babelwires::IdentifierRegistry::write()->addLongIdentifierWithMetadata(
         "test3", "Test3", "00000000-1111-2222-3333-666666666666",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 

--- a/Tests/TestUtils/testIdentifiers.cpp
+++ b/Tests/TestUtils/testIdentifiers.cpp
@@ -6,6 +6,12 @@ babelwires::ShortId testUtils::getTestRegisteredIdentifier(std::string_view name
     return id;
 }
 
+babelwires::MediumId testUtils::getTestRegisteredMediumIdentifier(std::string_view name, unsigned int discriminator) {
+    babelwires::MediumId id = name;
+    id.setDiscriminator(discriminator);
+    return id;
+}
+
 babelwires::LongId testUtils::getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator) {
     babelwires::LongId id = name;
     id.setDiscriminator(discriminator);

--- a/Tests/TestUtils/testIdentifiers.cpp
+++ b/Tests/TestUtils/testIdentifiers.cpp
@@ -1,7 +1,7 @@
 #include <Tests/TestUtils/testIdentifiers.hpp>
 
-babelwires::Identifier testUtils::getTestRegisteredIdentifier(std::string_view name, unsigned int discriminator) {
-    babelwires::Identifier id = name;
+babelwires::ShortId testUtils::getTestRegisteredIdentifier(std::string_view name, unsigned int discriminator) {
+    babelwires::ShortId id = name;
     id.setDiscriminator(discriminator);
     return id;
 }

--- a/Tests/TestUtils/testIdentifiers.cpp
+++ b/Tests/TestUtils/testIdentifiers.cpp
@@ -6,8 +6,8 @@ babelwires::ShortId testUtils::getTestRegisteredIdentifier(std::string_view name
     return id;
 }
 
-babelwires::LongIdentifier testUtils::getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator) {
-    babelwires::LongIdentifier id = name;
+babelwires::LongId testUtils::getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator) {
+    babelwires::LongId id = name;
     id.setDiscriminator(discriminator);
     return id;
 }

--- a/Tests/TestUtils/testIdentifiers.hpp
+++ b/Tests/TestUtils/testIdentifiers.hpp
@@ -6,7 +6,7 @@
 namespace testUtils {
     /// Get an identifier with the given discriminator.
     /// Convenience function for tests which don't require the id to be actually registered.
-    babelwires::Identifier getTestRegisteredIdentifier(std::string_view name, unsigned int discriminator = 1);
+    babelwires::ShortId getTestRegisteredIdentifier(std::string_view name, unsigned int discriminator = 1);
 
     /// Get a long identifier with the given discriminator.
     /// Convenience function for tests which don't require the id to be actually registered.

--- a/Tests/TestUtils/testIdentifiers.hpp
+++ b/Tests/TestUtils/testIdentifiers.hpp
@@ -10,5 +10,5 @@ namespace testUtils {
 
     /// Get a long identifier with the given discriminator.
     /// Convenience function for tests which don't require the id to be actually registered.
-    babelwires::LongIdentifier getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator = 1);
+    babelwires::LongId getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator = 1);
 }

--- a/Tests/TestUtils/testIdentifiers.hpp
+++ b/Tests/TestUtils/testIdentifiers.hpp
@@ -8,6 +8,10 @@ namespace testUtils {
     /// Convenience function for tests which don't require the id to be actually registered.
     babelwires::ShortId getTestRegisteredIdentifier(std::string_view name, unsigned int discriminator = 1);
 
+    /// Get an identifier with the given discriminator.
+    /// Convenience function for tests which don't require the id to be actually registered.
+    babelwires::MediumId getTestRegisteredMediumIdentifier(std::string_view name, unsigned int discriminator = 1);
+
     /// Get a long identifier with the given discriminator.
     /// Convenience function for tests which don't require the id to be actually registered.
     babelwires::LongId getTestRegisteredLongIdentifier(std::string_view name, unsigned int discriminator = 1);


### PR DESCRIPTION
Two changes: 
1. Identifiers in the type system are now Medium length (two words)
2. Replace vector-based storage in TypeRef by variant branches holding strictly-sized arrays of arguments.

The new storage implementation means:
1. TypeRef is smaller and tidier.
2. Very basic testing suggests a noticeably performance improvement.
3. The caches carried by TypeConstructors no longer have vector keys (which was making me sad)

A mild disadvantage is that a TypeRef cannot no longer describe a constructed type with more than 2 arguments. I've no use case for that, but it's nice to be able to represent data that could in theory be valid even if it currently isn't. This now gives a parse error, where previously it would just have some data which represents a unresolving typeref. I considered and discounted having fallback cases for this.