### PR TITLE
Edits at root

### DIFF
--- a/BabelWiresLib/Features/Path/pathStep.cpp
+++ b/BabelWiresLib/Features/Path/pathStep.cpp
@@ -16,24 +16,30 @@
 void babelwires::PathStep::writeToStream(std::ostream& os) const {
     if (const ShortId* f = asField()) {
         os << *f;
+    } else if (const ArrayIndex* index = asIndex()) {
+        os << *index;
     } else {
-        os << getIndex();
+        os << c_notAStepRepresentation;
     }
 }
 
 void babelwires::PathStep::writeToStreamReadable(std::ostream& os, const IdentifierRegistry& identifierRegistry) const {
     if (const ShortId* f = asField()) {
         os << identifierRegistry.getName(*f);
+    } else if (const ArrayIndex* index = asIndex()) {
+        os << "[" << *index << "]";
     } else {
-        os << "[" << getIndex() << "]";
+        os << c_notAStepRepresentation;
     }
 }
 
 std::string babelwires::PathStep::serializeToString() const {
     if (const ShortId* f = asField()) {
         return f->serializeToString();
+    } else if (const ArrayIndex* index = asIndex()) {
+        return std::to_string(*index);
     } else {
-        return std::to_string(getIndex());
+        return c_notAStepRepresentation;
     }
 }
 
@@ -49,6 +55,8 @@ babelwires::PathStep babelwires::PathStep::deserializeFromString(std::string_vie
             throw ParseException() << "Could not parse \"" << str << "\" as an array index";
         }
         return arrayIndex;
+    } else if (str == c_notAStepRepresentation) {
+        return PathStep();
     } else {
         return PathStep(ShortId::deserializeFromString(str));
     }

--- a/BabelWiresLib/Features/Path/pathStep.hpp
+++ b/BabelWiresLib/Features/Path/pathStep.hpp
@@ -134,7 +134,7 @@ namespace babelwires {
         } m_arrayIndex;
 
         struct NotAStep {
-            std::uint16_t m_notAStep[4] = { paddingVal, 0, paddingVal, 0 };
+            std::uint16_t m_notAStep[4] = { paddingVal, 0, paddingVal, paddingVal };
         } m_notAStep;
 
         /// Used for efficient comparison.

--- a/BabelWiresLib/Features/Path/pathStep.hpp
+++ b/BabelWiresLib/Features/Path/pathStep.hpp
@@ -20,10 +20,19 @@ namespace babelwires {
     /// A PathStep is a union of a ShortId and an ArrayIndex.
     union PathStep {
       public:
+        /// A default constructed step is neither a field nor an index.
+        /// Not-step steps are not permitted in paths, so most code can ignore this type of step
+        /// (or assert that it is not expected).
+        /// This is just a convenient way of representing an optional step.
+        PathStep() : m_notAStep() {}
+
         // explicit, because a temporary PathStep contains a copy of f, and any modification to its mutable
         // discriminator will be lost.
+        // TODO This was a mistake. Allow implicit construction from a field, and approach discriminator resolution
+        // a different way.
         explicit PathStep(const ShortId& f)
             : m_fieldIdentifier(f) {}
+
         PathStep(ArrayIndex index)
             : m_arrayIndex(Index()) {
             m_arrayIndex.m_index = index;
@@ -35,10 +44,13 @@ namespace babelwires {
         static constexpr ArrayIndex paddingVal = 0xffff;
 
         /// Does this step contain a field?
-        bool isField() const { return m_arrayIndex.m_padding[2] != paddingVal; }
+        bool isField() const { return m_arrayIndex.m_padding[0] != paddingVal; }
 
-        /// Do this step contain an array index?
-        bool isIndex() const { return !isField(); }
+        /// Does this step contain an array index?
+        bool isIndex() const { return m_arrayIndex.m_padding[1] == paddingVal; }
+
+        /// Does this step actually not represent a step at all.
+        bool isNotAStep() const { return m_arrayIndex.m_padding[2] == paddingVal; }
 
         /// Get the contained field identifier or assert.
         const ShortId& getField() const {
@@ -100,6 +112,9 @@ namespace babelwires {
             }
         }
 
+        /// How the not-a-step value is represented as a string.
+        static constexpr char c_notAStepRepresentation[] = "(notAStep)";
+
       private:
         /// Get a efficient representation of the contents of this object.
         std::uint64_t getDataAsCode() const { return m_code & 0xffffffffffff0000; }
@@ -114,9 +129,13 @@ namespace babelwires {
 
         struct Index {
             /// The last two bytes are used as the tag.
-            std::uint16_t m_padding[3] = {paddingVal, paddingVal, paddingVal};
+            std::uint16_t m_padding[3] = {paddingVal, paddingVal, 0};
             ArrayIndex m_index;
         } m_arrayIndex;
+
+        struct NotAStep {
+            std::uint16_t m_notAStep[4] = { paddingVal, 0, paddingVal, 0 };
+        } m_notAStep;
 
         /// Used for efficient comparison.
         std::uint64_t m_code;

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -252,12 +252,12 @@ void babelwires::ContentsCache::updateModifierFlags() {
     std::vector<StackData> stackDataStack;
 
     stackDataStack.emplace_back(0);
-    // The need for three variables here is a consequence of there being no root node in the Edit tree. Hmmm.
-    auto editIt = m_edits.end();
-    auto childBegin = m_edits.begin();
-    auto childEnd = m_edits.end();
     const static unsigned int notADepth = std::numeric_limits<unsigned int>::max();
     unsigned int depthOfLastConnectionModifier = notADepth;
+
+    // The edit iterator which matches the current row.
+    // It's set to m_edit.end() if there aren't any edits at or below this row.
+    auto editIt = m_edits.begin();
 
     for (int index = 0; index < m_rows.size(); ++index) {
         if (index > 0) {
@@ -268,13 +268,9 @@ void babelwires::ContentsCache::updateModifierFlags() {
             const auto it = parentStackData.m_iteratorFromStep.find(stepToHere);
             if (it != parentStackData.m_iteratorFromStep.end()) {
                 editIt = it->second;
-                childBegin = editIt.childrenBegin();
-                childEnd = editIt.childrenEnd();
                 parentStackData.m_iteratorFromStep.erase(it);
             } else {
                 editIt = m_edits.end();
-                childBegin = m_edits.end();
-                childEnd = m_edits.end();
             }
         }
 
@@ -308,9 +304,9 @@ void babelwires::ContentsCache::updateModifierFlags() {
         }
 
         // Find the set of edits for children at this row.
-        {
+        if (editIt != m_edits.end()) {
             StackData& stackData = stackDataStack.back();
-            for (auto childIt = childBegin; childIt != childEnd; childIt.nextSibling()) {
+            for (auto childIt = editIt.childrenBegin(); childIt != editIt.childrenEnd(); childIt.nextSibling()) {
                 stackData.m_iteratorFromStep.insert(std::make_pair(childIt.getStep(), childIt));
             }
         }

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -77,9 +77,7 @@ namespace babelwires {
                         return row.m_isExpanded;
                     }
                 } else {
-                    if (path.getNumSteps() > 0) {
-                        m_edits.setImplicitlyExpanded(path, true);
-                    }
+                    m_edits.setImplicitlyExpanded(path, true);
                     row.m_isExpandable = false;
                 }
                 return true;

--- a/BabelWiresLib/Project/FeatureElements/editTree.cpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree.cpp
@@ -13,13 +13,60 @@
 #include <cassert>
 #include <optional>
 
+inline void babelwires::EditTree::RootedPathIterator::operator++() {
+    if (m_isAtRoot) {
+        m_isAtRoot = false;
+    } else {
+        ++m_it;
+    }
+}
+
+inline bool babelwires::EditTree::RootedPathIterator::operator==(const RootedPathIterator& other) const {
+    return (m_it == other.m_it) && (m_isAtRoot == other.m_isAtRoot);
+}
+
+inline bool babelwires::EditTree::RootedPathIterator::operator!=(const RootedPathIterator& other) const {
+    return !(*this == other);
+};
+
+inline int babelwires::EditTree::RootedPathIterator::distanceFrom(const RootedPathIterator& other) const {
+    int itDist = m_it - other.m_it;
+    if (m_isAtRoot) {
+        --itDist;
+    }
+    if (other.m_isAtRoot) {
+        ++itDist;
+    }
+    return itDist;
+}
+
+inline babelwires::PathStep babelwires::EditTree::RootedPathIterator::operator*() const {
+    if (m_isAtRoot) {
+        return {};
+    } else {
+        return *m_it;
+    }
+}
+
+inline babelwires::EditTree::RootedPath::RootedPath(const FeaturePath& path)
+    : m_path(path) {}
+
+inline babelwires::EditTree::RootedPathIterator babelwires::EditTree::RootedPath::begin() const {
+    return RootedPathIterator{m_path.begin(), true};
+}
+inline babelwires::EditTree::RootedPathIterator babelwires::EditTree::RootedPath::end() const {
+    return RootedPathIterator{m_path.end(), false};
+};
+
+inline unsigned int babelwires::EditTree::RootedPath::getNumSteps() const {
+    return m_path.getNumSteps() + 1;
+}
 
 babelwires::EditTree::~EditTree() = default;
 
-babelwires::EditTree::FindNodeIndexResult
-babelwires::EditTree::findNodeIndex(RootedPathIterator& current,
-                                    const RootedPathIterator& end,
-                                    AncestorStack* ancestorStackOut) const {
+babelwires::EditTree::FindNodeIndexResult babelwires::EditTree::findNodeIndex(RootedPathIterator& current,
+                                                                              const RootedPathIterator& end,
+                                                                              AncestorStack* ancestorStackOut) const {
     if (m_nodes.empty()) {
         return {-1, 0};
     }
@@ -173,8 +220,8 @@ const babelwires::Modifier* babelwires::EditTree::findModifier(const FeaturePath
     }
 }
 
-void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& path,
-                                              babelwires::ArrayIndex startIndex, int adjustment) {
+void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& path, babelwires::ArrayIndex startIndex,
+                                              int adjustment) {
     const RootedPath pathToArray{path};
     auto it = pathToArray.begin();
     const auto end = pathToArray.end();
@@ -287,7 +334,6 @@ bool babelwires::EditTree::validateTree() const {
     if (m_nodes.size() == 0) {
         return true;
     }
-
 
     std::vector<int> endOfChildrenStack;
     endOfChildrenStack.emplace_back(m_nodes.size());
@@ -423,7 +469,8 @@ void babelwires::EditTree::truncatePathAtFirstCollapsedNode(babelwires::FeatureP
     }
 }
 
-std::vector<babelwires::FeaturePath> babelwires::EditTree::getAllExplicitlyExpandedPaths(const FeaturePath& path) const {
+std::vector<babelwires::FeaturePath>
+babelwires::EditTree::getAllExplicitlyExpandedPaths(const FeaturePath& path) const {
     std::vector<FeaturePath> expandedPaths;
 
     const RootedPath featurePath(path);

--- a/BabelWiresLib/Project/FeatureElements/editTree.cpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree.cpp
@@ -11,12 +11,14 @@
 #include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
 
 #include <cassert>
+#include <optional>
+
 
 babelwires::EditTree::~EditTree() = default;
 
 babelwires::EditTree::FindNodeIndexResult
-babelwires::EditTree::findNodeIndex(babelwires::FeaturePath::const_iterator& current,
-                                    const babelwires::FeaturePath::const_iterator& end,
+babelwires::EditTree::findNodeIndex(RootedPathIterator& current,
+                                    const RootedPathIterator& end,
                                     AncestorStack* ancestorStackOut) const {
     if (m_nodes.empty()) {
         return {-1, 0};
@@ -25,7 +27,7 @@ babelwires::EditTree::findNodeIndex(babelwires::FeaturePath::const_iterator& cur
     int nodeIndex = -1;
     int endOfChildren = m_nodes.size();
 
-    while (current < end) {
+    while (current != end) {
         int childIndex = nodeIndex + 1;
         while (childIndex < endOfChildren) {
             const TreeNode& child = m_nodes[childIndex];
@@ -59,13 +61,14 @@ bool babelwires::EditTree::TreeNode::isNeeded() const {
            m_isExpandedChanged || (m_numDescendents > 0);
 }
 
-void babelwires::EditTree::addEdit(const FeaturePath& featurePath, const EditNodeFunc& applyFunc) {
-    assert((featurePath.getNumSteps() > 0) && "The root cannot carry edits");
+void babelwires::EditTree::addEdit(const FeaturePath& path, const EditNodeFunc& applyFunc) {
+    RootedPath featurePath(path);
     auto it = featurePath.begin();
+    const auto end = featurePath.end();
     AncestorStack ancestorStack;
     ancestorStack.reserve(16);
-    auto [nodeIndex, childIndex] = findNodeIndex(it, featurePath.end(), &ancestorStack);
-    const auto numMissingNodes = std::distance(it, featurePath.end());
+    auto [nodeIndex, childIndex] = findNodeIndex(it, end, &ancestorStack);
+    const auto numMissingNodes = end.distanceFrom(it);
     if (numMissingNodes > 0) {
         const auto oldSize = m_nodes.size();
         m_nodes.resize(m_nodes.size() + numMissingNodes);
@@ -87,12 +90,14 @@ void babelwires::EditTree::addEdit(const FeaturePath& featurePath, const EditNod
     assert(validateTree());
 }
 
-void babelwires::EditTree::removeEdit(const FeaturePath& featurePath, const EditNodeFunc& applyFunc) {
+void babelwires::EditTree::removeEdit(const FeaturePath& path, const EditNodeFunc& applyFunc) {
+    RootedPath featurePath(path);
     auto it = featurePath.begin();
+    const auto end = featurePath.end();
     AncestorStack ancestorStack;
     ancestorStack.reserve(16);
     const auto [nodeIndex, _] = findNodeIndex(it, featurePath.end(), &ancestorStack);
-    assert((it == featurePath.end()) && "The expected edit was not in the tree");
+    assert((it == end) && "The expected edit was not in the tree");
     {
         TreeNode& nodeToEdit = m_nodes[nodeIndex];
         applyFunc(nodeToEdit);
@@ -144,30 +149,37 @@ std::unique_ptr<babelwires::Modifier> babelwires::EditTree::removeModifier(const
     return result;
 }
 
-babelwires::Modifier* babelwires::EditTree::findModifier(const FeaturePath& featurePath) {
+babelwires::Modifier* babelwires::EditTree::findModifier(const FeaturePath& path) {
+    const RootedPath featurePath(path);
     auto it = featurePath.begin();
-    const auto [nodeIndex, _] = findNodeIndex(it, featurePath.end());
-    if ((nodeIndex == -1) || (it != featurePath.end())) {
+    const auto end = featurePath.end();
+    const auto [nodeIndex, _] = findNodeIndex(it, end);
+    if ((nodeIndex == -1) || (it != end)) {
         return nullptr;
     } else {
         return m_nodes[nodeIndex].m_modifier.get();
     }
 }
 
-const babelwires::Modifier* babelwires::EditTree::findModifier(const FeaturePath& featurePath) const {
+const babelwires::Modifier* babelwires::EditTree::findModifier(const FeaturePath& path) const {
+    const RootedPath featurePath(path);
     auto it = featurePath.begin();
-    const auto [nodeIndex, _] = findNodeIndex(it, featurePath.end());
-    if ((nodeIndex == -1) || (it != featurePath.end())) {
+    const auto end = featurePath.end();
+    const auto [nodeIndex, _] = findNodeIndex(it, end);
+    if ((nodeIndex == -1) || (it != end)) {
         return nullptr;
     } else {
         return m_nodes[nodeIndex].m_modifier.get();
     }
 }
 
-void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& pathToArray,
+void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& path,
                                               babelwires::ArrayIndex startIndex, int adjustment) {
+    const RootedPath pathToArray{path};
     auto it = pathToArray.begin();
-    const auto [nodeIndex, _] = findNodeIndex(it, pathToArray.end());
+    const auto end = pathToArray.end();
+
+    const auto [nodeIndex, _] = findNodeIndex(it, end);
     if ((nodeIndex == -1) || (it != pathToArray.end())) {
         return;
     }
@@ -207,7 +219,7 @@ void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& pat
 
         for (const auto& m : modifiersToAdjust) {
             auto modPtr = removeModifier(m);
-            modPtr->adjustArrayIndex(pathToArray, startIndex, adjustment);
+            modPtr->adjustArrayIndex(pathToArray.m_path, startIndex, adjustment);
             modifiersAdjusted.emplace_back(std::move(modPtr));
         }
         for (auto& m : modifiersAdjusted) {
@@ -219,10 +231,10 @@ void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& pat
         setExpanded(p, c_expandedByDefault);
     }
 
-    const unsigned int pathIndexOfStepIntoArray = pathToArray.getNumSteps();
+    const unsigned int pathIndexOfStepIntoArray = path.getNumSteps();
 
     for (auto p : pathsToToggleExpansion) {
-        assert(pathToArray.isStrictPrefixOf(p));
+        assert(pathToArray.m_path.isStrictPrefixOf(p));
         babelwires::PathStep& stepIntoArray = p.getStep(pathIndexOfStepIntoArray);
         auto index = stepIntoArray.getIndex();
         assert((index >= startIndex) && "This code only applies when the index is correct.");
@@ -231,10 +243,13 @@ void babelwires::EditTree::adjustArrayIndices(const babelwires::FeaturePath& pat
     }
 }
 
-bool babelwires::EditTree::isExpanded(const FeaturePath& featurePath) const {
-    auto it = featurePath.begin();
-    const auto [nodeIndex, _] = findNodeIndex(it, featurePath.end());
-    if ((nodeIndex == -1) || (it != featurePath.end())) {
+bool babelwires::EditTree::isExpanded(const FeaturePath& path) const {
+    const RootedPath pathToArray(path);
+    auto it = pathToArray.begin();
+    const auto end = pathToArray.end();
+
+    const auto [nodeIndex, _] = findNodeIndex(it, end);
+    if ((nodeIndex == -1) || (it != end)) {
         return c_expandedByDefault;
     } else {
         return m_nodes[nodeIndex].m_isExpanded || m_nodes[nodeIndex].m_isImplicitlyExpanded;
@@ -269,13 +284,18 @@ void babelwires::EditTree::setImplicitlyExpanded(const FeaturePath& featurePath,
 }
 
 bool babelwires::EditTree::validateTree() const {
+    if (m_nodes.size() == 0) {
+        return true;
+    }
+
+
     std::vector<int> endOfChildrenStack;
     endOfChildrenStack.emplace_back(m_nodes.size());
 
     FeaturePath path;
     FeaturePath previousPath;
 
-    for (int i = 0; i < m_nodes.size(); ++i) {
+    for (int i = 1; i < m_nodes.size(); ++i) {
         assert(i <= endOfChildrenStack.back() && "Structural error in tree");
         const TreeNode& node = m_nodes[i];
         assert(node.isNeeded() && "Unnecessary node in the tree");
@@ -308,15 +328,17 @@ bool babelwires::EditTree::validateTree() const {
 babelwires::FeaturePath babelwires::EditTree::getPathToNode(TreeNodeIndex soughtIndex) const {
     assert((soughtIndex < m_nodes.size()) && "soughtIndex is out of range");
     FeaturePath path;
-    int currentIndex = 0;
+    if (soughtIndex != 0) {
+        int currentIndex = 1;
 
-    while (currentIndex <= soughtIndex) {
-        const int endOfChildren = currentIndex + m_nodes[currentIndex].m_numDescendents + 1;
-        if (soughtIndex < endOfChildren) {
-            path.pushStep(m_nodes[currentIndex].m_step);
-            ++currentIndex;
-        } else {
-            currentIndex = endOfChildren;
+        while (currentIndex <= soughtIndex) {
+            const int endOfChildren = currentIndex + m_nodes[currentIndex].m_numDescendents + 1;
+            if (soughtIndex < endOfChildren) {
+                path.pushStep(m_nodes[currentIndex].m_step);
+                ++currentIndex;
+            } else {
+                currentIndex = endOfChildren;
+            }
         }
     }
     return path;
@@ -352,37 +374,39 @@ void babelwires::EditTree::truncatePathAtFirstCollapsedNode(babelwires::FeatureP
     if (m_nodes.empty()) {
         // Path is not collapsed.
         if constexpr (!c_expandedByDefault) {
-            path.truncate(1);
+            path.truncate(0);
         }
         return;
     }
 
+    RootedPath rootedPath(path);
+    auto current = rootedPath.begin();
+    const auto end = rootedPath.end();
     int pathIndex = 0;
-    const int numPathSteps = path.getNumSteps();
 
     int nodeIndex = -1;
     int endOfChildren = m_nodes.size();
 
-    while (pathIndex < numPathSteps) {
-        const PathStep& current = path.getStep(pathIndex);
+    while (current != end) {
         int childIndex = nodeIndex + 1;
         while (childIndex < endOfChildren) {
             const TreeNode& child = m_nodes[childIndex];
-            if (child.m_step == current) {
+            if (child.m_step == *current) {
                 if (!child.m_isImplicitlyExpanded &&
                     (((state == State::CurrentState) && !child.m_isExpanded) ||
                      ((state == State::PreviousState) && (child.m_isExpanded == child.m_isExpandedChanged)))) {
-                    path.truncate(pathIndex + 1);
+                    path.truncate(pathIndex);
                     return;
                 }
+                ++current;
                 ++pathIndex;
                 nodeIndex = childIndex;
                 endOfChildren = nodeIndex + child.m_numDescendents + 1;
                 break;
-            } else if (current < child.m_step) {
+            } else if (*current < child.m_step) {
                 // The path leads outside the tree.
                 if constexpr (!c_expandedByDefault) {
-                    path.truncate(pathIndex + 1);
+                    path.truncate(pathIndex);
                 }
                 return;
             }
@@ -392,21 +416,25 @@ void babelwires::EditTree::truncatePathAtFirstCollapsedNode(babelwires::FeatureP
         if (childIndex == endOfChildren) {
             // The path leads outside the tree.
             if constexpr (!c_expandedByDefault) {
-                path.truncate(pathIndex + 1);
+                path.truncate(pathIndex);
             }
             return;
         }
     }
 }
 
-std::vector<babelwires::FeaturePath> babelwires::EditTree::getAllExplicitlyExpandedPaths(const FeaturePath& featurePath) const {
+std::vector<babelwires::FeaturePath> babelwires::EditTree::getAllExplicitlyExpandedPaths(const FeaturePath& path) const {
     std::vector<FeaturePath> expandedPaths;
+
+    const RootedPath featurePath(path);
+    auto it = featurePath.begin();
+    const auto end = featurePath.end();
 
     int beginIndex = 0;
     int endIndex = m_nodes.size();
     if (featurePath.getNumSteps() != 0) {
         auto it = featurePath.begin();
-        const auto [nodeIndex, _] = findNodeIndex(it, featurePath.end());
+        const auto [nodeIndex, _] = findNodeIndex(it, end);
         if ((nodeIndex == -1) || (it != featurePath.end())) {
             return expandedPaths;
         }

--- a/BabelWiresLib/Project/FeatureElements/editTree.cpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree.cpp
@@ -335,6 +335,9 @@ bool babelwires::EditTree::validateTree() const {
         return true;
     }
 
+    assert(m_nodes[0].m_step.isNotAStep());
+    assert(m_nodes.size() == m_nodes[0].m_numDescendents + 1);
+
     std::vector<int> endOfChildrenStack;
     endOfChildrenStack.emplace_back(m_nodes.size());
 

--- a/BabelWiresLib/Project/FeatureElements/editTree.hpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree.hpp
@@ -91,6 +91,9 @@ namespace babelwires {
         modifierRange(const FeaturePath& featurePath) const;
 
       private:
+        struct RootedPath;
+        struct RootedPathIterator;
+
         struct FindNodeIndexResult {
             int m_nodeIndex = -1;
             /// If there is a missing child, this is the index where the missing child would be.
@@ -102,7 +105,7 @@ namespace babelwires {
 
         /// Advance current along the nodes and return the index of the last node reached.
         /// If ancestorStackOut is provided, the indices of the path will be pushed on.
-        FindNodeIndexResult findNodeIndex(FeaturePath::const_iterator& current, const FeaturePath::const_iterator& end,
+        FindNodeIndexResult findNodeIndex(RootedPathIterator& current, const RootedPathIterator& end,
                                           AncestorStack* ancestorStackOut = nullptr) const;
 
         /// Check assertions about the validity of the tree.
@@ -137,7 +140,7 @@ namespace babelwires {
             /// Non-null for leaf nodes.
             std::unique_ptr<Modifier> m_modifier;
             /// The step to this node from its parent.
-            PathStep m_step = 0;
+            PathStep m_step;
             /// The total number of descendents of this node (not including this node).
             std::uint16_t m_numDescendents = 0;
 

--- a/BabelWiresLib/Project/FeatureElements/editTree_inl.hpp
+++ b/BabelWiresLib/Project/FeatureElements/editTree_inl.hpp
@@ -2,63 +2,34 @@
  * The EditTree arranges edits (modifiers and expand/collapse) in a tree organized by paths.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
+/// Iterate over a RootedPath.
 struct babelwires::EditTree::RootedPathIterator {
-    inline void operator++() {
-        if (m_isAtRoot) {
-            m_isAtRoot = false;
-        } else {
-            ++m_it;
-        }
-    }
-
-    inline bool operator==(const RootedPathIterator& other) const {
-        return (m_it == other.m_it) && (m_isAtRoot == other.m_isAtRoot);
-    }
-
-    inline bool operator!=(const RootedPathIterator& other) const { return !(*this == other); };
-    
-    inline int distanceFrom(const RootedPathIterator& other) const {
-        int itDist = m_it - other.m_it;
-        if (m_isAtRoot) {
-            --itDist;
-        }
-        if (other.m_isAtRoot) {
-            ++itDist;
-        }
-        return itDist;
-    }
-
-    inline PathStep operator*() const {
-        if (m_isAtRoot) {
-            return {};
-        } else {
-            return *m_it;
-        }
-    }
+    void operator++();
+    bool operator==(const RootedPathIterator& other) const;
+    bool operator!=(const RootedPathIterator& other) const;
+    int distanceFrom(const RootedPathIterator& other) const;
+    PathStep operator*() const;
 
     FeaturePath::const_iterator m_it;
     bool m_isAtRoot;
 };
 
-/// Acts like a path, but has an extra "NotAStep" at the front to indicate the non-step to the root.
-struct babelwires::EditTree::RootedPath
-{
-    inline RootedPath(const FeaturePath& path) : m_path(path) {}
-
-    inline RootedPathIterator begin() const { return RootedPathIterator{ m_path.begin(), true }; }
-    inline RootedPathIterator end() const { return RootedPathIterator{ m_path.end(), false}; };
-
-    inline unsigned int getNumSteps() const {
-        return m_path.getNumSteps() + 1;
-    }
+/// Acts like the path it wraps, but has an extra "NotAStep" at the front to indicate
+/// the non-step to the root. This is a convenience structure which simplifies
+/// a lot of the EditTree code, since RootedPaths correspond in a nicer way to
+/// nodes of the EditTree.
+struct babelwires::EditTree::RootedPath {
+    RootedPath(const FeaturePath& path);
+    RootedPathIterator begin() const;
+    RootedPathIterator end() const;
+    unsigned int getNumSteps() const;
 
     const FeaturePath& m_path;
 };
-
 
 template <typename EDIT_TREE> struct babelwires::EditTree::Iterator {
     using EDIT_TREE_PARAM = EDIT_TREE;
@@ -182,7 +153,7 @@ babelwires::EditTree::modifierRange(const FeaturePath& path) {
     RootedPath featurePath(path);
     auto it = featurePath.begin();
     const auto end = featurePath.end();
-    
+
     const auto [beginIndex, _] = findNodeIndex(it, end);
     if (it == featurePath.end()) {
         const TreeNodeIndex endIndex = beginIndex + m_nodes[beginIndex].m_numDescendents + 1;
@@ -198,7 +169,7 @@ babelwires::EditTree::modifierRange(const FeaturePath& path) const {
     RootedPath featurePath(path);
     auto it = featurePath.begin();
     const auto end = featurePath.end();
-    
+
     const auto [beginIndex, _] = findNodeIndex(it, end);
     if (it == featurePath.end()) {
         const TreeNodeIndex endIndex = beginIndex + m_nodes[beginIndex].m_numDescendents + 1;

--- a/Tests/BabelWiresLib/editTreeTest.cpp
+++ b/Tests/BabelWiresLib/editTreeTest.cpp
@@ -197,7 +197,10 @@ TEST(EditTreeTest, expandCollapse) {
     // These tests assume c_expandedByDefault is false.
     static_assert(babelwires::EditTree::c_expandedByDefault == false);
 
-    // TODO This is a little inconsistent with the fact that the system always treats the first level as expanded.
+    EXPECT_FALSE(tree.isExpanded(babelwires::FeaturePath()));
+    tree.setExpanded(babelwires::FeaturePath(), true);
+    EXPECT_TRUE(tree.isExpanded(babelwires::FeaturePath()));
+    tree.setExpanded(babelwires::FeaturePath(), false);
     EXPECT_FALSE(tree.isExpanded(babelwires::FeaturePath()));
 
     const babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("bb/4");

--- a/Tests/BabelWiresLib/editTreeTest.cpp
+++ b/Tests/BabelWiresLib/editTreeTest.cpp
@@ -33,6 +33,22 @@ namespace {
     }
 } // namespace
 
+TEST(EditTreeTest, fieldAddFindRemoveEmptyPath) {
+    babelwires::EditTree tree;
+
+    babelwires::FeaturePath path;
+    auto modPtr = createModifier(path, 1);
+    babelwires::Modifier* mod = modPtr.get();
+
+    tree.addModifier(std::move(modPtr));
+    EXPECT_EQ(tree.findModifier(path), mod);
+
+    auto modPtr2 = tree.removeModifier(mod);
+    EXPECT_EQ(modPtr2.get(), mod);
+    EXPECT_EQ(tree.findModifier(path), nullptr);
+}
+
+
 TEST(EditTreeTest, fieldAddFindRemove) {
     babelwires::EditTree tree;
 
@@ -479,6 +495,7 @@ TEST(EditTreeTest, adjustArrayIndices) {
 
 TEST(EditTreeTest, truncatePaths) {
     babelwires::EditTree tree;
+    tree.setImplicitlyExpanded(babelwires::FeaturePath(), true);
 
     {
         babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb");
@@ -572,6 +589,7 @@ TEST(EditTreeTest, truncatePaths) {
 
 TEST(EditTreeTest, truncatePathsWithImplicitlyExpandedPaths) {
     babelwires::EditTree tree;
+    tree.setImplicitlyExpanded(babelwires::FeaturePath(), true);
 
     {
         babelwires::FeaturePath path = babelwires::FeaturePath::deserializeFromString("aa/5/bb/cc");
@@ -691,8 +709,11 @@ TEST(EditTreeTest, treeIteration) {
     tree.addModifier(createModifier(path5, 5));
     tree.setExpanded(path6, true);
 
-    auto it = tree.begin();
-    EXPECT_NE(it, tree.end());
+    auto rit = tree.begin();
+    EXPECT_NE(rit, tree.end());
+    
+    auto it = rit.childrenBegin();
+    EXPECT_NE(it, rit.childrenEnd());
     EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("aa")));
     EXPECT_EQ(it.getModifier(), nullptr);
     {
@@ -705,7 +726,7 @@ TEST(EditTreeTest, treeIteration) {
         EXPECT_EQ(cit, it.childrenEnd());
     }
     it.nextSibling();
-    EXPECT_NE(it, tree.end());
+    EXPECT_NE(it, rit.childrenEnd());
     EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("bb")));
     ASSERT_NE(it.getModifier(), nullptr);
     EXPECT_EQ(it.getModifier()->getModifierData().m_pathToFeature, path3);
@@ -723,7 +744,7 @@ TEST(EditTreeTest, treeIteration) {
         EXPECT_EQ(cit, it.childrenEnd());
     }
     it.nextSibling();
-    EXPECT_NE(it, tree.end());
+    EXPECT_NE(it, rit.childrenEnd());
     EXPECT_EQ(it.getStep(), babelwires::PathStep(babelwires::ShortId("cc")));
     ASSERT_EQ(it.getModifier(), nullptr);
     {
@@ -739,7 +760,10 @@ TEST(EditTreeTest, treeIteration) {
         EXPECT_EQ(cit, it.childrenEnd());
     }
     it.nextSibling();
-    EXPECT_EQ(it, tree.end());
+    EXPECT_EQ(it, rit.childrenEnd());
+
+    rit.nextSibling();
+    EXPECT_EQ(rit, tree.end());
 }
 
 TEST(EditTreeTest, modifierIteration) {

--- a/Tests/BabelWiresLib/pathStepTest.cpp
+++ b/Tests/BabelWiresLib/pathStepTest.cpp
@@ -16,6 +16,11 @@ TEST(PathStepTest, projection) {
     babelwires::ShortId hello1("Hello");
     babelwires::ShortId goodbye("Byebye");
 
+    babelwires::PathStep notAStep;
+    EXPECT_TRUE(notAStep.isNotAStep());
+    EXPECT_FALSE(notAStep.isField());
+    EXPECT_FALSE(notAStep.isIndex());
+
     babelwires::PathStep helloStep(hello);
     babelwires::PathStep hello1Step(hello1);
     babelwires::PathStep goodbyeStep(goodbye);
@@ -90,6 +95,9 @@ TEST(PathStepTest, serialization) {
 
     babelwires::PathStep index(10);
     EXPECT_EQ(index.serializeToString(), "10");
+
+    babelwires::PathStep notAStep;
+    EXPECT_EQ(notAStep.serializeToString(), babelwires::PathStep::c_notAStepRepresentation);
 }
 
 TEST(PathStepTest, deserialization) {
@@ -110,6 +118,10 @@ TEST(PathStepTest, deserialization) {
     EXPECT_TRUE(step2.isIndex());
     EXPECT_EQ(step2.getIndex(), 10);
 
+    babelwires::PathStep notAStep;
+    EXPECT_NO_THROW(notAStep = babelwires::PathStep::deserializeFromString(babelwires::PathStep::c_notAStepRepresentation));
+    EXPECT_TRUE(notAStep.isNotAStep());
+    
     EXPECT_THROW(babelwires::PathStep::deserializeFromString("'"), babelwires::ParseException);
     EXPECT_THROW(babelwires::PathStep::deserializeFromString("/"), babelwires::ParseException);
     EXPECT_THROW(babelwires::PathStep::deserializeFromString("Hællo"), babelwires::ParseException);
@@ -130,6 +142,7 @@ TEST(PathStepTest, stringRepresentations) {
 
     babelwires::PathStep helloStep(hello2);
     babelwires::PathStep index(10);
+    babelwires::PathStep notAStep;
 
     {
         std::ostringstream os;
@@ -141,6 +154,11 @@ TEST(PathStepTest, stringRepresentations) {
         os << index;
         EXPECT_EQ(os.str(), "10");
     }
+    {
+        std::ostringstream os;
+        os << notAStep;
+        EXPECT_EQ(os.str(), babelwires::PathStep::c_notAStepRepresentation);
+    }
 
     {
         std::ostringstream os;
@@ -151,6 +169,11 @@ TEST(PathStepTest, stringRepresentations) {
         std::ostringstream os;
         index.writeToStreamReadable(os, reg);
         EXPECT_EQ(os.str(), "[10]");
+    }
+    {
+        std::ostringstream os;
+        notAStep.writeToStreamReadable(os, reg);
+        EXPECT_EQ(os.str(), babelwires::PathStep::c_notAStepRepresentation);
     }
 }
 

--- a/Tests/BabelWiresLib/projectObserverTest.cpp
+++ b/Tests/BabelWiresLib/projectObserverTest.cpp
@@ -249,7 +249,7 @@ TEST(ProjectObserverTest, featureElementResizedIgnore) {
 
 namespace {
     void testConnectionAdded(bool shouldIgnore, bool sourceRecordIsExpanded, bool targetArrayIsExpanded) {
-            testUtils::TestEnvironment testEnvironment;
+        testUtils::TestEnvironment testEnvironment;
 
         testUtils::TestComplexRecordElementData sourceElementData;
         sourceElementData.m_expandedPaths.emplace_back(testUtils::TestComplexRecordElementData::getPathToRecord());


### PR DESCRIPTION
The root of FeatureElements was usually hidden, so it could not be edited and there was therefore no need to store modifiers at the empty path. Additionally, there was no default constructable PathStep to assign to that node.

I now intend to place value types at the root and I want them to be editable. 

This PR prepares the way by adding an extra root node to the EditTree to allow it to store modifiers at the empty path. It also introduces a "NotAStep" value for PathStep which is used for the root.