### PR TITLE
WIP: FeatureElements with roots

### DIFF
--- a/BabelWiresLib/Features/simpleValueFeature.cpp
+++ b/BabelWiresLib/Features/simpleValueFeature.cpp
@@ -97,7 +97,3 @@ const babelwires::TypeSystem& babelwires::SimpleValueFeature::getTypeSystem() co
         return RootFeature::getTypeSystemAt(*this);
     }
 }
-
-babelwires::Feature::Style babelwires::SimpleValueFeature::getStyle() const {
-    return getOwner() ? Feature::getStyle() : babelwires::Feature::Style::isInlined;
-}

--- a/BabelWiresLib/Features/simpleValueFeature.hpp
+++ b/BabelWiresLib/Features/simpleValueFeature.hpp
@@ -39,9 +39,6 @@ namespace babelwires {
         /// Get the TypeSystem carried by this feature (or the one carried by the root of the hierarchy).
         const TypeSystem& getTypeSystem() const;
 
-        /// The root is not collapsable.
-        Style getStyle() const override;
-
       protected:
         const ValueHolder& doGetValue() const override;
         void doSetToDefault() override;

--- a/BabelWiresLib/Project/Commands/addElementCommand.cpp
+++ b/BabelWiresLib/Project/Commands/addElementCommand.cpp
@@ -2,7 +2,7 @@
  * The command which adds FeatureElements to the project.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -18,7 +18,10 @@
 
 babelwires::AddElementCommand::AddElementCommand(std::string commandName, std::unique_ptr<ElementData> elementToAdd)
     : SimpleCommand(std::move(commandName))
-    , m_elementToAdd(std::move(elementToAdd)) {}
+    , m_elementToAdd(std::move(elementToAdd)) {
+    assert((std::find(m_elementToAdd->m_expandedPaths.begin(), m_elementToAdd->m_expandedPaths.end(), FeaturePath()) == m_elementToAdd->m_expandedPaths.end()) && "The root is always expanded by default.");
+    m_elementToAdd->m_expandedPaths.emplace_back(FeaturePath());
+}
 
 void babelwires::AddElementCommand::execute(Project& project) const {
     ElementId newId = project.addFeatureElement(*m_elementToAdd);

--- a/BabelWiresLib/Project/Commands/addElementCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addElementCommand.hpp
@@ -19,6 +19,8 @@ namespace babelwires {
     /// Add a feature element to the project.
     class AddElementCommand : public SimpleCommand<Project> {
       public:
+        /// Create a command which adds the given element.
+        /// NOTE: An expanded path entry is always added for the root path, so the constructor asserts it is not already present.
         AddElementCommand(std::string commandName, std::unique_ptr<ElementData> elementToAdd);
 
         virtual bool initialize(const Project& project) override;

--- a/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.cpp
@@ -2,21 +2,23 @@
  * ProcessorElement are FeatureElements which carry a processor.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.hpp>
 
 #include <BabelWiresLib/Features/modelExceptions.hpp>
+#include <BabelWiresLib/Features/simpleValueFeature.hpp>
+#include <BabelWiresLib/Features/valueFeature.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processorFactoryRegistry.hpp>
-#include <BabelWiresLib/Project/FeatureElements/failedFeature.hpp>
 #include <BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElementData.hpp>
+#include <BabelWiresLib/Project/FeatureElements/failedFeature.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
-#include <BabelWiresLib/Features/valueFeature.hpp>
+#include <BabelWiresLib/Types/FailedType/failedType.hpp>
 
 #include <Common/Log/userLogger.hpp>
 
@@ -34,10 +36,13 @@ babelwires::ProcessorElement::ProcessorElement(const ProjectContext& context, Us
     } catch (const BaseException& e) {
         setFactoryName(elementData.m_factoryIdentifier);
         setInternalFailure(e.what());
-        m_sharedDummyFeature = std::make_unique<babelwires::FailedFeature>(context);
+        m_failedFeature =
+            std::make_unique<babelwires::SimpleValueFeature>(context.m_typeSystem, FailedType::getThisIdentifier());
         userLogger.logError() << "Failed to create processor id=" << elementData.m_id << ": " << e.what();
     }
 }
+
+babelwires::ProcessorElement::~ProcessorElement() = default;
 
 const babelwires::ProcessorElementData& babelwires::ProcessorElement::getElementData() const {
     return static_cast<const ProcessorElementData&>(FeatureElement::getElementData());
@@ -47,7 +52,7 @@ babelwires::Feature* babelwires::ProcessorElement::doGetOutputFeatureNonConst() 
     if (m_processor) {
         return &m_processor->getOutputFeature();
     } else {
-        return m_sharedDummyFeature.get();
+        return m_failedFeature.get();
     }
 }
 
@@ -55,7 +60,7 @@ babelwires::Feature* babelwires::ProcessorElement::doGetInputFeatureNonConst() {
     if (m_processor) {
         return &m_processor->getInputFeature();
     } else {
-        return m_sharedDummyFeature.get();
+        return m_failedFeature.get();
     }
 }
 
@@ -63,7 +68,7 @@ const babelwires::Feature* babelwires::ProcessorElement::getOutputFeature() cons
     if (m_processor) {
         return &m_processor->getOutputFeature();
     } else {
-        return m_sharedDummyFeature.get();
+        return m_failedFeature.get();
     }
 }
 
@@ -71,13 +76,21 @@ const babelwires::Feature* babelwires::ProcessorElement::getInputFeature() const
     if (m_processor) {
         return &m_processor->getInputFeature();
     } else {
-        return m_sharedDummyFeature.get();
+        return m_failedFeature.get();
     }
 }
 
 void babelwires::ProcessorElement::setProcessor(std::unique_ptr<Processor> processor) {
-    m_contentsCache.setFeatures(&processor->getInputFeature(), &processor->getOutputFeature());
     m_processor = std::move(processor);
+    m_contentsCache.setFeatures(getRootLabel(), &m_processor->getInputFeature(), &m_processor->getOutputFeature());
+}
+
+std::string babelwires::ProcessorElement::getRootLabel() const {
+    if (m_processor) {
+        return "Input/Output";
+    } else {
+        return "Failed";
+    }
 }
 
 void babelwires::ProcessorElement::doProcess(UserLogger& userLogger) {
@@ -99,7 +112,7 @@ void babelwires::ProcessorElement::doProcess(UserLogger& userLogger) {
     }
     if (isChanged(Changes::FeatureStructureChanged | Changes::CompoundExpandedOrCollapsed)) {
         if (m_processor) {
-            m_contentsCache.setFeatures(&m_processor->getInputFeature(), &m_processor->getOutputFeature());
+            m_contentsCache.setFeatures(getRootLabel(), &m_processor->getInputFeature(), &m_processor->getOutputFeature());
         }
     } else if (isChanged(Changes::ModifierChangesMask)) {
         m_contentsCache.updateModifierCache();

--- a/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.hpp
@@ -14,11 +14,13 @@ namespace babelwires {
     struct ProjectContext;
     struct ProcessorElementData;
     class Processor;
+    class SimpleValueFeature;
 
     class ProcessorElement : public FeatureElement {
       public:
         ProcessorElement(const ProjectContext& context, UserLogger& userLogger, const ProcessorElementData& data,
                          ElementId newId);
+        ~ProcessorElement();
 
         /// Down-cast version of the parent's method.
         const ProcessorElementData& getElementData() const;
@@ -32,13 +34,14 @@ namespace babelwires {
         void doProcess(UserLogger& userLogger) override;
 
       protected:
+        std::string getRootLabel() const;
         void setProcessor(std::unique_ptr<Processor> processor);
 
       private:
         std::unique_ptr<Processor> m_processor;
 
         /// Non-null when the defined processor could not be constructed.
-        std::unique_ptr<babelwires::Feature> m_sharedDummyFeature;
+        std::unique_ptr<babelwires::SimpleValueFeature> m_failedFeature;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.cpp
@@ -42,13 +42,13 @@ const babelwires::Feature* babelwires::SourceFileElement::getOutputFeature() con
 }
 
 void babelwires::SourceFileElement::setFeature(std::unique_ptr<RootFeature> feature) {
-    m_contentsCache.setFeatures(nullptr, feature.get());
+    m_contentsCache.setFeatures("File", nullptr, feature.get());
     m_feature = std::move(feature);
 }
 
 void babelwires::SourceFileElement::doProcess(UserLogger& userLogger) {
     if (isChanged(Changes::FeatureStructureChanged | Changes::CompoundExpandedOrCollapsed)) {
-        m_contentsCache.setFeatures(nullptr, m_feature.get());
+        m_contentsCache.setFeatures("File", nullptr, m_feature.get());
     }
 }
 

--- a/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.hpp
@@ -16,7 +16,6 @@ namespace babelwires {
 namespace babelwires {
 
     struct SourceFileElementData;
-    class RecordFeature;
     struct ProjectContext;
     class RootFeature;
 

--- a/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.cpp
@@ -66,7 +66,7 @@ const babelwires::Feature* babelwires::TargetFileElement::getInputFeature() cons
 }
 
 void babelwires::TargetFileElement::setFeature(std::unique_ptr<RootFeature> feature) {
-    m_contentsCache.setFeatures(feature.get(), nullptr);
+    m_contentsCache.setFeatures("File", feature.get(), nullptr);
     m_feature = std::move(feature);
 }
 
@@ -129,7 +129,7 @@ bool babelwires::TargetFileElement::save(const ProjectContext& context, UserLogg
 
 void babelwires::TargetFileElement::doProcess(UserLogger& userLogger) {
     if (isChanged(Changes::FeatureStructureChanged | Changes::CompoundExpandedOrCollapsed)) {
-        m_contentsCache.setFeatures(m_feature.get(), nullptr);
+        m_contentsCache.setFeatures("File", m_feature.get(), nullptr);
     } else if (isChanged(Changes::ModifierChangesMask)) {
         m_contentsCache.updateModifierCache();
     }

--- a/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.hpp
@@ -16,7 +16,6 @@ namespace babelwires {
 namespace babelwires {
 
     struct TargetFileElementData;
-    class RecordFeature;
     struct ProjectContext;
     class FileFeature;
     class RootFeature;

--- a/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElementData.cpp
@@ -7,7 +7,6 @@
  **/
 #include <BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElementData.hpp>
 
-#include <BabelWiresLib/Features/recordFeature.hpp>
 #include <BabelWiresLib/FileFormat/targetFileFormat.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/Features/rootFeature.hpp>

--- a/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
@@ -47,9 +47,17 @@ const babelwires::Feature* babelwires::ValueElement::getOutputFeature() const {
     return m_rootFeature.get();
 }
 
+std::string babelwires::ValueElement::getRootLabel() const {
+    if (m_rootFeature->getTypeRef() == FailedType::getThisIdentifier()) {
+        return "Failed";
+    } else {
+        return "Value";
+    }
+}
+
 void babelwires::ValueElement::doProcess(UserLogger& userLogger) {
     if (isChanged(Changes::FeatureStructureChanged | Changes::CompoundExpandedOrCollapsed)) {
-        m_contentsCache.setFeatures(m_rootFeature.get(), m_rootFeature.get());
+        m_contentsCache.setFeatures(getRootLabel(), m_rootFeature.get(), m_rootFeature.get());
     } else if (isChanged(Changes::ModifierChangesMask)) {
         m_contentsCache.updateModifierCache();
     }

--- a/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
@@ -12,7 +12,7 @@
 #include <BabelWiresLib/Project/FeatureElements/ValueElement/valueElementData.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
-#include <BabelWiresLib/Types/FailedType/failedType.hpp>
+#include <BabelWiresLib/Types/Failure/failureType.hpp>
 
 babelwires::ValueElement::ValueElement(const ProjectContext& context, UserLogger& userLogger,
                                        const ValueElementData& data, ElementId newId)
@@ -20,7 +20,10 @@ babelwires::ValueElement::ValueElement(const ProjectContext& context, UserLogger
     setFactoryName(data.getTypeRef().toString());
     TypeRef typeRefForConstruction = data.getTypeRef();
     if (!typeRefForConstruction.tryResolve(context.m_typeSystem)) {
-        typeRefForConstruction = FailedType::getThisIdentifier();
+        typeRefForConstruction = FailureType::getThisIdentifier();
+        std::ostringstream message;
+        message << "Type Reference " << data.getTypeRef().toString() << " could not be resolved";
+        setInternalFailure(message.str());
     }
     m_rootFeature = std::make_unique<SimpleValueFeature>(context.m_typeSystem, typeRefForConstruction);
 }
@@ -48,7 +51,7 @@ const babelwires::Feature* babelwires::ValueElement::getOutputFeature() const {
 }
 
 std::string babelwires::ValueElement::getRootLabel() const {
-    if (m_rootFeature->getTypeRef() == FailedType::getThisIdentifier()) {
+    if (m_rootFeature->getTypeRef() == FailureType::getThisIdentifier()) {
         return "Failed";
     } else {
         return "Value";

--- a/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.hpp
@@ -32,6 +32,9 @@ namespace babelwires {
         Feature* doGetOutputFeatureNonConst() override;
         void doProcess(UserLogger& userLogger) override;
 
+      protected:
+        std::string getRootLabel() const;
+
       private:
         std::unique_ptr<babelwires::SimpleValueFeature> m_rootFeature;
     };

--- a/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.hpp
@@ -13,7 +13,7 @@
 namespace babelwires {
     struct UserLogger;
     class ValueElementData;
-    class RootFeature;
+    class SimpleValueFeature;
 
     class ValueElement : public FeatureElement {
       public:
@@ -27,16 +27,13 @@ namespace babelwires {
         virtual const Feature* getInputFeature() const override;
         virtual const Feature* getOutputFeature() const override;
 
-        /// The root feature has a single step to the value feature, which always uses this identifier.
-        static ShortId getStepToValue();
-
       protected:
         Feature* doGetInputFeatureNonConst() override;
         Feature* doGetOutputFeatureNonConst() override;
         void doProcess(UserLogger& userLogger) override;
 
       private:
-        std::unique_ptr<babelwires::RootFeature> m_rootFeature;
+        std::unique_ptr<babelwires::SimpleValueFeature> m_rootFeature;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -193,18 +193,16 @@ namespace babelwires {
     } // namespace Detail
 } // namespace babelwires
 
-void babelwires::ContentsCache::setFeatures(const Feature* inputFeature, const Feature* outputFeature) {
+void babelwires::ContentsCache::setFeatures(std::string rootLabel, const Feature* inputFeature, const Feature* outputFeature) {
     m_rows.clear();
     Detail::ContentsCacheBuilder builder(m_rows, m_edits);
     const babelwires::Feature* const rootFeature = inputFeature ? inputFeature : outputFeature;
-    // TODO Instead of this hack, make the extra "file" row a UI feature.
-    const char* rootLabel = rootFeature->as<const babelwires::FileFeature>() ? "File" : "Root";
     if (inputFeature && outputFeature) {
-        builder.addFeatureToCache(rootLabel, inputFeature, outputFeature, FeaturePath(), 0, 0);
+        builder.addFeatureToCache(std::move(rootLabel), inputFeature, outputFeature, FeaturePath(), 0, 0);
     } else if (inputFeature) {
-        builder.addInputFeatureToCache(rootLabel, inputFeature, FeaturePath(), 0, 0);
+        builder.addInputFeatureToCache(std::move(rootLabel), inputFeature, FeaturePath(), 0, 0);
     } else if (outputFeature) {
-        builder.addOutputFeatureToCache(rootLabel, outputFeature, FeaturePath(), 0, 0);
+        builder.addOutputFeatureToCache(std::move(rootLabel), outputFeature, FeaturePath(), 0, 0);
     } else {
         assert(!"Unimplemented");
     }

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -222,7 +222,7 @@ void babelwires::ContentsCache::setIndexOffset() {
     const int oldIndexOffset = m_indexOffset;
     const ContentsCacheEntry& rootEntry = m_rows[0];
     const babelwires::Feature* const rootFeature = rootEntry.getInputThenOutputFeature();
-    m_indexOffset = (rootEntry.hasFailedHiddenModifiers() || rootFeature->as<const babelwires::FileFeature>()) ? 0 : 1;
+    m_indexOffset = 0; // (rootEntry.hasFailedHiddenModifiers() || rootFeature->as<const babelwires::FileFeature>()) ? 0 : 1;
     if (oldIndexOffset != m_indexOffset) {
         setChanged(Changes::StructureChanged);
     }

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.cpp
@@ -210,22 +210,10 @@ void babelwires::ContentsCache::setFeatures(const Feature* inputFeature, const F
     }
     setChanged(Changes::StructureChanged);
     updateModifierFlags();
-    setIndexOffset();
 }
 
 void babelwires::ContentsCache::updateModifierCache() {
     updateModifierFlags();
-    setIndexOffset();
-}
-
-void babelwires::ContentsCache::setIndexOffset() {
-    const int oldIndexOffset = m_indexOffset;
-    const ContentsCacheEntry& rootEntry = m_rows[0];
-    const babelwires::Feature* const rootFeature = rootEntry.getInputThenOutputFeature();
-    m_indexOffset = 0; // (rootEntry.hasFailedHiddenModifiers() || rootFeature->as<const babelwires::FileFeature>()) ? 0 : 1;
-    if (oldIndexOffset != m_indexOffset) {
-        setChanged(Changes::StructureChanged);
-    }
 }
 
 void babelwires::ContentsCache::updateModifierFlags() {
@@ -344,26 +332,25 @@ void babelwires::ContentsCache::updateModifierFlags() {
 }
 
 const babelwires::ContentsCacheEntry* babelwires::ContentsCache::getEntry(int i) const {
-    const int adjustedI = i + m_indexOffset;
-    if ((0 <= adjustedI) && (adjustedI < m_rows.size())) {
-        return &m_rows[adjustedI];
+    if ((0 <= i) && (i < m_rows.size())) {
+        return &m_rows[i];
     }
     // TODO This is defensive. Is this necessary?
     return nullptr;
 }
 
 int babelwires::ContentsCache::getNumRows() const {
-    return m_rows.size() - m_indexOffset;
+    return m_rows.size();
 }
 
 int babelwires::ContentsCache::getIndexOfPath(bool seekInputFeature, const FeaturePath& path) const {
-    for (int i = m_indexOffset; i < m_rows.size(); ++i) {
+    for (int i = 0; i < m_rows.size(); ++i) {
         const ContentsCacheEntry& entry = m_rows[i];
         if ((seekInputFeature && !entry.m_inputFeature) || (!seekInputFeature && !entry.m_outputFeature)) {
             continue;
         }
         if (path == m_rows[i].m_path) {
-            return i - m_indexOffset;
+            return i;
         }
     }
     return -1;

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
@@ -109,7 +109,7 @@ namespace babelwires {
         ContentsCache(EditTree& edits);
 
         /// Build the cache with the given input and output features.
-        void setFeatures(const Feature* inputFeature, const Feature* outputFeature);
+        void setFeatures(std::string rootName, const Feature* inputFeature, const Feature* outputFeature);
 
         /// Update the part of the cache concerning modifiers.
         void updateModifierCache();

--- a/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
+++ b/BabelWiresLib/Project/FeatureElements/contentsCache.hpp
@@ -140,9 +140,6 @@ namespace babelwires {
         void clearChanges();
 
       private:
-        /// Determine whether the root is visible and set the indexOffset accordingly.
-        void setIndexOffset();
-
         /// Set flags recording a change.
         void setChanged(Changes changes);
 
@@ -157,9 +154,6 @@ namespace babelwires {
         /// Non-const because the cache builder can encounter features whose style states that they are not collapsable
         /// (i.e. that they are expanded without required an edit) and we have to update the edit tree with that fact.
         EditTree& m_edits;
-
-        /// We hide the roots unless necessary (root is a file or there are hidden failed modifiers)
-        int m_indexOffset = 0;
 
         Changes m_changes;
     };

--- a/BabelWiresLib/Project/FeatureElements/featureElement.hpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElement.hpp
@@ -25,7 +25,6 @@ namespace babelwires {
     struct ModifierData;
     class ConnectionModifier;
     struct ElementData;
-    class RecordFeature;
     class FeaturePath;
     struct UiPosition;
     struct UiSize;

--- a/BabelWiresLib/Project/FeatureElements/featureElementData.cpp
+++ b/BabelWiresLib/Project/FeatureElements/featureElementData.cpp
@@ -7,7 +7,6 @@
  **/
 #include <BabelWiresLib/Project/FeatureElements/featureElementData.hpp>
 
-#include <BabelWiresLib/Features/recordFeature.hpp>
 #include <BabelWiresLib/Processors/processor.hpp>
 #include <BabelWiresLib/Processors/processorFactory.hpp>
 #include <BabelWiresLib/Processors/processorFactoryRegistry.hpp>

--- a/BabelWiresLib/Project/Modifiers/connectionModifierData.cpp
+++ b/BabelWiresLib/Project/Modifiers/connectionModifierData.cpp
@@ -9,7 +9,6 @@
 
 #include <BabelWiresLib/Features/Utilities/modelUtilities.hpp>
 #include <BabelWiresLib/Features/modelExceptions.hpp>
-#include <BabelWiresLib/Features/recordFeature.hpp>
 #include <BabelWiresLib/Features/rootFeature.hpp>
 #include <BabelWiresLib/Features/valueFeature.hpp>
 #include <BabelWiresLib/Project/FeatureElements/featureElement.hpp>

--- a/BabelWiresLib/Project/project.hpp
+++ b/BabelWiresLib/Project/project.hpp
@@ -22,7 +22,6 @@ namespace babelwires {
 
 namespace babelwires {
 
-    class RecordFeature;
     class TargetFileFormatRegistry;
     class SourceFileFormatRegistry;
     class ProcessorFactoryRegistry;

--- a/BabelWiresLib/Types/FailedType/failedType.hpp
+++ b/BabelWiresLib/Types/FailedType/failedType.hpp
@@ -1,0 +1,28 @@
+/**
+ * A type which can stand in when a type or element fails to resolve.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/Types/Record/recordType.hpp>
+
+#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+
+namespace babelwires {
+
+    /// A type which can stand in when a type or element fails to resolve.
+    /// For now, just implement as an empty record.
+    /// TODO: Probably should have values which carry a string.
+    class FailedType : public RecordType {
+      public:
+        PRIMITIVE_TYPE("failed", "Failed", "d58040ff-00dc-4f25-a9a7-17c54b56d57d", 1);
+
+        FailedType() : RecordType({}) {}
+
+        std::string getKind() const override { return "Failed"; }
+    };
+
+}

--- a/BabelWiresLib/Types/Failure/failureType.hpp
+++ b/BabelWiresLib/Types/Failure/failureType.hpp
@@ -15,12 +15,11 @@ namespace babelwires {
 
     /// A type which can stand in when a type or element fails to resolve.
     /// For now, just implement as an empty record.
-    /// TODO: Probably should have values which carry a string.
-    class FailedType : public RecordType {
+    class FailureType : public RecordType {
       public:
         PRIMITIVE_TYPE("failed", "Failed", "d58040ff-00dc-4f25-a9a7-17c54b56d57d", 1);
 
-        FailedType() : RecordType({}) {}
+        FailureType() : RecordType({}) {}
 
         std::string getKind() const override { return "Failed"; }
     };

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -19,6 +19,7 @@
 #include <BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp>
 #include <BabelWiresLib/Types/String/stringType.hpp>
 #include <BabelWiresLib/Types/Sum/sumTypeConstructor.hpp>
+#include <BabelWiresLib/Types/FailedType/failedType.hpp>
 
 /*
 // TODO Remove
@@ -33,6 +34,7 @@ void babelwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<StringType>();
     context.m_typeSystem.addEntry<DefaultRationalType>();
     context.m_typeSystem.addEntry<MapEntryFallbackKind>();
+    context.m_typeSystem.addEntry<FailedType>();
     context.m_typeSystem.addTypeConstructor<AddBlankToEnum>();
     context.m_typeSystem.addTypeConstructor<IntTypeConstructor>();
     context.m_typeSystem.addTypeConstructor<RationalTypeConstructor>();

--- a/BabelWiresLib/libRegistration.cpp
+++ b/BabelWiresLib/libRegistration.cpp
@@ -19,7 +19,7 @@
 #include <BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp>
 #include <BabelWiresLib/Types/String/stringType.hpp>
 #include <BabelWiresLib/Types/Sum/sumTypeConstructor.hpp>
-#include <BabelWiresLib/Types/FailedType/failedType.hpp>
+#include <BabelWiresLib/Types/Failure/failureType.hpp>
 
 /*
 // TODO Remove
@@ -34,7 +34,7 @@ void babelwires::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<StringType>();
     context.m_typeSystem.addEntry<DefaultRationalType>();
     context.m_typeSystem.addEntry<MapEntryFallbackKind>();
-    context.m_typeSystem.addEntry<FailedType>();
+    context.m_typeSystem.addEntry<FailureType>();
     context.m_typeSystem.addTypeConstructor<AddBlankToEnum>();
     context.m_typeSystem.addTypeConstructor<IntTypeConstructor>();
     context.m_typeSystem.addTypeConstructor<RationalTypeConstructor>();

--- a/Tests/BabelWiresLib/TestUtils/testArrayType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testArrayType.cpp
@@ -21,9 +21,7 @@ testUtils::TestArrayElementData::TestArrayElementData()
     : babelwires::ValueElementData(TestSimpleArrayType::getThisIdentifier()) {}
 
 babelwires::FeaturePath testUtils::TestArrayElementData::getPathToArray() {
-    babelwires::FeaturePath pathToArray;
-    pathToArray.pushStep(babelwires::PathStep(babelwires::ValueElement::getStepToValue()));
-    return pathToArray;
+    return babelwires::FeaturePath();
 }
 
 

--- a/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
@@ -140,7 +140,8 @@ babelwires::FeaturePath testUtils::TestComplexRecordElementData::getPathToRecord
 
 testUtils::TestComplexRecordTypeFeatureInfo::TestComplexRecordTypeFeatureInfo(
     const babelwires::ValueFeature& testRecord)
-    : m_intFeature(testRecord.getChildFromStep(babelwires::PathStep(testUtils::TestComplexRecordType::getInt0Id()))
+    : m_record(testRecord)
+    , m_intFeature(testRecord.getChildFromStep(babelwires::PathStep(testUtils::TestComplexRecordType::getInt0Id()))
                        .is<babelwires::ValueFeature>())
     , m_arrayFeature(testRecord.getChildFromStep(babelwires::PathStep(testUtils::TestComplexRecordType::getArrayId()))
                          .is<babelwires::ValueFeature>())

--- a/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
@@ -63,9 +63,7 @@ testUtils::TestSimpleRecordElementData::TestSimpleRecordElementData()
     : babelwires::ValueElementData(TestSimpleRecordType::getThisIdentifier()) {}
 
 babelwires::FeaturePath testUtils::TestSimpleRecordElementData::getPathToRecord() {
-    babelwires::FeaturePath path;
-    path.pushStep(babelwires::PathStep(babelwires::ValueElement::getStepToValue()));
-    return path;
+    return babelwires::FeaturePath();
 }
 
 babelwires::FeaturePath testUtils::TestSimpleRecordElementData::getPathToRecordInt0() {
@@ -78,9 +76,7 @@ testUtils::TestComplexRecordElementData::TestComplexRecordElementData()
     : babelwires::ValueElementData(TestComplexRecordType::getThisIdentifier()) {}
 
 babelwires::FeaturePath testUtils::TestComplexRecordElementData::getPathToRecord() {
-    babelwires::FeaturePath path;
-    path.pushStep(babelwires::PathStep(babelwires::ValueElement::getStepToValue()));
-    return path;
+    return babelwires::FeaturePath();
 }
 
 babelwires::FeaturePath testUtils::TestComplexRecordElementData::getPathToRecordInt0() {

--- a/Tests/BabelWiresLib/TestUtils/testRecordType.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordType.hpp
@@ -108,6 +108,7 @@ namespace testUtils {
     /// without using the Instance system.
     // Currently not all features are represented.
     struct TestComplexRecordTypeFeatureInfo {
+        const babelwires::ValueFeature& m_record;
         const babelwires::ValueFeature& m_intFeature;
         const babelwires::ValueFeature& m_subRecordFeature;
         const babelwires::ValueFeature& m_subRecordIntFeature;

--- a/Tests/BabelWiresLib/TestUtils/testRecordWithVariantsType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordWithVariantsType.cpp
@@ -65,24 +65,21 @@ testUtils::TestRecordWithVariantsElementData::TestRecordWithVariantsElementData(
     : ValueElementData(testUtils::TestRecordWithVariantsType::getThisIdentifier()) {}
 
 babelwires::FeaturePath testUtils::TestRecordWithVariantsElementData::getPathToRecordWithVariants() {
-    return std::vector<babelwires::PathStep>{babelwires::PathStep(babelwires::ValueElement::getStepToValue())};
+    return babelwires::FeaturePath();
 }
 
 const babelwires::FeaturePath testUtils::TestRecordWithVariantsElementData::getPathToFieldA0() {
     return std::vector<babelwires::PathStep>{
-        babelwires::PathStep(babelwires::ValueElement::getStepToValue()),
         babelwires::PathStep(testUtils::TestRecordWithVariantsType::getFieldA0Id())};
 }
 
 const babelwires::FeaturePath testUtils::TestRecordWithVariantsElementData::getPathToFieldA1_Int0() {
     return std::vector<babelwires::PathStep>{
-        babelwires::PathStep(babelwires::ValueElement::getStepToValue()),
         babelwires::PathStep(testUtils::TestRecordWithVariantsType::getFieldA1Id()),
         babelwires::PathStep(testUtils::TestSimpleRecordType::getInt0Id())};
 }
 
 const babelwires::FeaturePath testUtils::TestRecordWithVariantsElementData::getPathToFieldAB() {
     return std::vector<babelwires::PathStep>{
-        babelwires::PathStep(babelwires::ValueElement::getStepToValue()),
         babelwires::PathStep(testUtils::TestRecordWithVariantsType::getFieldABId())};
 }

--- a/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
@@ -22,14 +22,12 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     const babelwires::ValueElement* const element =
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);
-    const babelwires::RootFeature* const inputFeature = element->getInputFeature()->as<babelwires::RootFeature>();
-    ASSERT_NE(inputFeature, nullptr);
 
-    const babelwires::ValueFeature* const valueFeature = inputFeature->getFeature(0)->as<babelwires::ValueFeature>();
+    const babelwires::ValueFeature* const valueFeature = element->getInputFeature()->as<babelwires::ValueFeature>();
+    ASSERT_NE(valueFeature, nullptr);
     const testUtils::TestComplexRecordType* const type = valueFeature->getType().as<testUtils::TestComplexRecordType>();
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::ActivateOptionalCommand command("Test command", elementId, pathToValue,
                                                 testUtils::TestComplexRecordType::getOpRecId());
@@ -104,8 +102,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
         babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
@@ -127,8 +124,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     opId.setDiscriminator(1);
 
     // Subrecord is a TestSimpleRecordType and has no optionals.
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::ActivateOptionalCommand command(
         "Test command", elementId, pathToValue, opId);
@@ -145,13 +141,10 @@ TEST(ActivateOptionalsCommandTest, failSafelyAlreadyActivated) {
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
-    auto* const inputFeature = element->getInputFeatureNonConst(pathToValue)->as<babelwires::RootFeature>();
-    ASSERT_NE(inputFeature, nullptr);
-
-    auto* const inputRecord = inputFeature->getFeature(0)->as<babelwires::ValueFeature>();
+    auto* const inputRecord = element->getInputFeatureNonConst(pathToValue)->as<babelwires::ValueFeature>();
+    ASSERT_NE(inputRecord, nullptr);
 
     // Active the optional first.
     testUtils::TestComplexRecordType::Instance instance{*inputRecord};

--- a/Tests/BabelWiresLib/addEntryToArrayCommandTest.cpp
+++ b/Tests/BabelWiresLib/addEntryToArrayCommandTest.cpp
@@ -23,8 +23,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtIndex) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [element](bool isCommandExecuted) {
@@ -75,8 +74,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtEnd) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [element](bool isCommandExecuted) {
@@ -137,8 +135,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoPriorModifier) {
     testEnvironment.m_project.process();
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [element](bool isCommandExecuted) {
@@ -207,8 +204,7 @@ TEST(AddEntryToArrayCommandTest, failSafelyOutOfRange) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     ASSERT_NE(getArrayFeature(), nullptr);
@@ -250,8 +246,7 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoWithValues) {
         ASSERT_NE(element, nullptr);
 
         const auto getArrayFeature = [element]() {
-            auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-            return root->getFeature(0)->as<babelwires::ValueFeature>();
+            return element->getInputFeature()->as<babelwires::ValueFeature>();
         };
 
         ASSERT_NE(getArrayFeature(), nullptr);

--- a/Tests/BabelWiresLib/contentsCacheTest.cpp
+++ b/Tests/BabelWiresLib/contentsCacheTest.cpp
@@ -53,8 +53,8 @@ namespace {
         } else {
             EXPECT_FALSE(entry->getOutputFeature());
         }
-        // EXPECT_FALSE(entry->isExpandable());
-        // EXPECT_TRUE(entry->isExpanded());
+        EXPECT_TRUE(entry->isExpandable());
+        EXPECT_TRUE(entry->isExpanded());
     }
 
 
@@ -413,6 +413,7 @@ TEST(ContentsCacheTest, inputFeatureOnly) {
     babelwires::SimpleValueFeature inputFeature(testEnvironment.m_typeSystem,
                                                 testUtils::TestComplexRecordType::getThisIdentifier());
     inputFeature.setToDefault();
+    editTree.setExpanded(babelwires::FeaturePath(), true);
 
     testCommonBehaviour(cache, editTree, &inputFeature, nullptr);
     testModifierBehaviour(testEnvironment.m_projectContext, cache, editTree, &inputFeature, nullptr);
@@ -427,6 +428,7 @@ TEST(ContentsCacheTest, outputFeatureOnly) {
     babelwires::SimpleValueFeature outputFeature(testEnvironment.m_typeSystem,
                                                  testUtils::TestComplexRecordType::getThisIdentifier());
     outputFeature.setToDefault();
+    editTree.setExpanded(babelwires::FeaturePath(), true);
 
     testCommonBehaviour(cache, editTree, nullptr, &outputFeature);
 }
@@ -443,6 +445,7 @@ TEST(ContentsCacheTest, inputAndOutputFeature) {
                                                  testUtils::TestComplexRecordType::getThisIdentifier());
     inputFeature.setToDefault();
     outputFeature.setToDefault();
+    editTree.setExpanded(babelwires::FeaturePath(), true);
 
     testCommonBehaviour(cache, editTree, &inputFeature, &outputFeature);
     testModifierBehaviour(testEnvironment.m_projectContext, cache, editTree, &inputFeature, &outputFeature);
@@ -461,6 +464,7 @@ TEST(ContentsCacheTest, inputAndOutputDifferentFeatures) {
 
     inputFeature.setToDefault();
     outputFeature.setToDefault();
+    editTree.setExpanded(babelwires::FeaturePath(), true);
 
     testUtils::TestComplexRecordTypeFeatureInfo inputInfo(inputFeature);
     testUtils::TestComplexRecordTypeFeatureInfo outputInfo(outputFeature);
@@ -524,6 +528,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
 
     inputFeature.setToDefault();
     outputFeature.setToDefault();
+    editTree.setExpanded(babelwires::FeaturePath(), true);
 
     cache.setFeatures("Test", &inputFeature, &outputFeature);
     ASSERT_EQ(cache.getNumRows(), 6);
@@ -551,8 +556,8 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
         EXPECT_EQ(entry->getInputFeature(), &inputFeature);
         EXPECT_EQ(entry->getOutputFeature(), &outputFeature);
         EXPECT_EQ(entry->getPath(), babelwires::FeaturePath());
-        EXPECT_FALSE(entry->isExpandable());
-        EXPECT_FALSE(entry->isExpanded());
+        EXPECT_TRUE(entry->isExpandable());
+        EXPECT_TRUE(entry->isExpanded());
         EXPECT_FALSE(entry->hasModifier());
         EXPECT_TRUE(entry->hasSubmodifiers());
         EXPECT_FALSE(entry->hasFailedModifier());

--- a/Tests/BabelWiresLib/contentsCacheTest.cpp
+++ b/Tests/BabelWiresLib/contentsCacheTest.cpp
@@ -186,7 +186,7 @@ namespace {
 
     void testCommonBehaviour(babelwires::ContentsCache& cache, babelwires::EditTree& editTree,
                              babelwires::ValueFeature* inputFeature, babelwires::ValueFeature* outputFeature) {
-        cache.setFeatures(inputFeature, outputFeature);
+        cache.setFeatures("Test", inputFeature, outputFeature);
         ASSERT_EQ(cache.getNumRows(), 6);
         auto inputInfo =
             inputFeature ? std::make_unique<testUtils::TestComplexRecordTypeFeatureInfo>(*inputFeature) : nullptr;
@@ -215,7 +215,7 @@ namespace {
         }
         // Expand the record
         editTree.setExpanded(info->m_pathToSubRecord, true);
-        cache.setFeatures(inputFeature, outputFeature);
+        cache.setFeatures("Test", inputFeature, outputFeature);
         ASSERT_EQ(cache.getNumRows(), 8);
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
@@ -244,7 +244,7 @@ namespace {
         }
         // Expand the array
         editTree.setExpanded(info->m_pathToArray, true);
-        cache.setFeatures(inputFeature, outputFeature);
+        cache.setFeatures("Test", inputFeature, outputFeature);
         ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_defaultSize);
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
@@ -365,7 +365,7 @@ namespace {
 
         // Collapse the array
         editTree.setExpanded(info->m_pathToArray, false);
-        cache.setFeatures(inputFeature, outputFeature);
+        cache.setFeatures("Test", inputFeature, outputFeature);
         ASSERT_EQ(cache.getNumRows(), 8);
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
@@ -468,15 +468,15 @@ TEST(ContentsCacheTest, inputAndOutputDifferentFeatures) {
     testUtils::TestComplexRecordType::Instance output(outputFeature);
     output.getarray().setSize(testUtils::TestSimpleArrayType::s_nonDefaultSize);
 
-    cache.setFeatures(&inputFeature, &outputFeature);
+    cache.setFeatures("Test", &inputFeature, &outputFeature);
     ASSERT_EQ(cache.getNumRows(), 6);
 
     editTree.setExpanded(inputInfo.m_pathToSubRecord, true);
-    cache.setFeatures(&inputFeature, &outputFeature);
+    cache.setFeatures("Test", &inputFeature, &outputFeature);
     ASSERT_EQ(cache.getNumRows(), 8);
 
     editTree.setExpanded(inputInfo.m_pathToArray, true);
-    cache.setFeatures(&inputFeature, &outputFeature);
+    cache.setFeatures("Test", &inputFeature, &outputFeature);
     ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_nonDefaultSize);
 
     {
@@ -525,7 +525,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
     inputFeature.setToDefault();
     outputFeature.setToDefault();
 
-    cache.setFeatures(&inputFeature, &outputFeature);
+    cache.setFeatures("Test", &inputFeature, &outputFeature);
     ASSERT_EQ(cache.getNumRows(), 6);
 
     // Adding a hidden failed modifier whose parent is logically the root requires us to present
@@ -547,7 +547,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
 
     {
         const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
-        EXPECT_EQ(entry->getLabel(), "Root");
+        EXPECT_EQ(entry->getLabel(), "Test");
         EXPECT_EQ(entry->getInputFeature(), &inputFeature);
         EXPECT_EQ(entry->getOutputFeature(), &outputFeature);
         EXPECT_EQ(entry->getPath(), babelwires::FeaturePath());
@@ -601,7 +601,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
 namespace {
     void checkFileRootEntry(const babelwires::ContentsCacheEntry* entry, testUtils::TestFileFeature* inputFeature,
                             testUtils::TestFileFeature* outputFeature) {
-        EXPECT_EQ(entry->getLabel(), "File");
+        EXPECT_EQ(entry->getLabel(), "Test");
         if (inputFeature) {
             EXPECT_EQ(entry->getInputFeature(), inputFeature);
         } else {
@@ -696,7 +696,7 @@ TEST(ContentsCacheTest, inputFileFeatureOnly) {
     testUtils::TestFileFeature inputFeature(testEnvironment.m_projectContext);
     inputFeature.setToDefault();
 
-    cache.setFeatures(&inputFeature, nullptr);
+    cache.setFeatures("Test", &inputFeature, nullptr);
     testFileCommonBehaviour(cache, editTree, &inputFeature, nullptr);
     testModifierBehaviour(testEnvironment.m_projectContext, cache, editTree, &inputFeature, nullptr);
 }
@@ -710,7 +710,7 @@ TEST(ContentsCacheTest, outputFileFeatureOnly) {
     testUtils::TestFileFeature outputFeature(testEnvironment.m_projectContext);
     outputFeature.setToDefault();
 
-    cache.setFeatures(nullptr, &outputFeature);
+    cache.setFeatures("Test", nullptr, &outputFeature);
     testFileCommonBehaviour(cache, editTree, nullptr, &outputFeature);
 }
 
@@ -725,7 +725,7 @@ TEST(ContentsCacheTest, inputAndOutputFileFeature) {
     inputFeature.setToDefault();
     outputFeature.setToDefault();
 
-    cache.setFeatures(&inputFeature, &outputFeature);
+    cache.setFeatures("Test", &inputFeature, &outputFeature);
     testFileCommonBehaviour(cache, editTree, &inputFeature, &outputFeature);
     testModifierBehaviour(testEnvironment.m_projectContext, cache, editTree, &inputFeature, &outputFeature);
 }
@@ -763,7 +763,7 @@ TEST(ContentsCacheTest, style) {
 
     TestRecordWithChildStyles record(testEnvironment.m_projectContext);
     // Handling of style should be unaffected by input / output features.
-    cache.setFeatures(&record, nullptr);
+    cache.setFeatures("Test", &record, nullptr);
 
     EXPECT_EQ(cache.getNumRows(), 7);
     EXPECT_EQ(cache.getEntry(0)->getIndent(), 0);
@@ -785,7 +785,7 @@ TEST(ContentsCacheTest, style) {
     editTree.setExpanded(cache.getEntry(3)->getPath(), true);
     editTree.setExpanded(cache.getEntry(4)->getPath(), true);
 
-    cache.setFeatures(&record, nullptr);
+    cache.setFeatures("Test", &record, nullptr);
 
     EXPECT_EQ(cache.getNumRows(), 8);
     EXPECT_EQ(cache.getEntry(0)->getIndent(), 0);

--- a/Tests/BabelWiresLib/contentsCacheTest.cpp
+++ b/Tests/BabelWiresLib/contentsCacheTest.cpp
@@ -37,6 +37,27 @@ namespace {
         return modPtr;
     }
 
+    void checkRootEntry(const babelwires::ContentsCacheEntry* entry,
+                            testUtils::TestComplexRecordTypeFeatureInfo* inputInfo,
+                            testUtils::TestComplexRecordTypeFeatureInfo* outputInfo) {
+        // TODO EXPECT_EQ(entry->getLabel(), ...);
+        if (inputInfo) {
+            EXPECT_EQ(entry->getInputFeature(), &inputInfo->m_record);
+            EXPECT_EQ(entry->getPath(), inputInfo->m_pathToRecord);
+        } else {
+            EXPECT_FALSE(entry->getInputFeature());
+        }
+        if (outputInfo) {
+            EXPECT_EQ(entry->getOutputFeature(), &outputInfo->m_record);
+            EXPECT_EQ(entry->getPath(), outputInfo->m_pathToRecord);
+        } else {
+            EXPECT_FALSE(entry->getOutputFeature());
+        }
+        // EXPECT_FALSE(entry->isExpandable());
+        // EXPECT_TRUE(entry->isExpanded());
+    }
+
+
     void checkFirstIntEntry(const babelwires::ContentsCacheEntry* entry,
                             testUtils::TestComplexRecordTypeFeatureInfo* inputInfo,
                             testUtils::TestComplexRecordTypeFeatureInfo* outputInfo) {
@@ -166,7 +187,7 @@ namespace {
     void testCommonBehaviour(babelwires::ContentsCache& cache, babelwires::EditTree& editTree,
                              babelwires::ValueFeature* inputFeature, babelwires::ValueFeature* outputFeature) {
         cache.setFeatures(inputFeature, outputFeature);
-        ASSERT_EQ(cache.getNumRows(), 5);
+        ASSERT_EQ(cache.getNumRows(), 6);
         auto inputInfo =
             inputFeature ? std::make_unique<testUtils::TestComplexRecordTypeFeatureInfo>(*inputFeature) : nullptr;
         auto outputInfo =
@@ -174,74 +195,89 @@ namespace {
         auto info = inputInfo ? inputInfo.get() : outputInfo.get();
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
-            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
+            checkRootEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
+            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
+            checkUnmodified(entry);
+        }
+        {
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(2);
             checkSubRecordEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(4);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(5);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         // Expand the record
         editTree.setExpanded(info->m_pathToSubRecord, true);
         cache.setFeatures(inputFeature, outputFeature);
-        ASSERT_EQ(cache.getNumRows(), 7);
+        ASSERT_EQ(cache.getNumRows(), 8);
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
-            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
+            checkRootEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
-            checkSubRecordEntry(entry, inputInfo.get(), outputInfo.get());
+            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(2);
+            checkSubRecordEntry(entry, inputInfo.get(), outputInfo.get());
+            checkUnmodified(entry);
+        }
+        {
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(3);
             checkSubRecordIntEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         // Expand the array
         editTree.setExpanded(info->m_pathToArray, true);
         cache.setFeatures(inputFeature, outputFeature);
-        ASSERT_EQ(cache.getNumRows(), 7 + testUtils::TestSimpleArrayType::s_defaultSize);
+        ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_defaultSize);
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
-            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
+            checkRootEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
-            checkSubRecordEntry(entry, inputInfo.get(), outputInfo.get());
+            checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
             const babelwires::ContentsCacheEntry* const entry = cache.getEntry(2);
+            checkSubRecordEntry(entry, inputInfo.get(), outputInfo.get());
+            checkUnmodified(entry);
+        }
+        {
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(3);
             checkSubRecordIntEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(8);
             checkFirstArrayEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(8);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(9);
             checkSecondArrayEntry(entry, inputInfo.get(), outputInfo.get());
             checkUnmodified(entry);
         }
@@ -262,12 +298,12 @@ namespace {
         editTree.addModifier(createIntModifier(info->m_pathToInt));
         cache.updateModifierCache();
 
-        ASSERT_EQ(cache.getNumRows(), 7 + testUtils::TestSimpleArrayType::s_defaultSize);
-        for (int i = 1; i < 7 + testUtils::TestSimpleArrayType::s_defaultSize; ++i) {
+        ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_defaultSize);
+        for (int i = 2; i < 8 + testUtils::TestSimpleArrayType::s_defaultSize; ++i) {
             checkUnmodified(cache.getEntry(i));
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
             checkFirstIntEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_TRUE(entry->hasModifier());
             EXPECT_FALSE(entry->hasFailedModifier());
@@ -278,9 +314,9 @@ namespace {
         // Add a submodifier to the array
         editTree.addModifier(createIntModifier(info->m_pathToElem1));
         cache.updateModifierCache();
-        ASSERT_EQ(cache.getNumRows(), 7 + testUtils::TestSimpleArrayType::s_defaultSize);
+        ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_defaultSize);
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_FALSE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -288,9 +324,9 @@ namespace {
             EXPECT_FALSE(entry->hasHiddenModifier());
             EXPECT_FALSE(entry->hasFailedHiddenModifiers());
         }
-        checkUnmodified(cache.getEntry(7));
+        checkUnmodified(cache.getEntry(8));
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(8);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(9);
             checkSecondArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_TRUE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -298,7 +334,7 @@ namespace {
             EXPECT_FALSE(entry->hasHiddenModifier());
             EXPECT_FALSE(entry->hasFailedHiddenModifiers());
         }
-        checkUnmodified(cache.getEntry(9));
+        checkUnmodified(cache.getEntry(10));
         // Add a failing modifier to the array
         {
             testUtils::TestFeatureElement owner(context);
@@ -307,9 +343,9 @@ namespace {
             editTree.addModifier(std::move(modifier));
         }
         cache.updateModifierCache();
-        ASSERT_EQ(cache.getNumRows(), 7 + testUtils::TestSimpleArrayType::s_defaultSize);
+        ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_defaultSize);
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_FALSE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -318,7 +354,7 @@ namespace {
             EXPECT_FALSE(entry->hasFailedHiddenModifiers());
         }
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(8);
             checkFirstArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_TRUE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -330,9 +366,9 @@ namespace {
         // Collapse the array
         editTree.setExpanded(info->m_pathToArray, false);
         cache.setFeatures(inputFeature, outputFeature);
-        ASSERT_EQ(cache.getNumRows(), 7);
+        ASSERT_EQ(cache.getNumRows(), 8);
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_FALSE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -343,9 +379,9 @@ namespace {
         // Remove the failing modifier
         editTree.removeModifier(editTree.findModifier(info->m_pathToElem0));
         cache.updateModifierCache();
-        ASSERT_EQ(cache.getNumRows(), 7);
+        ASSERT_EQ(cache.getNumRows(), 8);
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_FALSE(entry->hasModifier());
             EXPECT_TRUE(entry->hasSubmodifiers());
@@ -355,9 +391,9 @@ namespace {
         }
         editTree.removeModifier(editTree.findModifier(info->m_pathToElem1));
         cache.updateModifierCache();
-        ASSERT_EQ(cache.getNumRows(), 7);
+        ASSERT_EQ(cache.getNumRows(), 8);
         {
-            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+            const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
             checkArrayEntry(entry, inputInfo.get(), outputInfo.get());
             EXPECT_FALSE(entry->hasModifier());
             EXPECT_FALSE(entry->hasSubmodifiers());
@@ -433,34 +469,39 @@ TEST(ContentsCacheTest, inputAndOutputDifferentFeatures) {
     output.getarray().setSize(testUtils::TestSimpleArrayType::s_nonDefaultSize);
 
     cache.setFeatures(&inputFeature, &outputFeature);
-    ASSERT_EQ(cache.getNumRows(), 5);
+    ASSERT_EQ(cache.getNumRows(), 6);
 
     editTree.setExpanded(inputInfo.m_pathToSubRecord, true);
     cache.setFeatures(&inputFeature, &outputFeature);
-    ASSERT_EQ(cache.getNumRows(), 7);
+    ASSERT_EQ(cache.getNumRows(), 8);
 
     editTree.setExpanded(inputInfo.m_pathToArray, true);
     cache.setFeatures(&inputFeature, &outputFeature);
-    ASSERT_EQ(cache.getNumRows(), 7 + testUtils::TestSimpleArrayType::s_nonDefaultSize);
+    ASSERT_EQ(cache.getNumRows(), 8 + testUtils::TestSimpleArrayType::s_nonDefaultSize);
 
     {
         const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
+        checkRootEntry(entry, &inputInfo, &outputInfo);
+        checkUnmodified(entry);
+    }
+    {
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
         checkFirstIntEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
     {
-        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(6);
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
         checkArrayEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
     {
-        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(7);
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(8);
         checkFirstArrayEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
     {
         const babelwires::ContentsCacheEntry* const entry =
-            cache.getEntry(7 + testUtils::TestSimpleArrayType::s_nonDefaultSize - 1);
+            cache.getEntry(8 + testUtils::TestSimpleArrayType::s_nonDefaultSize - 1);
         EXPECT_FALSE(entry->getInputFeature());
         EXPECT_EQ(entry->getOutputFeature(),
                   outputInfo.m_arrayFeature.getFeature(testUtils::TestSimpleArrayType::s_nonDefaultSize - 1));
@@ -485,7 +526,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
     outputFeature.setToDefault();
 
     cache.setFeatures(&inputFeature, &outputFeature);
-    ASSERT_EQ(cache.getNumRows(), 5);
+    ASSERT_EQ(cache.getNumRows(), 6);
 
     // Adding a hidden failed modifier whose parent is logically the root requires us to present
     // a root entry to the user, so the UI functionality for failed modifiers has somewhere to live.
@@ -501,7 +542,7 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
     cache.clearChanges();
     cache.updateModifierCache();
 
-    EXPECT_TRUE(cache.isChanged(babelwires::ContentsCache::Changes::StructureChanged));
+    EXPECT_FALSE(cache.isChanged(babelwires::ContentsCache::Changes::StructureChanged));
     EXPECT_EQ(cache.getNumRows(), 6);
 
     {
@@ -538,20 +579,20 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
     cache.clearChanges();
     cache.updateModifierCache();
 
-    EXPECT_TRUE(cache.isChanged(babelwires::ContentsCache::Changes::StructureChanged));
-    EXPECT_EQ(cache.getNumRows(), 5);
+    EXPECT_FALSE(cache.isChanged(babelwires::ContentsCache::Changes::StructureChanged));
+    EXPECT_EQ(cache.getNumRows(), 6);
     {
-        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(0);
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
         checkFirstIntEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
     {
-        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(1);
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(2);
         checkSubRecordEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
     {
-        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(4);
+        const babelwires::ContentsCacheEntry* const entry = cache.getEntry(5);
         checkArrayEntry(entry, &inputInfo, &outputInfo);
         checkUnmodified(entry);
     }
@@ -724,32 +765,34 @@ TEST(ContentsCacheTest, style) {
     // Handling of style should be unaffected by input / output features.
     cache.setFeatures(&record, nullptr);
 
-    EXPECT_EQ(cache.getNumRows(), 6);
+    EXPECT_EQ(cache.getNumRows(), 7);
     EXPECT_EQ(cache.getEntry(0)->getIndent(), 0);
-    EXPECT_EQ(cache.getEntry(1)->getIndent(), 1);
-    EXPECT_EQ(cache.getEntry(2)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(1)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(2)->getIndent(), 1);
     EXPECT_EQ(cache.getEntry(3)->getIndent(), 0);
     EXPECT_EQ(cache.getEntry(4)->getIndent(), 0);
     EXPECT_EQ(cache.getEntry(5)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(6)->getIndent(), 0);
 
     EXPECT_EQ(cache.getEntry(0)->isExpandable(), false);
     EXPECT_EQ(cache.getEntry(1)->isExpandable(), false);
-    EXPECT_EQ(cache.getEntry(2)->isExpandable(), true);
-    EXPECT_EQ(cache.getEntry(3)->isExpandable(), false);
+    EXPECT_EQ(cache.getEntry(2)->isExpandable(), false);
+    EXPECT_EQ(cache.getEntry(3)->isExpandable(), true);
     EXPECT_EQ(cache.getEntry(4)->isExpandable(), false);
-    EXPECT_EQ(cache.getEntry(5)->isExpandable(), true);
+    EXPECT_EQ(cache.getEntry(5)->isExpandable(), false);
+    EXPECT_EQ(cache.getEntry(6)->isExpandable(), true);
 
-    editTree.setExpanded(cache.getEntry(2)->getPath(), true);
-    editTree.setExpanded(cache.getEntry(5)->getPath(), true);
+    editTree.setExpanded(cache.getEntry(3)->getPath(), true);
+    editTree.setExpanded(cache.getEntry(4)->getPath(), true);
 
     cache.setFeatures(&record, nullptr);
 
     EXPECT_EQ(cache.getNumRows(), 8);
     EXPECT_EQ(cache.getEntry(0)->getIndent(), 0);
-    EXPECT_EQ(cache.getEntry(1)->getIndent(), 1);
-    EXPECT_EQ(cache.getEntry(2)->getIndent(), 0);
-    EXPECT_EQ(cache.getEntry(3)->getIndent(), 1);
-    EXPECT_EQ(cache.getEntry(4)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(1)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(2)->getIndent(), 1);
+    EXPECT_EQ(cache.getEntry(3)->getIndent(), 0);
+    EXPECT_EQ(cache.getEntry(4)->getIndent(), 1);
     EXPECT_EQ(cache.getEntry(5)->getIndent(), 0);
     EXPECT_EQ(cache.getEntry(6)->getIndent(), 0);
     EXPECT_EQ(cache.getEntry(7)->getIndent(), 0);

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -34,8 +34,7 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
         testEnvironment.m_project.getFeatureElement(targetId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::FeaturePath pathToOptional = pathToValue;
     pathToOptional.pushStep(babelwires::PathStep(testUtils::TestComplexRecordType::getOpRecId()));
@@ -67,9 +66,8 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
         testEnvironment.m_project.addModifier(targetId, outputConnection);
     }
 
-    const babelwires::RootFeature* const inputFeature = element->getInputFeature()->as<babelwires::RootFeature>();
-    ASSERT_NE(inputFeature, nullptr);
-    const babelwires::ValueFeature* const valueFeature = inputFeature->getFeature(0)->as<babelwires::ValueFeature>();
+    const babelwires::ValueFeature* const valueFeature = element->getInputFeature()->as<babelwires::ValueFeature>();
+    ASSERT_NE(valueFeature, nullptr);
     const testUtils::TestComplexRecordType* const type = valueFeature->getType().as<testUtils::TestComplexRecordType>();
 
     babelwires::DeactivateOptionalCommand command("Test command", elementId, pathToValue,
@@ -155,8 +153,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoOptional) {
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
         babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::ShortId opId("flerm");
     opId.setDiscriminator(1);
@@ -176,8 +173,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     opId.setDiscriminator(1);
 
     // Subrecord is a TestSimpleRecordType and has no optionals.
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::DeactivateOptionalCommand command(
         "Test command", elementId, pathToValue, opId);
@@ -191,8 +187,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
         babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::DeactivateOptionalCommand command(
         "Test command", elementId, pathToValue, testUtils::TestComplexRecordType::getOpIntId());

--- a/Tests/BabelWiresLib/featureElementTest.cpp
+++ b/Tests/BabelWiresLib/featureElementTest.cpp
@@ -126,10 +126,8 @@ TEST(FeatureElementTest, modifiers) {
                   71);
     }
 
-    const babelwires::Feature* const rootFeature = featureElement->getInputFeature();
-    ASSERT_TRUE(rootFeature);
     const auto* const testRecordFeature =
-        rootFeature->as<babelwires::CompoundFeature>()->getFeature(0)->as<babelwires::ValueFeature>();
+        featureElement->getInputFeature()->as<babelwires::ValueFeature>();
     ASSERT_TRUE(testRecordFeature);
 
     testUtils::TestComplexRecordType::ConstInstance testRecord(*testRecordFeature);

--- a/Tests/BabelWiresLib/featurePathTest.cpp
+++ b/Tests/BabelWiresLib/featurePathTest.cpp
@@ -2,7 +2,6 @@
 
 #include <BabelWiresLib/Features/Path/featurePath.hpp>
 #include <BabelWiresLib/Features/modelExceptions.hpp>
-#include <BabelWiresLib/Features/recordFeature.hpp>
 #include <BabelWiresLib/Features/simpleValueFeature.hpp>
 #include <BabelWiresLib/Types/Int/intFeature.hpp>
 

--- a/Tests/BabelWiresLib/modifierTest.cpp
+++ b/Tests/BabelWiresLib/modifierTest.cpp
@@ -378,8 +378,7 @@ TEST(ModifierTest, connectionModifierApplicationFailure) {
     babelwires::ValueElementData elementData{testUtils::TestComplexRecordType::getThisIdentifier()};
 
     const babelwires::FeaturePath sourcePath{
-        std::vector<babelwires::PathStep>{babelwires::PathStep(babelwires::ValueElement::getStepToValue()),
-                                          babelwires::PathStep(testUtils::TestComplexRecordType::getSubrecordId()),
+        std::vector<babelwires::PathStep>{babelwires::PathStep(testUtils::TestComplexRecordType::getSubrecordId()),
                                           babelwires::PathStep(testUtils::TestSimpleRecordType::getInt0Id())}};
 
     babelwires::ValueAssignmentData sourceData(babelwires::IntValue(100));

--- a/Tests/BabelWiresLib/projectDataTest.cpp
+++ b/Tests/BabelWiresLib/projectDataTest.cpp
@@ -15,6 +15,7 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 TEST(ProjectDataTest, serialization) {
+    testUtils::TestLog log;
     std::string serializedContents;
     {
         testUtils::TestProjectData projectData;
@@ -26,7 +27,6 @@ TEST(ProjectDataTest, serialization) {
         serializedContents = std::move(os.str());
     }
 
-    testUtils::TestLog log;
     babelwires::AutomaticDeserializationRegistry deserializationReg;
     babelwires::XmlDeserializer deserializer(serializedContents, deserializationReg, log);
     auto dataPtr = deserializer.deserializeObject<babelwires::ProjectData>();

--- a/Tests/BabelWiresLib/projectObserverTest.cpp
+++ b/Tests/BabelWiresLib/projectObserverTest.cpp
@@ -280,10 +280,10 @@ namespace {
         // The connection we expect to observe.
         babelwires::ConnectionDescription connectionDescription(targetElementId, connectionData);
         if (!sourceRecordIsExpanded) {
-            connectionDescription.m_pathToSourceFeature.truncate(2);
+            connectionDescription.m_pathToSourceFeature.truncate(1);
         }
         if (!targetArrayIsExpanded) {
-            connectionDescription.m_pathToTargetFeature.truncate(2);
+            connectionDescription.m_pathToTargetFeature.truncate(1);
         }
 
         testEnvironment.m_project.addModifier(targetElementId, connectionData);
@@ -381,10 +381,10 @@ namespace {
         // The connection we expect to observe.
         babelwires::ConnectionDescription connectionDescription(targetElementId, connectionData);
         if (!sourceRecordIsExpanded) {
-            connectionDescription.m_pathToSourceFeature.truncate(2);
+            connectionDescription.m_pathToSourceFeature.truncate(1);
         }
         if (!targetArrayIsExpanded) {
-            connectionDescription.m_pathToTargetFeature.truncate(2);
+            connectionDescription.m_pathToTargetFeature.truncate(1);
         }
 
         testEnvironment.m_project.removeModifier(targetElementId, connectionData.m_pathToFeature);

--- a/Tests/BabelWiresLib/removeEntryFromArrayCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeEntryFromArrayCommandTest.cpp
@@ -54,8 +54,7 @@ TEST(RemoveEntryFromArrayCommandTest, executeAndUndoNonDefaultArray) {
     ASSERT_NE(targetElement, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [&testEnvironment, element, targetElement](bool isCommandExecuted) {
@@ -145,8 +144,7 @@ TEST(RemoveEntryFromArrayCommandTest, failSafelyOutOfRange) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     ASSERT_NE(getArrayFeature(), nullptr);

--- a/Tests/BabelWiresLib/removeModifierCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeModifierCommandTest.cpp
@@ -60,8 +60,7 @@ TEST(RemoveModifierCommandTest, executeAndUndoArray) {
     ASSERT_NE(targetElement, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [&testEnvironment, element, targetElement, pathToArrayEntry](bool isCommandExecuted) {
@@ -139,8 +138,7 @@ TEST(RemoveModifierCommandTest, executeAndUndoOptionals) {
         testEnvironment.m_project.getFeatureElement(targetId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);
 
-    const babelwires::FeaturePath pathToValue =
-        babelwires::FeaturePath({babelwires::PathStep(babelwires::ValueElement::getStepToValue())});
+    const babelwires::FeaturePath pathToValue;
 
     babelwires::FeaturePath pathToOptional = pathToValue;
     pathToOptional.pushStep(babelwires::PathStep(testUtils::TestComplexRecordType::getOpRecId()));
@@ -172,9 +170,8 @@ TEST(RemoveModifierCommandTest, executeAndUndoOptionals) {
         testEnvironment.m_project.addModifier(targetId, outputConnection);
     }
 
-    const babelwires::CompoundFeature* const inputFeature = element->getInputFeature()->as<babelwires::CompoundFeature>();
-    ASSERT_NE(inputFeature, nullptr);
-    const babelwires::ValueFeature* const valueFeature = inputFeature->getFeature(0)->as<babelwires::ValueFeature>();
+    const babelwires::ValueFeature* const valueFeature = element->getInputFeature()->as<babelwires::ValueFeature>();
+    ASSERT_NE(valueFeature, nullptr);
     const testUtils::TestComplexRecordType* const type = valueFeature->getType().as<testUtils::TestComplexRecordType>();
 
     babelwires::RemoveModifierCommand command("Test command", elementId, pathToValue);

--- a/Tests/BabelWiresLib/selectRecordVariantCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectRecordVariantCommandTest.cpp
@@ -35,8 +35,7 @@ TEST(SelectRecordVariantCommandTest, executeAndUndo) {
     ASSERT_NE(targetElement, nullptr);
 
     const auto getInputValueFeature = [element]() {
-        const auto* root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
     const auto getSelectedTag = [](const babelwires::ValueFeature* valueFeature) {
         const auto& type = valueFeature->getType().is<testUtils::TestRecordWithVariantsType>();

--- a/Tests/BabelWiresLib/setArraySizeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setArraySizeCommandTest.cpp
@@ -55,8 +55,7 @@ TEST(SetArraySizeCommandTest, executeAndUndoArrayGrow) {
     ASSERT_NE(targetElement, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [&testEnvironment, element, targetElement]() {
@@ -147,8 +146,7 @@ TEST(SetArraySizeCommandTest, executeAndUndoArrayShrink) {
     ASSERT_NE(targetElement, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [&testEnvironment, element, targetElement](bool isCommandExecuted) {
@@ -219,8 +217,7 @@ TEST(SetArraySizeCommandTest, executeAndUndoArrayNoPriorModifier) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     const auto checkModifiers = [&testEnvironment, element](bool isCommandExecuted) {
@@ -296,8 +293,7 @@ TEST(SetArraySizeCommandTest, failSafelyOutOfRange) {
     ASSERT_NE(element, nullptr);
 
     const auto getArrayFeature = [element]() {
-        auto root = element->getInputFeature()->as<babelwires::CompoundFeature>();
-        return root->getFeature(0)->as<babelwires::ValueFeature>();
+        return element->getInputFeature()->as<babelwires::ValueFeature>();
     };
 
     ASSERT_NE(getArrayFeature(), nullptr);

--- a/Tests/BabelWiresLib/valueElementTest.cpp
+++ b/Tests/BabelWiresLib/valueElementTest.cpp
@@ -18,7 +18,6 @@ TEST(ValueElementTest, simpleType) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueAssignmentData assignmentData(babelwires::EditableValueHolder::makeValue<babelwires::IntValue>(-4));
-    assignmentData.m_pathToFeature.pushStep(babelwires::PathStep("value"));
 
     babelwires::ValueElementData data(babelwires::DefaultIntType::getThisIdentifier());
     data.m_modifiers.emplace_back(assignmentData.clone());
@@ -42,16 +41,11 @@ TEST(ValueElementTest, simpleType) {
     ASSERT_NE(outputFeature, nullptr);
     EXPECT_EQ(inputFeature, outputFeature);
 
-    ASSERT_TRUE(inputFeature->as<babelwires::CompoundFeature>());
-    ASSERT_EQ(inputFeature->is<babelwires::CompoundFeature>().getNumFeatures(), 1);
+    const babelwires::ValueFeature* const valueFeature = inputFeature->as<babelwires::ValueFeature>();
+    ASSERT_TRUE(valueFeature);
 
-    const babelwires::Feature* const child = inputFeature->is<babelwires::CompoundFeature>().getFeature(0);
-    ASSERT_NE(child, nullptr);
-    const babelwires::ValueFeature* const childAsValue = child->as<babelwires::ValueFeature>();
-    ASSERT_NE(childAsValue, nullptr);
-
-    EXPECT_EQ(childAsValue->getTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
-    const babelwires::ValueHolder value = childAsValue->getValue();
+    EXPECT_EQ(valueFeature->getTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
+    const babelwires::ValueHolder value = valueFeature->getValue();
     const babelwires::IntValue* intValue = value->as<babelwires::IntValue>();
     ASSERT_NE(intValue, nullptr);
     EXPECT_EQ(intValue->get(), -4);


### PR DESCRIPTION
I want to delegate the feature system to just being wrappers for values. This PR allows ValueElements to hold values directly, without needing a root feature.

Additionally: The UI now shows the base feature of each element. This is necessary to allow the these roots to be wired to each other.

The UI of the root will need work after this change, but I'm prioritizing the goal of switching from features to values.
