### PR TITLE
Provide cloneShared, where the new object is managed by a shared_ptr.

### DIFF
--- a/BabelWiresLib/TypeSystem/type.hpp
+++ b/BabelWiresLib/TypeSystem/type.hpp
@@ -12,8 +12,6 @@
 
 #include <Common/Identifiers/identifier.hpp>
 
-#include <optional>
-
 namespace babelwires {
 
     /// A type describes a valid set of values.

--- a/BabelWiresLib/TypeSystem/valueHolder_inl.hpp
+++ b/BabelWiresLib/TypeSystem/valueHolder_inl.hpp
@@ -16,12 +16,12 @@ babelwires::ValueHolderTemplate<VALUE>::ValueHolderTemplate(ValueHolderTemplate&
 
 template <typename VALUE>
 babelwires::ValueHolderTemplate<VALUE>::ValueHolderTemplate(const VALUE& value)
-    : m_pointerToValue(value.clone().release()) {}
+    : m_pointerToValue(value.cloneShared()) {}
 
 template <typename VALUE>
 babelwires::ValueHolderTemplate<VALUE>::ValueHolderTemplate(VALUE&& value)
     // R-value cloning uses the move contructor.
-    : m_pointerToValue(std::move(value).clone().release()) {}
+    : m_pointerToValue(std::move(value).cloneShared()) {}
 
 template <typename VALUE>
 babelwires::ValueHolderTemplate<VALUE>::ValueHolderTemplate(std::unique_ptr<VALUE> ptr)
@@ -46,14 +46,14 @@ babelwires::ValueHolderTemplate<VALUE>& babelwires::ValueHolderTemplate<VALUE>::
 
 template <typename VALUE>
 babelwires::ValueHolderTemplate<VALUE>& babelwires::ValueHolderTemplate<VALUE>::operator=(const VALUE& value) {
-    m_pointerToValue = std::shared_ptr<const Value>(value.clone().release());
+    m_pointerToValue = value.cloneShared();
     return *this;
 }
 
 template <typename VALUE>
 babelwires::ValueHolderTemplate<VALUE>& babelwires::ValueHolderTemplate<VALUE>::operator=(VALUE&& value) {
     // R-value cloning uses the move contructor.
-    m_pointerToValue = std::shared_ptr<const VALUE>(std::move(value).clone().release());
+    m_pointerToValue = std::move(value).cloneShared();
     return *this;
 }
 
@@ -83,9 +83,9 @@ template <typename VALUE> const VALUE* babelwires::ValueHolderTemplate<VALUE>::o
 }
 
 template <typename VALUE> VALUE& babelwires::ValueHolderTemplate<VALUE>::copyContentsAndGetNonConst() {
-    std::unique_ptr<VALUE> clone = m_pointerToValue->clone();
+    std::shared_ptr<VALUE> clone = m_pointerToValue->cloneShared();
     VALUE* ptrToClone = clone.get();
-    m_pointerToValue = std::shared_ptr<const VALUE>(clone.release());
+    m_pointerToValue = clone;
     return *ptrToClone;
 }
 

--- a/Common/Cloning/cloneable.hpp
+++ b/Common/Cloning/cloneable.hpp
@@ -14,25 +14,45 @@ namespace babelwires {
 
     /// Use this at the base of a hierarchy of cloneable classes.
     /// Note: The expected semantics of copy contructors of any class deriving from Cloneable
-    /// is that it should deep-clone its members.
+    /// is that it should deep-clone its non-const members.
     struct Cloneable {
         virtual ~Cloneable();
         virtual Cloneable* cloneImpl() const& = 0;
         virtual Cloneable* cloneImpl() && = 0;
+        virtual std::shared_ptr<Cloneable> cloneSharedImpl() const& = 0;
+        virtual std::shared_ptr<Cloneable> cloneSharedImpl() && = 0;
     };
 
 /// Use this macros in abstract classes which derive from Cloneable.
 #define CLONEABLE_ABSTRACT(CLASS)                                                                                      \
-    std::unique_ptr<CLASS> clone() const& { return std::unique_ptr<CLASS>(static_cast<CLASS*>(cloneImpl())); }         \
+    std::unique_ptr<CLASS> clone() const& {                                                                            \
+        return std::unique_ptr<CLASS>(static_cast<CLASS*>(cloneImpl()));                                               \
+    }                                                                                                                  \
     std::unique_ptr<CLASS> clone()&& {                                                                                 \
         return std::unique_ptr<CLASS>(static_cast<CLASS*>(std::move(*this).cloneImpl()));                              \
+    }                                                                                                                  \
+    std::shared_ptr<CLASS> cloneShared() const& {                                                                      \
+        return std::static_pointer_cast<CLASS>(cloneSharedImpl());                                                     \
+    }                                                                                                                  \
+    std::shared_ptr<CLASS> cloneShared()&& {                                                                           \
+        return std::static_pointer_cast<CLASS>(std::move(*this).cloneSharedImpl());                                    \
     }
 
 /// Use this macros in classes which derive from Cloneable.
 #define CLONEABLE(CLASS)                                                                                               \
     CLONEABLE_ABSTRACT(CLASS)                                                                                          \
-    Cloneable* cloneImpl() const& override { return new CLASS(*this); }                                                \
-    Cloneable* cloneImpl() && override { return new CLASS(std::move(*this)); }
+    Cloneable* cloneImpl() const& override {                                                                           \
+        return new CLASS(*this);                                                                                       \
+    }                                                                                                                  \
+    Cloneable* cloneImpl() && override {                                                                               \
+        return new CLASS(std::move(*this));                                                                            \
+    }                                                                                                                  \
+    std::shared_ptr<Cloneable> cloneSharedImpl() const& override {                                                       \
+        return std::make_shared<CLASS>(*this);                                                                         \
+    }                                                                                                                  \
+    std::shared_ptr<Cloneable> cloneSharedImpl()&& override {                                                            \
+        return std::make_shared<CLASS>(std::move(*this));                                                              \
+    }
 
     /// Use this at the base of a hierarchy of cloneable classes to support non-default clone behaviour.
     /// Note: Classes T deriving from CustomCloneable must have a constructor taking a T and a Context.
@@ -65,5 +85,7 @@ namespace babelwires {
         CustomCloneContext c;                                                                                          \
         return customClone(c);                                                                                         \
     }                                                                                                                  \
-    virtual CLASS* customCloneImpl(CustomCloneContext& c) const override { return new CLASS(*this, c); }
+    virtual CLASS* customCloneImpl(CustomCloneContext& c) const override {                                             \
+        return new CLASS(*this, c);                                                                                    \
+    }
 } // namespace babelwires


### PR DESCRIPTION
ValueHolder manages values using shared_ptr.

While you can release the result of clone into a shared pointer, the management block is necessarily separate. By providing a shared_ptr specific clone, the implementation can use make_shared.