### PR TITLE
RecordTypeConstructor - construct record types at runtime

### DIFF
--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -58,6 +58,7 @@ SET( BABELWIRESLIB_SRCS
 	Types/Map/mapTypeConstructor.cpp
 	Types/Map/standardMapIdentifiers.cpp
 	Types/Map/SumOfMaps/sumOfMapsType.cpp
+	Types/Record/fieldIdValue.cpp
 	Types/Record/recordType.cpp
 	Types/Record/recordValue.cpp
 	Types/Record/recordTypeConstructor.cpp

--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -60,6 +60,7 @@ SET( BABELWIRESLIB_SRCS
 	Types/Map/SumOfMaps/sumOfMapsType.cpp
 	Types/Record/recordType.cpp
 	Types/Record/recordValue.cpp
+	Types/Record/recordTypeConstructor.cpp
 	Types/RecordWithVariants/recordWithVariantsType.cpp
 	Types/RecordWithVariants/recordWithVariantsValue.cpp
 	Types/Tuple/tupleType.cpp

--- a/BabelWiresLib/TypeSystem/Detail/identifierValueBase.hpp
+++ b/BabelWiresLib/TypeSystem/Detail/identifierValueBase.hpp
@@ -1,0 +1,55 @@
+/**
+ * The typeNameFormatter allows complex type names to be provided for type constructors.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/TypeSystem/editableValue.hpp>
+#include <Common/Identifiers/identifierRegistry.hpp>
+#include <Common/Serialization/deserializer.hpp>
+#include <Common/Serialization/serializer.hpp>
+
+namespace babelwires {
+
+    template<typename IDENTIFIER>
+    class IdentifierValueBase : public EditableValue {
+      public:
+        CLONEABLE_ABSTRACT(IdentifierValueBase);
+        SERIALIZABLE_ABSTRACT(IdentifierValueBase, EditableValue);
+
+        IdentifierValueBase() = default;
+        IdentifierValueBase(IDENTIFIER value) : m_value(value) {}
+
+        /// Get the current value of the feature.
+        IDENTIFIER get() const { return m_value; }
+
+        /// Set the value in the feature.
+        void set(IDENTIFIER value) {
+            m_value = value;
+        }
+
+        void serializeContents(Serializer& serializer) const override {
+            serializer.serializeValue("value", m_value);
+        }
+
+        void deserializeContents(Deserializer& deserializer) override {
+            deserializer.deserializeValue("value", m_value);
+        }
+
+        void visitIdentifiers(IdentifierVisitor& visitor) override { visitor(m_value); }
+        void visitFilePaths(FilePathVisitor& visitor) override {}
+        bool canContainIdentifiers() const override { return true; }
+        bool canContainFilePaths() const override { return false; }
+
+        std::string toString() const override {
+            return IdentifierRegistry::read()->getName(m_value);
+        }
+
+      private:
+        IDENTIFIER m_value;
+    };
+
+}

--- a/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
+++ b/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
@@ -1,5 +1,5 @@
 /**
- * A TypeRef describes a type.
+ * The typeNameFormatter allows complex type names to be provided for type constructors.
  *
  * (C) 2021 Malcolm Tyrrell
  *

--- a/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.hpp
+++ b/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.hpp
@@ -1,5 +1,5 @@
 /**
- * A TypeRef describes a type.
+ * The typeNameFormatter allows complex type names to be provided for type constructors.
  *
  * (C) 2021 Malcolm Tyrrell
  *
@@ -21,7 +21,7 @@ namespace babelwires {
     /// chars>}" describes how the types from n and up will be written with the <operator chars> between them. "}" and
     /// "]" used in operators by escaping them with a "\" character. So "({0|,})" can build type names like 
     /// "(Foo, Bar)". The (ridiculous) type constructor name "<{0}>+<[1|...]>+[0]" with type argument "Foo" and value
-    /// arguments "a", "b" and "c" will build the string "<Foo>+b...c+a".
+    /// arguments "a", "b" and "c" will build the string "<Foo>+<b...c>+a".
     std::string typeNameFormatter(std::string_view format, const std::vector<std::string>& typeArguments,
                                   const std::vector<std::string>& valueArguments);
 } // namespace babelwires

--- a/BabelWiresLib/Types/Enum/enumValue.cpp
+++ b/BabelWiresLib/Types/Enum/enumValue.cpp
@@ -7,57 +7,17 @@
  **/
 #include <BabelWiresLib/Types/Enum/enumValue.hpp>
 
-#include <BabelWiresLib/Types/Enum/enumType.hpp>
-
-#include <Common/Identifiers/identifierRegistry.hpp>
-#include <Common/Serialization/deserializer.hpp>
-#include <Common/Serialization/serializer.hpp>
-
 babelwires::EnumValue::EnumValue() = default;
 
 babelwires::EnumValue::EnumValue(ShortId value)
-    : m_value(value) {}
-
-babelwires::ShortId babelwires::EnumValue::get() const {
-    return m_value;
-}
-
-void babelwires::EnumValue::set(ShortId value) {
-    m_value = value;
-}
-
-void babelwires::EnumValue::serializeContents(Serializer& serializer) const {
-    serializer.serializeValue("value", m_value);
-}
-
-void babelwires::EnumValue::deserializeContents(Deserializer& deserializer) {
-    deserializer.deserializeValue("value", m_value);
-}
-
-void babelwires::EnumValue::visitIdentifiers(IdentifierVisitor& visitor) {
-    visitor(m_value);
-}
-
-void babelwires::EnumValue::visitFilePaths(FilePathVisitor& visitor) {}
-
-bool babelwires::EnumValue::canContainIdentifiers() const {
-    return true;
-}
-
-bool babelwires::EnumValue::canContainFilePaths() const {
-    return false;
-}
+    : IdentifierValueBase(value) {}
 
 std::size_t babelwires::EnumValue::getHash() const {
     // eeee - Arbitrary discriminator.
-    return hash::mixtureOf(0xeeee, m_value);
+    return hash::mixtureOf(0xeeee, get());
 }
 
 bool babelwires::EnumValue::operator==(const Value& other) const {
     const EnumValue* otherValue = other.as<EnumValue>();
-    return otherValue && (m_value == otherValue->m_value);
-}
-
-std::string babelwires::EnumValue::toString() const {
-    return IdentifierRegistry::read()->getName(m_value);
+    return otherValue && (get() == otherValue->get());
 }

--- a/BabelWiresLib/Types/Record/fieldIdValue.cpp
+++ b/BabelWiresLib/Types/Record/fieldIdValue.cpp
@@ -1,0 +1,23 @@
+/**
+ * Holds the identifier of a field name.
+ *
+ * (C) 2025 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresLib/Types/Record/fieldIdValue.hpp>
+
+babelwires::FieldIdValue::FieldIdValue() = default;
+
+babelwires::FieldIdValue::FieldIdValue(ShortId value)
+    : IdentifierValueBase(value) {}
+
+std::size_t babelwires::FieldIdValue::getHash() const {
+    // ffff - Arbitrary discriminator.
+    return hash::mixtureOf(0xffff, get());
+}
+
+bool babelwires::FieldIdValue::operator==(const Value& other) const {
+    const FieldIdValue* otherValue = other.as<FieldIdValue>();
+    return otherValue && (get() == otherValue->get());
+}

--- a/BabelWiresLib/Types/Record/fieldIdValue.hpp
+++ b/BabelWiresLib/Types/Record/fieldIdValue.hpp
@@ -1,7 +1,7 @@
 /**
- * Holds a single value of an enum.
+ * Holds the identifier of a field name.
  *
- * (C) 2021 Malcolm Tyrrell
+ * (C) 2025 Malcolm Tyrrell
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
@@ -11,13 +11,13 @@
 
 namespace babelwires {
 
-    class EnumValue : public IdentifierValueBase<ShortId> {
+    class FieldIdValue : public IdentifierValueBase<ShortId> {
       public:
-        CLONEABLE(EnumValue);
-        SERIALIZABLE(EnumValue, "enum", EditableValue, 1);
+        CLONEABLE(FieldIdValue);
+        SERIALIZABLE(FieldIdValue, "fieldId", EditableValue, 1);
 
-        EnumValue();
-        EnumValue(ShortId value);
+        FieldIdValue();
+        FieldIdValue(ShortId value);
 
         std::size_t getHash() const override;
         bool operator==(const Value& other) const override;

--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -15,6 +15,7 @@
 babelwires::RecordType::RecordType(std::vector<Field> fields)
     : m_fields(std::move(fields)) {
     for (const auto& f : m_fields) {
+        assert(f.m_identifier.getDiscriminator() != 0 && "Field identifiers must be registered");
         if (f.m_optionality != Optionality::alwaysActive) {
             m_optionalFieldIds.emplace_back(f.m_identifier);
         }

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
@@ -1,0 +1,32 @@
+/**
+ * 
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresLib/Types/Record/recordTypeConstructor.hpp>
+
+#include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
+#include <BabelWiresLib/Types/Record/recordType.hpp>
+
+
+std::unique_ptr<babelwires::Type>
+babelwires::RecordTypeConstructor::constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
+                                              const std::vector<EditableValueHolder>& valueArguments) const {
+    if (typeArguments.size() != valueArguments.size()) {
+        throw TypeSystemException() << "RecordTypeConstructor requires the same number of types and values, but got "
+                                    << typeArguments.size() << " and " << valueArguments.size() << " respectively";
+    }
+
+    std::vector<RecordType::Field> fields;
+    for (unsigned int i = 0; i < valueArguments.size(); ++i) {
+        if (const FieldIdValue* fieldId = valueArguments[i]->as<FieldIdValue>()) {
+            fields.emplace_back(RecordType::Field{fieldId->get(), typeArguments[i]->getTypeRef()});
+        } else {
+            throw TypeSystemException() << "RecordTypeConstructor value argument " << i << " was not a FieldIdValue";
+        }
+    }
+
+    return std::make_unique<ConstructedType<RecordType>>(std::move(newTypeRef), std::move(fields));
+}

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
@@ -1,19 +1,20 @@
 /**
- * 
+ * Construct a simple record from types and fieldIds.
  *
- * (C) 2021 Malcolm Tyrrell
+ * (C) 2025 Malcolm Tyrrell
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <BabelWiresLib/Types/Record/recordTypeConstructor.hpp>
 
 #include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
+#include <BabelWiresLib/Types/Record/fieldIdValue.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
-
 std::unique_ptr<babelwires::Type>
-babelwires::RecordTypeConstructor::constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
-                                              const std::vector<EditableValueHolder>& valueArguments) const {
+babelwires::RecordTypeConstructor::constructType(const TypeSystem& typeSystem, TypeRef newTypeRef,
+                                                 const std::vector<const Type*>& typeArguments,
+                                                 const std::vector<EditableValueHolder>& valueArguments) const {
     if (typeArguments.size() != valueArguments.size()) {
         throw TypeSystemException() << "RecordTypeConstructor requires the same number of types and values, but got "
                                     << typeArguments.size() << " and " << valueArguments.size() << " respectively";

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.cpp
@@ -8,7 +8,6 @@
 #include <BabelWiresLib/Types/Record/recordTypeConstructor.hpp>
 
 #include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
-#include <BabelWiresLib/Types/Record/fieldIdValue.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 std::unique_ptr<babelwires::Type>

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
@@ -8,17 +8,44 @@
 #pragma once
 
 #include <BabelWiresLib/TypeSystem/typeConstructor.hpp>
+#include <BabelWiresLib/Types/Record/fieldIdValue.hpp>
 
 namespace babelwires {
 
     /// Construct a simple record from types and fieldIds.
     class RecordTypeConstructor : public TypeConstructor {
       public:
-        // Example: Record{a, b, c : Int, Int, Int}
-        TYPE_CONSTRUCTOR("Record", "Record{{{0|, } : [0|, ]}}", "295459cc-9485-4526-86ac-e8f27e4e7667", 1);
+        // Example: Record{a, b, c : String, Integer, String}
+        TYPE_CONSTRUCTOR("Record", "Record{{[0|, ] : {0|, }}}", "295459cc-9485-4526-86ac-e8f27e4e7667", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef,
                                             const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;
+
+        /// Convenience method.
+        template<typename... ARGS>
+        static TypeRef makeTypeRef(ARGS&&... args) {
+          TypeConstructorArguments constructorArgs;
+          constructorArgs.m_valueArguments.reserve(sizeof...(args) / 2);
+          constructorArgs.m_typeArguments.reserve(sizeof...(args) / 2);
+          Detail::addToArrays(
+            constructorArgs.m_valueArguments, constructorArgs.m_typeArguments,
+            std::forward<ARGS>(args)...);
+          return TypeRef(getThisIdentifier(), std::move(constructorArgs));
+        }
+
+        struct Detail {
+            /// Construct a TypeRef for a record type with the given field names and types.
+            /// The field names are given as ShortIds, and the types as TypeRefs.
+            static void addToArrays(std::vector<EditableValueHolder>& fieldNames, std::vector<TypeRef>& fieldTypes) {}
+
+            template<typename... ARGS>
+            static void addToArrays(std::vector<EditableValueHolder>& fieldNames, std::vector<TypeRef>& fieldTypes, ShortId fieldA, TypeRef typeRefA,
+                                       ARGS&&... args) {
+                fieldNames.emplace_back(FieldIdValue(fieldA));
+                fieldTypes.emplace_back(typeRefA);
+                addToArrays(fieldNames, fieldTypes, std::forward<ARGS>(args)...);
+            };
+        };
     };
 } // namespace babelwires

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
@@ -1,7 +1,7 @@
 /**
- * 
+ * Construct a simple record from types and fieldIds.
  *
- * (C) 2021 Malcolm Tyrrell
+ * (C) 2025 Malcolm Tyrrell
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
@@ -9,18 +9,13 @@
 
 #include <BabelWiresLib/TypeSystem/typeConstructor.hpp>
 
-// TODO Temporarily using enum values to hold field IDs.
-#include <BabelWiresLib/Types/Enum/enumValue.hpp>
-
 namespace babelwires {
-
-    // TODO Temporarily using enum values to hold field IDs.
-    using FieldIdValue = EnumValue;
 
     /// Construct a simple record from types and fieldIds.
     class RecordTypeConstructor : public TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR("Record", "Record{{...}}", "295459cc-9485-4526-86ac-e8f27e4e7667", 1);
+        // Example: Record{a, b, c : Int, Int, Int}
+        TYPE_CONSTRUCTOR("Record", "Record{{{0|, } : [0|, ]}}", "295459cc-9485-4526-86ac-e8f27e4e7667", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef,
                                             const std::vector<const Type*>& typeArguments,

--- a/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Record/recordTypeConstructor.hpp
@@ -1,0 +1,29 @@
+/**
+ * 
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/TypeSystem/typeConstructor.hpp>
+
+// TODO Temporarily using enum values to hold field IDs.
+#include <BabelWiresLib/Types/Enum/enumValue.hpp>
+
+namespace babelwires {
+
+    // TODO Temporarily using enum values to hold field IDs.
+    using FieldIdValue = EnumValue;
+
+    /// Construct a simple record from types and fieldIds.
+    class RecordTypeConstructor : public TypeConstructor {
+      public:
+        TYPE_CONSTRUCTOR("Record", "Record{{...}}", "295459cc-9485-4526-86ac-e8f27e4e7667", 1);
+
+        std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef,
+                                            const std::vector<const Type*>& typeArguments,
+                                            const std::vector<EditableValueHolder>& valueArguments) const override;
+    };
+} // namespace babelwires

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -20,6 +20,7 @@
 #include <BabelWiresLib/Types/Map/mapTypeConstructor.hpp>
 #include <BabelWiresLib/Types/Rational/rationalType.hpp>
 #include <BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp>
+#include <BabelWiresLib/Types/Record/recordTypeConstructor.hpp>
 #include <BabelWiresLib/Types/String/stringType.hpp>
 #include <BabelWiresLib/Types/Sum/sumTypeConstructor.hpp>
 #include <BabelWiresLib/Types/Tuple/tupleTypeConstructor.hpp>

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -43,4 +43,5 @@ void babelwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addTypeConstructor<ArrayTypeConstructor>();
     context.m_typeSystem.addTypeConstructor<FileTypeConstructor>();
     context.m_typeSystem.addTypeConstructor<TupleTypeConstructor>();
+    context.m_typeSystem.addTypeConstructor<RecordTypeConstructor>();
 }

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -17,6 +17,7 @@
 #include <Tests/BabelWiresLib/TestUtils/testEnvironment.hpp>
 
 #include <Tests/TestUtils/equalSets.hpp>
+#include <Tests/TestUtils/testIdentifiers.hpp>
 
 TEST(RecordTypeTest, simpleRecordTypeValue) {
     testUtils::TestEnvironment testEnvironment;
@@ -554,11 +555,12 @@ TEST(RecordTypeTest, exceptions) {
 TEST(RecordTypeTest, constructorBasics) {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::TypeRef recordTypeRef(babelwires::RecordTypeConstructor::getThisIdentifier(),
+    babelwires::TypeRef recordTypeRef(
+        babelwires::RecordTypeConstructor::getThisIdentifier(),
         babelwires::TypeConstructorArguments{
-            { babelwires::DefaultIntType::getThisType(), babelwires::StringType::getThisType() },
-            { babelwires::FieldIdValue("int0"), babelwires::FieldIdValue("str0") }
-        });
+            {babelwires::DefaultIntType::getThisType(), babelwires::StringType::getThisType()},
+            {babelwires::FieldIdValue(testUtils::getTestRegisteredIdentifier("int0")),
+             babelwires::FieldIdValue(testUtils::getTestRegisteredIdentifier("str0"))}});
 
     const babelwires::Type& type = recordTypeRef.resolve(testEnvironment.m_typeSystem);
     ASSERT_TRUE(type.as<babelwires::RecordType>());
@@ -574,19 +576,17 @@ TEST(RecordTypeTest, constructorBadArgs) {
     testUtils::TestEnvironment testEnvironment;
 
     {
-        babelwires::TypeRef recordTypeRef(babelwires::RecordTypeConstructor::getThisIdentifier(),
-            babelwires::TypeConstructorArguments{
-                { babelwires::DefaultIntType::getThisType() },
-                { /* No value */ }
-            });
+        babelwires::TypeRef recordTypeRef(
+            babelwires::RecordTypeConstructor::getThisIdentifier(),
+            babelwires::TypeConstructorArguments{{babelwires::DefaultIntType::getThisType()}, {/* No value */}});
         EXPECT_THROW(recordTypeRef.resolve(testEnvironment.m_typeSystem), babelwires::TypeSystemException);
     }
     {
-        babelwires::TypeRef recordTypeRef(babelwires::RecordTypeConstructor::getThisIdentifier(),
+        babelwires::TypeRef recordTypeRef(
+            babelwires::RecordTypeConstructor::getThisIdentifier(),
             babelwires::TypeConstructorArguments{
-                { babelwires::DefaultIntType::getThisType(), babelwires::StringType::getThisType() },
-                { babelwires::FieldIdValue("int0"), babelwires::IntValue(42) }
-            });
+                {babelwires::DefaultIntType::getThisType(), babelwires::StringType::getThisType()},
+                {babelwires::FieldIdValue("int0"), babelwires::IntValue(42)}});
         EXPECT_THROW(recordTypeRef.resolve(testEnvironment.m_typeSystem), babelwires::TypeSystemException);
     }
 }
@@ -595,9 +595,8 @@ TEST(RecordTypeTest, constructorMakeRef) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::TypeRef recordTypeRef = babelwires::RecordTypeConstructor::makeTypeRef(
-        "int0", babelwires::DefaultIntType::getThisType(),
-        "str0", babelwires::StringType::getThisType()
-    );
+        testUtils::getTestRegisteredIdentifier("int0"), babelwires::DefaultIntType::getThisType(),
+        testUtils::getTestRegisteredIdentifier("str0"), babelwires::StringType::getThisType());
 
     const babelwires::Type& type = recordTypeRef.resolve(testEnvironment.m_typeSystem);
     ASSERT_TRUE(type.as<babelwires::RecordType>());
@@ -613,10 +612,8 @@ TEST(RecordTypeTest, constructorName) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::TypeRef recordTypeRef = babelwires::RecordTypeConstructor::makeTypeRef(
-        "a", babelwires::StringType::getThisType(),
-        "b", babelwires::DefaultIntType::getThisType(),
-        "c", babelwires::StringType::getThisType()
-    );
+        "a", babelwires::StringType::getThisType(), "b", babelwires::DefaultIntType::getThisType(), "c",
+        babelwires::StringType::getThisType());
 
     EXPECT_EQ(recordTypeRef.toString(), "Record{a, b, c : String, Integer, String}");
 }


### PR DESCRIPTION
Adds a type constructor so RecordTypes can be created in code.

Note: RecordTypes expect fieldIds to be registered, so this PR does not enable record types to be purely created at runtime. Truly dynamic records are definitely interesting, but the implications for data robustness would need to be considered. (As an example of a dynamic type: It might be possible to interpret a JSON schema as a BabelWires type, and then load/modify/save instances of that schema as types within BabelWires. In this particular case, it may even be possible to generate IDs (including UUIDs) for the identifiers if the schema is stable and has a unique "$id" field).