### PR TITLE
Introduce FileTypeT

### DIFF
--- a/BabelWiresLib/Instance/instanceDSL.hpp
+++ b/BabelWiresLib/Instance/instanceDSL.hpp
@@ -15,90 +15,91 @@
 
 /// Start the declaration of an instance.
 #define DECLARE_INSTANCE_BEGIN(TYPE)                                                                                   \
-    template <typename VALUE_TREE_NODE> class InstanceImpl : public babelwires::InstanceParent<VALUE_TREE_NODE, TYPE> {    \
+    template <typename VALUE_TREE_NODE>                                                                                \
+    class InstanceImpl : public babelwires::InstanceParent<VALUE_TREE_NODE, TYPE> {                                    \
       public:                                                                                                          \
-        InstanceImpl(VALUE_TREE_NODE& valueFeature)                                                                      \
+        InstanceImpl(VALUE_TREE_NODE& valueFeature)                                                                    \
             : babelwires::InstanceParent<VALUE_TREE_NODE, TYPE>(valueFeature) {}
 
 /// Declare a (non-optional) field.
 #define DECLARE_INSTANCE_FIELD(FIELD_NAME, VALUE_TYPE)                                                                 \
     babelwires::ConstInstance<VALUE_TYPE> get##FIELD_NAME() const {                                                    \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::Instance<VALUE_TYPE>> get##FIELD_NAME() {          \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::Instance<VALUE_TYPE>> get##FIELD_NAME() {        \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }
 
 /// Declare an optional field.
 #define DECLARE_INSTANCE_FIELD_OPTIONAL(FIELD_NAME, VALUE_TYPE)                                                        \
     DECLARE_INSTANCE_FIELD(FIELD_NAME, VALUE_TYPE)                                                                     \
     std::optional<babelwires::ConstInstance<VALUE_TYPE>> tryGet##FIELD_NAME() const {                                  \
-        if (const babelwires::ValueTreeNode* valueTreeNode =                                                             \
-                babelwires::InstanceUtils::tryGetChild(this->m_valueTreeNode, #FIELD_NAME)) {                           \
-            return {*valueTreeNode};                                                                                    \
+        if (const babelwires::ValueTreeNode* valueTreeNode =                                                           \
+                babelwires::InstanceUtils::tryGetChild(this->m_valueTreeNode, #FIELD_NAME)) {                          \
+            return {*valueTreeNode};                                                                                   \
         } else {                                                                                                       \
             return {};                                                                                                 \
         }                                                                                                              \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::Instance<VALUE_TYPE>>                              \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::Instance<VALUE_TYPE>>                            \
         activateAndGet##FIELD_NAME() {                                                                                 \
-        return babelwires::InstanceUtils::activateAndGetChild(this->m_valueTreeNode, #FIELD_NAME);                      \
+        return babelwires::InstanceUtils::activateAndGetChild(this->m_valueTreeNode, #FIELD_NAME);                     \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, void> deactivate##FIELD_NAME() {                               \
-        return babelwires::InstanceUtils::deactivateChild(this->m_valueTreeNode, #FIELD_NAME);                          \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, void> deactivate##FIELD_NAME() {                             \
+        return babelwires::InstanceUtils::deactivateChild(this->m_valueTreeNode, #FIELD_NAME);                         \
     }
 
 /// Add convenience methods for specific tag.
 #define DECLARE_INSTANCE_VARIANT_TAG(TAG_NAME)                                                                         \
     bool isTag##TAG_NAME##Selected() const {                                                                           \
-        return babelwires::InstanceUtils::getSelectedTag(this->m_valueTreeNode) == #TAG_NAME;                           \
+        return babelwires::InstanceUtils::getSelectedTag(this->m_valueTreeNode) == #TAG_NAME;                          \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, void> selectTag##TAG_NAME() {                                  \
-        return babelwires::InstanceUtils::selectTag(this->m_valueTreeNode, #TAG_NAME);                                  \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, void> selectTag##TAG_NAME() {                                \
+        return babelwires::InstanceUtils::selectTag(this->m_valueTreeNode, #TAG_NAME);                                 \
     }
 
 /// Declare a (non-optional) array field.
 #define DECLARE_INSTANCE_ARRAY_FIELD(FIELD_NAME, ENTRY_TYPE)                                                           \
-    babelwires::ArrayInstanceImpl<const babelwires::ValueTreeNode, ENTRY_TYPE> get##FIELD_NAME() const {                \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+    babelwires::ArrayInstanceImpl<const babelwires::ValueTreeNode, ENTRY_TYPE> get##FIELD_NAME() const {               \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>,                                                                \
-                     babelwires::ArrayInstanceImpl<babelwires::ValueTreeNode, ENTRY_TYPE>>                              \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>,                                                              \
+                     babelwires::ArrayInstanceImpl<babelwires::ValueTreeNode, ENTRY_TYPE>>                             \
         get##FIELD_NAME() {                                                                                            \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }
 
 /// Declare a (non-optional) map field.
 #define DECLARE_INSTANCE_MAP_FIELD(FIELD_NAME, SOURCE_TYPE, TARGET_TYPE)                                               \
-    babelwires::MapInstanceImpl<const babelwires::ValueTreeNode, SOURCE_TYPE, TARGET_TYPE> get##FIELD_NAME() const {    \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+    babelwires::MapInstanceImpl<const babelwires::ValueTreeNode, SOURCE_TYPE, TARGET_TYPE> get##FIELD_NAME() const {   \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>,                                                                \
-                     babelwires::MapInstanceImpl<babelwires::ValueTreeNode, SOURCE_TYPE, TARGET_TYPE>>                  \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>,                                                              \
+                     babelwires::MapInstanceImpl<babelwires::ValueTreeNode, SOURCE_TYPE, TARGET_TYPE>>                 \
         get##FIELD_NAME() {                                                                                            \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }
 
 /// Declare a (non-optional) field whose value type is not expected to have an instance specialization.
 #define DECLARE_INSTANCE_GENERIC_FIELD(FIELD_NAME)                                                                     \
-    babelwires::InstanceUntypedBase<const babelwires::ValueTreeNode> get##FIELD_NAME() const {                          \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+    babelwires::InstanceUntypedBase<const babelwires::ValueTreeNode> get##FIELD_NAME() const {                         \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }                                                                                                                  \
-    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                                \
-    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::InstanceUntypedBase<babelwires::ValueTreeNode>>     \
+    template <typename VALUE_TREE_NODE_M = VALUE_TREE_NODE>                                                            \
+    std::enable_if_t<!std::is_const_v<VALUE_TREE_NODE_M>, babelwires::InstanceUntypedBase<babelwires::ValueTreeNode>>  \
         get##FIELD_NAME() {                                                                                            \
-        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                 \
+        return babelwires::InstanceUtils::getChild(this->m_valueTreeNode, #FIELD_NAME);                                \
     }
 
 /// Conclude the declaration.
 #define DECLARE_INSTANCE_END()                                                                                         \
     }                                                                                                                  \
     ;                                                                                                                  \
-    using Instance = InstanceImpl<babelwires::ValueTreeNode>;                                                           \
+    using Instance = InstanceImpl<babelwires::ValueTreeNode>;                                                          \
     using ConstInstance = InstanceImpl<const babelwires::ValueTreeNode>;

--- a/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/ProcessorElement/processorElement.cpp
@@ -36,7 +36,7 @@ babelwires::ProcessorElement::ProcessorElement(const ProjectContext& context, Us
         setFactoryName(elementData.m_factoryIdentifier);
         setInternalFailure(e.what());
         m_failedValueTree =
-            std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, FailureType::getThisIdentifier());
+            std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, FailureType::getThisType());
         userLogger.logError() << "Failed to create processor id=" << elementData.m_id << ": " << e.what();
     }
 }

--- a/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/SourceFileElement/sourceFileElement.cpp
@@ -98,14 +98,14 @@ bool babelwires::SourceFileElement::reload(const ProjectContext& context, UserLo
         setFactoryName(data.m_factoryIdentifier);
         setInternalFailure(e.what());
         // A dummy root
-        auto failure = std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisIdentifier());
+        auto failure = std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisType());
         failure->setToDefault();
         setValueTreeRoot(std::move(failure));
     } catch (const BaseException& e) {
         userLogger.logError() << "Source File Feature id=" << data.m_id << " could not be loaded: " << e.what();
         setInternalFailure(e.what());
         // A dummy file root which allows the user to change the file via the context menu.
-        auto failure = std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisIdentifier());
+        auto failure = std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisType());
         failure->setToDefault();
         setValueTreeRoot(std::move(failure));
     }

--- a/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/TargetFileElement/targetFileElement.cpp
@@ -36,11 +36,11 @@ babelwires::TargetFileElement::TargetFileElement(const ProjectContext& context, 
         setValueTreeRoot(std::move(newFeature));
     } catch (const RegistryException& e) {
         setInternalFailure(e.what());
-        setValueTreeRoot(std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisIdentifier()));
+        setValueTreeRoot(std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisType()));
         userLogger.logError() << "Failed to create target id=" << elementData.m_id << ": " << e.what();
     } catch (const BaseException& e) {
         setInternalFailure(e.what());
-        setValueTreeRoot(std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisIdentifier()));
+        setValueTreeRoot(std::make_unique<ValueTreeRoot>(context.m_typeSystem, FailureType::getThisType()));
         userLogger.logError() << "Failed to create target \"" << elementData.m_factoryIdentifier
                               << "\": " << e.what();
     }

--- a/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
+++ b/BabelWiresLib/Project/FeatureElements/ValueElement/valueElement.cpp
@@ -19,7 +19,7 @@ babelwires::ValueElement::ValueElement(const ProjectContext& context, UserLogger
     setFactoryName(data.getTypeRef().toString());
     TypeRef typeRefForConstruction = data.getTypeRef();
     if (!typeRefForConstruction.tryResolve(context.m_typeSystem)) {
-        typeRefForConstruction = FailureType::getThisIdentifier();
+        typeRefForConstruction = FailureType::getThisType();
         std::ostringstream message;
         message << "Type Reference " << data.getTypeRef().toString() << " could not be resolved";
         setInternalFailure(message.str());
@@ -50,7 +50,7 @@ const babelwires::ValueTreeNode* babelwires::ValueElement::getOutput() const {
 }
 
 std::string babelwires::ValueElement::getRootLabel() const {
-    if (m_valueTreeRoot->getTypeRef() == FailureType::getThisIdentifier()) {
+    if (m_valueTreeRoot->getTypeRef() == FailureType::getThisType()) {
         return "Failed";
     } else {
         return "Value";

--- a/BabelWiresLib/TypeSystem/primitiveType.hpp
+++ b/BabelWiresLib/TypeSystem/primitiveType.hpp
@@ -13,9 +13,18 @@
 
 /// Intended mainly for testing.
 #define PRIMITIVE_TYPE_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                         \
-    static babelwires::PrimitiveTypeId getThisIdentifier() { return IDENTIFIER; }                                       \
-    static babelwires::VersionNumber getVersion() { return VERSION; }                                                  \
-    babelwires::TypeRef getTypeRef() const override { return getThisIdentifier(); }
+    static babelwires::PrimitiveTypeId getThisIdentifier() {                                                           \
+        return IDENTIFIER;                                                                                             \
+    }                                                                                                                  \
+    static babelwires::TypeRef getThisType() {                                                                         \
+        return getThisIdentifier();                                                                                    \
+    }                                                                                                                  \
+    static babelwires::VersionNumber getVersion() {                                                                    \
+        return VERSION;                                                                                                \
+    }                                                                                                                  \
+    babelwires::TypeRef getTypeRef() const override {                                                                  \
+        return getThisIdentifier();                                                                                    \
+    }
 
 /// Primitive types (i.e. types which are not constructed from other types) need to be directly
 /// registered in the TypeSystem.

--- a/BabelWiresLib/Types/Array/arrayType.cpp
+++ b/BabelWiresLib/Types/Array/arrayType.cpp
@@ -16,10 +16,10 @@
 #include <BabelWiresLib/Types/Int/intType.hpp>
 
 babelwires::TestArrayType::TestArrayType()
-    : ArrayType(DefaultIntType::getThisIdentifier(), 1, 10, 3) {}
+    : ArrayType(DefaultIntType::getThisType(), 1, 10, 3) {}
 
 babelwires::TestArrayType2::TestArrayType2()
-    : ArrayType(TestArrayType::getThisIdentifier(), 1, 4, 2) {}
+    : ArrayType(TestArrayType::getThisType(), 1, 4, 2) {}
 */
 
 babelwires::ArrayType::ArrayType(TypeRef entryType, unsigned int minimumSize, unsigned int maximumSize, int initialSize)

--- a/BabelWiresLib/Types/File/fileTypeT.hpp
+++ b/BabelWiresLib/Types/File/fileTypeT.hpp
@@ -20,10 +20,10 @@ namespace babelwires {
     template <typename T> class FileTypeT : public FileType {
       public:
         FileTypeT()
-            : FileType(T::getThisIdentifier()) {}
+            : FileType(T::getThisType()) {}
 
         static babelwires::TypeRef getThisType() {
-            return babelwires::FileTypeConstructor::makeTypeRef(T::getThisIdentifier());
+            return babelwires::FileTypeConstructor::makeTypeRef(T::getThisType());
         }
 
         TypeRef getTypeRef() const override { return getThisType(); }

--- a/BabelWiresLib/Types/File/fileTypeT.hpp
+++ b/BabelWiresLib/Types/File/fileTypeT.hpp
@@ -1,0 +1,38 @@
+/**
+ * A type template which provides a convenient way to create a FileType for specific type of contents.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <BabelWiresLib/Types/File/fileType.hpp>
+#include <BabelWiresLib/Types/File/fileTypeConstructor.hpp>
+
+#include <BabelWiresLib/Instance/instance.hpp>
+
+namespace babelwires {
+
+    /// This template provides a convenient way to use FileType without defining and registering a subclass.
+    /// T is the class of the content types and this template assumes that instance support has been defined
+    /// for T (see instance.hpp). 
+    template <typename T> class FileTypeT : public FileType {
+      public:
+        FileTypeT()
+            : FileType(T::getThisIdentifier()) {}
+
+        static babelwires::TypeRef getThisType() {
+            return babelwires::FileTypeConstructor::makeTypeRef(T::getThisIdentifier());
+        }
+
+        TypeRef getTypeRef() const override { return getThisType(); }
+
+        /// Implementation Note: Cannot use FileType<T> here because the FileTypeConstructor does not construct
+        /// instances of this template but instances of the parent FileType class.
+        DECLARE_INSTANCE_BEGIN(FileType)
+        DECLARE_INSTANCE_FIELD(Conts, T)
+        DECLARE_INSTANCE_END()
+    };
+
+} // namespace babelwires

--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -16,14 +16,14 @@
 /*
 babelwires::TestRecordType::TestRecordType()
     : RecordType(
-          {{BW_SHORT_ID("foo", "Foo", "b36ab40f-c570-46f7-9dab-3af1b8f3216e"), DefaultIntType::getThisIdentifier()},
-           {BW_SHORT_ID("erm", "Erm", "bcb21539-6d10-41b2-886b-4b46f158f6bd"), DefaultIntType::getThisIdentifier()}}) {}
+          {{BW_SHORT_ID("foo", "Foo", "b36ab40f-c570-46f7-9dab-3af1b8f3216e"), DefaultIntType::getThisType()},
+           {BW_SHORT_ID("erm", "Erm", "bcb21539-6d10-41b2-886b-4b46f158f6bd"), DefaultIntType::getThisType()}}) {}
 
 babelwires::TestRecordType2::TestRecordType2()
     : RecordType(
-          {{BW_SHORT_ID("bar", "Bar", "8e746efa-1db8-4c43-b80c-451b6ee5db55"), DefaultIntType::getThisIdentifier()},
-           {BW_SHORT_ID("obj", "Obj", "e4629b27-0286-4712-8cf4-6cce69bb3636"), TestRecordType::getThisIdentifier()},
-           {BW_SHORT_ID("merm", "Merm", "b69f16a6-fcfb-49e8-be4b-c7910bff15c7"), DefaultIntType::getThisIdentifier(),
+          {{BW_SHORT_ID("bar", "Bar", "8e746efa-1db8-4c43-b80c-451b6ee5db55"), DefaultIntType::getThisType()},
+           {BW_SHORT_ID("obj", "Obj", "e4629b27-0286-4712-8cf4-6cce69bb3636"), TestRecordType::getThisType()},
+           {BW_SHORT_ID("merm", "Merm", "b69f16a6-fcfb-49e8-be4b-c7910bff15c7"), DefaultIntType::getThisType(),
             Optionality::optionalDefaultInactive}}) {}
 */
 

--- a/BabelWiresLib/Types/RecordWithVariants/recordWithVariantsType.cpp
+++ b/BabelWiresLib/Types/RecordWithVariants/recordWithVariantsType.cpp
@@ -29,11 +29,11 @@ babelwires::TestRecordWithVariants::TestRecordWithVariants()
     : RecordWithVariantsType(
           {getTag0(), getTag1()},
           {{BW_SHORT_ID("foo", "Foo", "b36ab40f-c570-46f7-9dab-3af1b8f3216e"),
-            DefaultIntType::getThisIdentifier(),
+            DefaultIntType::getThisType(),
             {getTag0()}},
-           {BW_SHORT_ID("erm", "Erm", "bcb21539-6d10-41b2-886b-4b46f158f6bd"), DefaultIntType::getThisIdentifier()},
+           {BW_SHORT_ID("erm", "Erm", "bcb21539-6d10-41b2-886b-4b46f158f6bd"), DefaultIntType::getThisType()},
            {BW_SHORT_ID("oom", "Oom", "2cb79b61-c3b3-4df4-b8a0-11ec286bf659"),
-            DefaultIntType::getThisIdentifier(),
+            DefaultIntType::getThisType(),
             {getTag1()}}}) {}
 */
 

--- a/Common/Registry/registry.hpp
+++ b/Common/Registry/registry.hpp
@@ -120,7 +120,7 @@ namespace babelwires {
         /// and get a typed reference back.
         template<typename ENTRY_SUBTYPE, std::enable_if_t<std::is_base_of_v<ENTRY, ENTRY_SUBTYPE>, std::nullptr_t> = nullptr>
         const ENTRY_SUBTYPE& getEntryByType() const {
-          const ENTRY& entry = getRegisteredEntry(ENTRY_SUBTYPE::getThisIdentifier());
+          const ENTRY& entry = getRegisteredEntry(ENTRY_SUBTYPE::getThisType());
           assert(dynamic_cast<const ENTRY_SUBTYPE*>(&entry) && "The registered type was not of the expected type");
           return static_cast<const ENTRY_SUBTYPE&>(entry);
         }

--- a/Tests/BabelWiresLib/TestUtils/testArrayType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testArrayType.cpp
@@ -7,18 +7,18 @@ testUtils::TestSimpleArrayType::TestSimpleArrayType()
     : babelwires::ArrayType(getEntryTypeStatic(), s_minimumSize, s_maximumSize, s_defaultSize) {}
 
 babelwires::TypeRef testUtils::TestSimpleArrayType::getEntryTypeStatic() {
-    return babelwires::DefaultIntType::getThisIdentifier();
+    return babelwires::DefaultIntType::getThisType();
 }
 
 testUtils::TestCompoundArrayType::TestCompoundArrayType()
     : babelwires::ArrayType(getEntryTypeStatic(), s_minimumSize, s_maximumSize, s_defaultSize) {}
 
 babelwires::TypeRef testUtils::TestCompoundArrayType::getEntryTypeStatic() {
-    return testUtils::TestSimpleArrayType::getThisIdentifier();
+    return testUtils::TestSimpleArrayType::getThisType();
 }
 
 testUtils::TestArrayElementData::TestArrayElementData()
-    : babelwires::ValueElementData(TestSimpleArrayType::getThisIdentifier()) {}
+    : babelwires::ValueElementData(TestSimpleArrayType::getThisType()) {}
 
 babelwires::Path testUtils::TestArrayElementData::getPathToArray() {
     return babelwires::Path();

--- a/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFeatureElement.cpp
@@ -36,7 +36,7 @@ testUtils::TestFeatureElement::TestFeatureElement(const babelwires::ProjectConte
                                                   const TestFeatureElementData& data, babelwires::ElementId newId)
     : FeatureElement(data, newId) {
     setFactoryName(data.m_factoryIdentifier);
-    m_valueTreeRoot = std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, TestComplexRecordType::getThisIdentifier());
+    m_valueTreeRoot = std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, TestComplexRecordType::getThisType());
 }
 
 void testUtils::TestFeatureElement::doProcess(babelwires::UserLogger&) {}
@@ -60,10 +60,10 @@ babelwires::ValueTreeNode* testUtils::TestFeatureElement::doGetOutputNonConst() 
 void testUtils::TestFeatureElement::simulateFailure(const babelwires::ProjectContext& context) {
     setInternalFailure("Simulated failure");
     m_valueTreeRoot = std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem,
-                                                                 babelwires::FailureType::getThisIdentifier());
+                                                                 babelwires::FailureType::getThisType());
 }
 
 void testUtils::TestFeatureElement::simulateRecovery(const babelwires::ProjectContext& context) {
-    m_valueTreeRoot = std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, TestComplexRecordType::getThisIdentifier());
+    m_valueTreeRoot = std::make_unique<babelwires::ValueTreeRoot>(context.m_typeSystem, TestComplexRecordType::getThisType());
     clearInternalFailure();
 }

--- a/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testFileFormats.cpp
@@ -22,7 +22,7 @@ namespace {
 } // namespace
 
 babelwires::TypeRef testUtils::getTestFileType() {
-    return babelwires::FileTypeConstructor::makeTypeRef(TestSimpleRecordType::getThisIdentifier());
+    return babelwires::FileTypeConstructor::makeTypeRef(TestSimpleRecordType::getThisType());
 }
 
 babelwires::Path testUtils::getTestFileElementPathToInt0() {

--- a/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
@@ -21,13 +21,13 @@ babelwires::ShortId testUtils::TestProcessorInputOutputType::getRecordId() {
 
 testUtils::TestProcessorInputOutputType::TestProcessorInputOutputType()
     : RecordType(
-          {{getIntId(), babelwires::DefaultIntType::getThisIdentifier()},
-           {getOptIntId(), babelwires::DefaultIntType::getThisIdentifier(), Optionality::optionalDefaultInactive},
+          {{getIntId(), babelwires::DefaultIntType::getThisType()},
+           {getOptIntId(), babelwires::DefaultIntType::getThisType(), Optionality::optionalDefaultInactive},
            {getArrayId(),
             babelwires::TypeRef{babelwires::ArrayTypeConstructor::getThisIdentifier(),
-                                {{babelwires::DefaultIntType::getThisIdentifier()},
+                                {{babelwires::DefaultIntType::getThisType()},
                                  {babelwires::IntValue(2), babelwires::IntValue(8), babelwires::IntValue(2)}}}},
-           {getRecordId(), TestSimpleRecordType::getThisIdentifier()}}) {}
+           {getRecordId(), TestSimpleRecordType::getThisType()}}) {}
 
 const babelwires::Path testUtils::TestProcessorInputOutputType::s_pathToInt =
     babelwires::Path::deserializeFromString("Int");
@@ -49,8 +49,8 @@ const babelwires::Path testUtils::TestProcessorInputOutputType::s_pathToInt2 =
     babelwires::Path::deserializeFromString("Record/intR0");
 
 testUtils::TestProcessor::TestProcessor(const babelwires::ProjectContext& context)
-    : babelwires::Processor(context, testUtils::TestProcessorInputOutputType::getThisIdentifier(),
-                                 testUtils::TestProcessorInputOutputType::getThisIdentifier()) {}
+    : babelwires::Processor(context, testUtils::TestProcessorInputOutputType::getThisType(),
+                                 testUtils::TestProcessorInputOutputType::getThisType()) {}
 
 void testUtils::TestProcessor::processValue(babelwires::UserLogger& userLogger,
                                              const babelwires::ValueTreeNode& input,

--- a/Tests/BabelWiresLib/TestUtils/testProjectData.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testProjectData.cpp
@@ -144,7 +144,7 @@ void testUtils::TestProjectData::testProjectData(const babelwires::ProjectContex
 }
 
 void testUtils::TestProjectData::resolvePathsInCurrentContext(const babelwires::ProjectContext& context) {
-    babelwires::ValueTreeRoot testRecord(context.m_typeSystem, testUtils::TestProcessorInputOutputType::getThisIdentifier());
+    babelwires::ValueTreeRoot testRecord(context.m_typeSystem, testUtils::TestProcessorInputOutputType::getThisType());
     testRecord.setToDefault();
     babelwires::ValueTreeRoot testFileFeature(context.m_typeSystem, testUtils::getTestFileType());
 

--- a/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordType.cpp
@@ -8,8 +8,8 @@
 #include <Tests/BabelWiresLib/TestUtils/testArrayType.hpp>
 
 testUtils::TestSimpleRecordType::TestSimpleRecordType()
-    : RecordType({{getInt0Id(), babelwires::DefaultIntType::getThisIdentifier()},
-                  {getInt1Id(), babelwires::DefaultIntType::getThisIdentifier()}}) {}
+    : RecordType({{getInt0Id(), babelwires::DefaultIntType::getThisType()},
+                  {getInt1Id(), babelwires::DefaultIntType::getThisType()}}) {}
 
 babelwires::ShortId testUtils::TestSimpleRecordType::getInt0Id() {
     return BW_SHORT_ID(s_int0IdInitializer, s_int0FieldName, s_int0Uuid);
@@ -20,13 +20,13 @@ babelwires::ShortId testUtils::TestSimpleRecordType::getInt1Id() {
 }
 
 testUtils::TestComplexRecordType::TestComplexRecordType()
-    : RecordType({{getInt0Id(), babelwires::DefaultIntType::getThisIdentifier()},
-                  {getOpIntId(), babelwires::DefaultIntType::getThisIdentifier(), Optionality::optionalDefaultInactive},
-                  {getSubrecordId(), TestSimpleRecordType::getThisIdentifier()},
+    : RecordType({{getInt0Id(), babelwires::DefaultIntType::getThisType()},
+                  {getOpIntId(), babelwires::DefaultIntType::getThisType(), Optionality::optionalDefaultInactive},
+                  {getSubrecordId(), TestSimpleRecordType::getThisType()},
                   {getInt1Id(), babelwires::IntTypeConstructor::makeTypeRef(c_int1min, c_int1max, c_int1default)},
-                  {getOpRecId(), TestSimpleRecordType::getThisIdentifier(), Optionality::optionalDefaultInactive},
-                  {getStringId(), babelwires::StringType::getThisIdentifier()},
-                  {getArrayId(), testUtils::TestSimpleArrayType::getThisIdentifier()}}) {}
+                  {getOpRecId(), TestSimpleRecordType::getThisType(), Optionality::optionalDefaultInactive},
+                  {getStringId(), babelwires::StringType::getThisType()},
+                  {getArrayId(), testUtils::TestSimpleArrayType::getThisType()}}) {}
 
 babelwires::ShortId testUtils::TestComplexRecordType::getInt0Id() {
     return BW_SHORT_ID(s_intIdInitializer, s_intFieldName, "1aafde9a-fb39-4a2d-8a29-55fc9d6d093b");
@@ -57,7 +57,7 @@ babelwires::ShortId testUtils::TestComplexRecordType::getArrayId() {
 }
 
 testUtils::TestSimpleRecordElementData::TestSimpleRecordElementData()
-    : babelwires::ValueElementData(TestSimpleRecordType::getThisIdentifier()) {}
+    : babelwires::ValueElementData(TestSimpleRecordType::getThisType()) {}
 
 babelwires::Path testUtils::TestSimpleRecordElementData::getPathToRecord() {
     return babelwires::Path();
@@ -70,7 +70,7 @@ babelwires::Path testUtils::TestSimpleRecordElementData::getPathToRecordInt0() {
 }
 
 testUtils::TestComplexRecordElementData::TestComplexRecordElementData()
-    : babelwires::ValueElementData(TestComplexRecordType::getThisIdentifier()) {}
+    : babelwires::ValueElementData(TestComplexRecordType::getThisType()) {}
 
 babelwires::Path testUtils::TestComplexRecordElementData::getPathToRecord() {
     return babelwires::Path();

--- a/Tests/BabelWiresLib/TestUtils/testRecordWithVariantsType.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testRecordWithVariantsType.cpp
@@ -8,13 +8,13 @@
 testUtils::TestRecordWithVariantsType::TestRecordWithVariantsType()
     : RecordWithVariantsType(
           {getTagAId(), getTagBId(), getTagCId(), getTagDId()},
-          {{getFieldA0Id(), babelwires::DefaultIntType::getThisIdentifier(), {getTagAId(), getTagDId()}},
-           {getFf0Id(), babelwires::DefaultIntType::getThisIdentifier()},
-           {getFieldB0Id(), TestSimpleRecordType::getThisIdentifier(), {getTagBId()}},
-           {getFieldABId(), babelwires::DefaultIntType::getThisIdentifier(), {getTagAId(), getTagBId(), getTagDId()}},
-           {getFieldA1Id(), TestSimpleRecordType::getThisIdentifier(), {getTagAId(), getTagDId()}},
-           {getFf1Id(), TestSimpleRecordType::getThisIdentifier()},
-           {getFieldBCId(), babelwires::DefaultIntType::getThisIdentifier(), {getTagBId(), getTagCId()}}},
+          {{getFieldA0Id(), babelwires::DefaultIntType::getThisType(), {getTagAId(), getTagDId()}},
+           {getFf0Id(), babelwires::DefaultIntType::getThisType()},
+           {getFieldB0Id(), TestSimpleRecordType::getThisType(), {getTagBId()}},
+           {getFieldABId(), babelwires::DefaultIntType::getThisType(), {getTagAId(), getTagBId(), getTagDId()}},
+           {getFieldA1Id(), TestSimpleRecordType::getThisType(), {getTagAId(), getTagDId()}},
+           {getFf1Id(), TestSimpleRecordType::getThisType()},
+           {getFieldBCId(), babelwires::DefaultIntType::getThisType(), {getTagBId(), getTagCId()}}},
           1) {}
 
 babelwires::ShortId testUtils::TestRecordWithVariantsType::getTagAId() {
@@ -62,7 +62,7 @@ babelwires::ShortId testUtils::TestRecordWithVariantsType::getFieldBCId() {
 }
 
 testUtils::TestRecordWithVariantsElementData::TestRecordWithVariantsElementData()
-    : ValueElementData(testUtils::TestRecordWithVariantsType::getThisIdentifier()) {}
+    : ValueElementData(testUtils::TestRecordWithVariantsType::getThisType()) {}
 
 babelwires::Path testUtils::TestRecordWithVariantsElementData::getPathToRecordWithVariants() {
     return babelwires::Path();

--- a/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
@@ -17,7 +17,7 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
     const babelwires::ValueElement* const element =
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);
@@ -85,7 +85,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoRecord) {
     babelwires::ActivateOptionalCommand command("Test command", 51,
                                                 babelwires::Path::deserializeFromString("qqq/zzz"), opId);
 
-    babelwires::ValueElementData elementData(testUtils::TestComplexRecordType::getThisIdentifier());
+    babelwires::ValueElementData elementData(testUtils::TestComplexRecordType::getThisType());
     elementData.m_id = 51;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(elementData);
@@ -99,7 +99,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyNoOptional) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     const babelwires::Path pathToValue;
 
@@ -116,7 +116,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     // Not an optional field
     babelwires::ShortId opId("flerm");
@@ -135,7 +135,7 @@ TEST(ActivateOptionalsCommandTest, failSafelyAlreadyActivated) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
     babelwires::ValueElement* const element =
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();
     ASSERT_NE(element, nullptr);

--- a/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalsModifierDataTest.cpp
@@ -18,7 +18,7 @@
 TEST(ActivateOptionalsModifierDataTest, apply) {
     testUtils::TestEnvironment testEnvironment;
     babelwires::ValueTreeRoot valueFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     valueFeature.setToDefault();
     const auto* type = valueFeature.getType().as<testUtils::TestComplexRecordType>();
 
@@ -45,7 +45,7 @@ TEST(ActivateOptionalsModifierDataTest, apply) {
 TEST(ActivateOptionalsModifierDataTest, failureNotOptionals) {
     testUtils::TestEnvironment testEnvironment;
     babelwires::ValueTreeRoot valueFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     valueFeature.setToDefault();
     const auto* type = valueFeature.getType().as<testUtils::TestComplexRecordType>();
 
@@ -63,7 +63,7 @@ TEST(ActivateOptionalsModifierDataTest, failureNotOptionals) {
 TEST(ActivateOptionalsModifierDataTest, failureNotARecordWithOptionals) {
     testUtils::TestEnvironment testEnvironment;
     babelwires::ValueTreeRoot valueFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                testUtils::TestSimpleRecordType::getThisType());
     valueFeature.setToDefault();
 
     babelwires::ActivateOptionalsModifierData data;

--- a/Tests/BabelWiresLib/addBlankToEnumTest.cpp
+++ b/Tests/BabelWiresLib/addBlankToEnumTest.cpp
@@ -41,10 +41,10 @@ TEST(AddBlankToEnum, constructType) {
 
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
-        addBlankToEnum.tryGetOrConstructType(testEnvironment.m_typeSystem, babelwires::TypeConstructorArguments{{testUtils::TestEnum::getThisIdentifier()}});
+        addBlankToEnum.tryGetOrConstructType(testEnvironment.m_typeSystem, babelwires::TypeConstructorArguments{{testUtils::TestEnum::getThisType()}});
     ASSERT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(), babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                         testUtils::TestEnum::getThisIdentifier()));
+                                                         testUtils::TestEnum::getThisType()));
 
     const babelwires::EnumType* const newEnum = newType->as<babelwires::EnumType>();
     ASSERT_NE(newEnum, nullptr);
@@ -64,13 +64,13 @@ TEST(AddBlankToEnum, idempotency) {
     babelwires::AddBlankToEnum addBlankToEnum;
     const babelwires::Type* const newType =
         addBlankToEnum.tryGetOrConstructType(testEnvironment.m_typeSystem, babelwires::TypeConstructorArguments{{babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                                      testUtils::TestEnum::getThisIdentifier())}});
+                                                                      testUtils::TestEnum::getThisType())}});
 
     ASSERT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(),
               babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
                                   babelwires::TypeRef(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                                        testUtils::TestEnum::getThisIdentifier())));
+                                                        testUtils::TestEnum::getThisType())));
 
     const babelwires::EnumType* const newEnum = newType->as<babelwires::EnumType>();
     ASSERT_NE(newEnum, nullptr);
@@ -87,13 +87,13 @@ TEST(AddBlankToEnum, compareSubtype) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::TypeRef addBlankToEnumToSubEnum(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                          testUtils::TestSubEnum::getThisIdentifier());
+                                          testUtils::TestSubEnum::getThisType());
 
     babelwires::TypeRef addBlankToEnumToSubSubEnum1(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                              testUtils::TestSubSubEnum1::getThisIdentifier());
+                                              testUtils::TestSubSubEnum1::getThisType());
 
     babelwires::TypeRef addBlankToEnumToSubSubEnum2(babelwires::AddBlankToEnum::getThisIdentifier(),
-                                              testUtils::TestSubSubEnum2::getThisIdentifier());
+                                              testUtils::TestSubSubEnum2::getThisType());
 
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, addBlankToEnumToSubEnum), babelwires::SubtypeOrder::IsEquivalent);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, addBlankToEnumToSubSubEnum1),
@@ -111,17 +111,17 @@ TEST(AddBlankToEnum, compareSubtype) {
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubSubEnum2, addBlankToEnumToSubSubEnum2),
               babelwires::SubtypeOrder::IsEquivalent);
 
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestSubEnum::getThisIdentifier()),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestSubEnum::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestSubSubEnum1::getThisIdentifier()),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestSubSubEnum1::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestEnum::getThisIdentifier()),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(addBlankToEnumToSubEnum, testUtils::TestEnum::getThisType()),
               babelwires::SubtypeOrder::IsUnrelated);
 
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestSubEnum::getThisIdentifier(), addBlankToEnumToSubEnum),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestSubEnum::getThisType(), addBlankToEnumToSubEnum),
               babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestSubSubEnum1::getThisIdentifier(), addBlankToEnumToSubEnum),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestSubSubEnum1::getThisType(), addBlankToEnumToSubEnum),
               babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestEnum::getThisIdentifier(), addBlankToEnumToSubEnum),
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testUtils::TestEnum::getThisType(), addBlankToEnumToSubEnum),
               babelwires::SubtypeOrder::IsUnrelated);
 }

--- a/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
@@ -17,18 +17,18 @@ TEST(AddEntryToMapCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
@@ -55,18 +55,18 @@ TEST(AddEntryToMapCommandTest, failAtEnd) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());

--- a/Tests/BabelWiresLib/arrayTypeTest.cpp
+++ b/Tests/BabelWiresLib/arrayTypeTest.cpp
@@ -315,7 +315,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorSucceed) {
 
     babelwires::TypeRef arrayTypeRef(babelwires::ArrayTypeConstructor::getThisIdentifier(),
                                      babelwires::TypeConstructorArguments{
-                                         {babelwires::StringType::getThisIdentifier()},
+                                         {babelwires::StringType::getThisType()},
                                          {babelwires::IntValue(1), babelwires::IntValue(5), babelwires::IntValue(3)}});
 
     EXPECT_STREQ(arrayTypeRef.toString().c_str(), "Array<String>[1..5]");
@@ -326,7 +326,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorSucceed) {
     const babelwires::ArrayType* const arrayType = newType->as<babelwires::ArrayType>();
     ASSERT_NE(arrayType, nullptr);
 
-    EXPECT_EQ(arrayType->getEntryType(), babelwires::StringType::getThisIdentifier());
+    EXPECT_EQ(arrayType->getEntryType(), babelwires::StringType::getThisType());
     EXPECT_EQ(arrayType->getSizeRange().m_min, 1);
     EXPECT_EQ(arrayType->getSizeRange().m_max, 5);
     EXPECT_EQ(arrayType->getInitialSize(), 3);
@@ -348,7 +348,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorFail) {
     {
         babelwires::TypeRef arrayTypeRef(
             babelwires::ArrayTypeConstructor::getThisIdentifier(),
-            babelwires::TypeConstructorArguments{{babelwires::StringType::getThisIdentifier()}, {}});
+            babelwires::TypeConstructorArguments{{babelwires::StringType::getThisType()}, {}});
 
         EXPECT_EQ(arrayTypeRef.tryResolve(testEnvironment.m_typeSystem), nullptr);
         EXPECT_THROW(arrayTypeRef.resolve(testEnvironment.m_typeSystem), babelwires::TypeSystemException);
@@ -357,7 +357,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorFail) {
         babelwires::TypeRef arrayTypeRef(
             babelwires::ArrayTypeConstructor::getThisIdentifier(),
             babelwires::TypeConstructorArguments{
-                {babelwires::StringType::getThisIdentifier()},
+                {babelwires::StringType::getThisType()},
                 {babelwires::IntValue(-1), babelwires::IntValue(5), babelwires::IntValue(3)}});
 
         EXPECT_EQ(arrayTypeRef.tryResolve(testEnvironment.m_typeSystem), nullptr);
@@ -367,7 +367,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorFail) {
         babelwires::TypeRef arrayTypeRef(
             babelwires::ArrayTypeConstructor::getThisIdentifier(),
             babelwires::TypeConstructorArguments{
-                {babelwires::StringType::getThisIdentifier()},
+                {babelwires::StringType::getThisType()},
                 {babelwires::IntValue(6), babelwires::IntValue(2), babelwires::IntValue(7)}});
 
         EXPECT_EQ(arrayTypeRef.tryResolve(testEnvironment.m_typeSystem), nullptr);
@@ -377,7 +377,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorFail) {
         babelwires::TypeRef arrayTypeRef(
             babelwires::ArrayTypeConstructor::getThisIdentifier(),
             babelwires::TypeConstructorArguments{
-                {babelwires::StringType::getThisIdentifier()},
+                {babelwires::StringType::getThisType()},
                 {babelwires::IntValue(6), babelwires::IntValue(10), babelwires::IntValue(3)}});
 
         EXPECT_EQ(arrayTypeRef.tryResolve(testEnvironment.m_typeSystem), nullptr);
@@ -387,7 +387,7 @@ TEST(ArrayTypeTest, arrayTypeConstructorFail) {
         babelwires::TypeRef arrayTypeRef(
             babelwires::ArrayTypeConstructor::getThisIdentifier(),
             babelwires::TypeConstructorArguments{
-                {babelwires::StringType::getThisIdentifier()},
+                {babelwires::StringType::getThisType()},
                 {babelwires::IntValue(6), babelwires::IntValue(10), babelwires::IntValue(12)}});
 
         EXPECT_EQ(arrayTypeRef.tryResolve(testEnvironment.m_typeSystem), nullptr);
@@ -401,19 +401,19 @@ TEST(ArrayTypeTest, subtyping) {
     babelwires::TypeRef arrayTypeRef(
         babelwires::ArrayTypeConstructor::getThisIdentifier(),
         babelwires::TypeConstructorArguments{
-            {testUtils::TestSubEnum::getThisIdentifier()},
+            {testUtils::TestSubEnum::getThisType()},
             {babelwires::IntValue(2), babelwires::IntValue(6), babelwires::IntValue(3)}});
 
     babelwires::TypeRef biggerArrayTypeRef(
         babelwires::ArrayTypeConstructor::getThisIdentifier(),
         babelwires::TypeConstructorArguments{
-            {testUtils::TestSubEnum::getThisIdentifier()},
+            {testUtils::TestSubEnum::getThisType()},
             {babelwires::IntValue(1), babelwires::IntValue(7), babelwires::IntValue(3)}});
 
     babelwires::TypeRef arrayOfSupertypeTypeRef(
         babelwires::ArrayTypeConstructor::getThisIdentifier(),
         babelwires::TypeConstructorArguments{
-            {testUtils::TestEnum::getThisIdentifier()},
+            {testUtils::TestEnum::getThisType()},
             {babelwires::IntValue(2), babelwires::IntValue(6), babelwires::IntValue(3)}});
 
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(arrayTypeRef, arrayTypeRef), babelwires::SubtypeOrder::IsEquivalent);
@@ -427,7 +427,7 @@ TEST(ArrayTypeTest, subtyping) {
 
 TEST(ArrayTypeTest, featureChanges) {
     testUtils::TestEnvironment testEnvironment;
-    babelwires::ValueTreeRoot arrayFeature(testEnvironment.m_typeSystem, testUtils::TestSimpleArrayType::getThisIdentifier());
+    babelwires::ValueTreeRoot arrayFeature(testEnvironment.m_typeSystem, testUtils::TestSimpleArrayType::getThisType());
     arrayFeature.setToDefault();
 
     const testUtils::TestSimpleArrayType* arrayType = arrayFeature.getType().as<testUtils::TestSimpleArrayType>();

--- a/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
+++ b/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
@@ -17,18 +17,18 @@ TEST(ChangeEntryKindCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
@@ -52,18 +52,18 @@ TEST(ChangeEntryKindCommandTest, failFallbackNotAtEnd) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(oneToOne.clone());
@@ -78,18 +78,18 @@ TEST(ChangeEntryKindCommandTest, failNotFallbackAtEnd) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(oneToOne.clone());

--- a/Tests/BabelWiresLib/contentsCacheTest.cpp
+++ b/Tests/BabelWiresLib/contentsCacheTest.cpp
@@ -410,7 +410,7 @@ TEST(ContentsCacheTest, inputFeatureOnly) {
     babelwires::ContentsCache cache(editTree);
 
     babelwires::ValueTreeRoot inputFeature(testEnvironment.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     inputFeature.setToDefault();
     editTree.setExpanded(babelwires::Path(), true);
 
@@ -425,7 +425,7 @@ TEST(ContentsCacheTest, outputFeatureOnly) {
     babelwires::ContentsCache cache(editTree);
 
     babelwires::ValueTreeRoot outputFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
     outputFeature.setToDefault();
     editTree.setExpanded(babelwires::Path(), true);
 
@@ -439,9 +439,9 @@ TEST(ContentsCacheTest, inputAndOutputFeature) {
     babelwires::ContentsCache cache(editTree);
 
     babelwires::ValueTreeRoot inputFeature(testEnvironment.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     babelwires::ValueTreeRoot outputFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
     inputFeature.setToDefault();
     outputFeature.setToDefault();
     editTree.setExpanded(babelwires::Path(), true);
@@ -457,9 +457,9 @@ TEST(ContentsCacheTest, inputAndOutputDifferentFeatures) {
     babelwires::ContentsCache cache(editTree);
 
     babelwires::ValueTreeRoot inputFeature(testEnvironment.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     babelwires::ValueTreeRoot outputFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
 
     inputFeature.setToDefault();
     outputFeature.setToDefault();
@@ -521,9 +521,9 @@ TEST(ContentsCacheTest, hiddenTopLevelModifiers) {
     babelwires::ContentsCache cache(editTree);
 
     babelwires::ValueTreeRoot inputFeature(testEnvironment.m_typeSystem,
-                                                testUtils::TestComplexRecordType::getThisIdentifier());
+                                                testUtils::TestComplexRecordType::getThisType());
     babelwires::ValueTreeRoot outputFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
 
     inputFeature.setToDefault();
     outputFeature.setToDefault();

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -18,12 +18,12 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisType()));
     const babelwires::ElementId targetId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisType()));
 
     const babelwires::ValueElement* const element =
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();
@@ -136,7 +136,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoRecord) {
     babelwires::DeactivateOptionalCommand command("Test command", 51,
                                                   babelwires::Path::deserializeFromString("qqq/zzz"), opId);
 
-    babelwires::ValueElementData elementData(testUtils::TestComplexRecordType::getThisIdentifier());
+    babelwires::ValueElementData elementData(testUtils::TestComplexRecordType::getThisType());
     elementData.m_id = 51;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(elementData);
@@ -150,7 +150,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyNoOptional) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     const babelwires::Path pathToValue;
 
@@ -165,7 +165,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyFieldNotOptional) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     // Not an optional field
     babelwires::ShortId opId("flerm");
@@ -184,7 +184,7 @@ TEST(DeactivateOptionalsCommandTest, failSafelyAlreadyInactive) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     const babelwires::Path pathToValue;
 

--- a/Tests/BabelWiresLib/enumFeatureTest.cpp
+++ b/Tests/BabelWiresLib/enumFeatureTest.cpp
@@ -13,7 +13,7 @@
 TEST(EnumFeatureTest, enumFeature) { 
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisIdentifier()};
+    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisType()};
     babelwires::Instance<testUtils::TestEnum> enumInstance{enumFeature};
  
     enumFeature.setToDefault();
@@ -22,7 +22,7 @@ TEST(EnumFeatureTest, enumFeature) {
     enumInstance.set(testUtils::TestEnum::Value::Boo);
     EXPECT_EQ(enumInstance.get(), testUtils::TestEnum::Value::Boo);
 
-    babelwires::ValueTreeRoot enumFeature2{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisIdentifier()};
+    babelwires::ValueTreeRoot enumFeature2{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisType()};
     babelwires::Instance<testUtils::TestEnum> enumInstance2{enumFeature2};
 
     enumFeature2.setToDefault();
@@ -33,7 +33,7 @@ TEST(EnumFeatureTest, enumFeature) {
 TEST(EnumFeatureTest, enumFeatureChanges) {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisIdentifier()};
+    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisType()};
     babelwires::Instance<testUtils::TestEnum> enumInstance{enumFeature};
     
     // After construction, everything has changed.
@@ -65,7 +65,7 @@ TEST(EnumFeatureTest, enumFeatureChanges) {
 TEST(EnumFeatureTest, enumFeatureHash) {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisIdentifier()};
+    babelwires::ValueTreeRoot enumFeature{testEnvironment.m_typeSystem, testUtils::TestEnum::getThisType()};
     babelwires::Instance<testUtils::TestEnum> enumInstance{enumFeature};
 
     enumInstance.set(testUtils::TestEnum::Value::Boo);

--- a/Tests/BabelWiresLib/featurePathTest.cpp
+++ b/Tests/BabelWiresLib/featurePathTest.cpp
@@ -120,7 +120,7 @@ TEST(FeaturePathTest, pathFollow) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot testRecordFeature(testEnvironment.m_typeSystem,
-                                                     testUtils::TestComplexRecordType::getThisIdentifier());
+                                                     testUtils::TestComplexRecordType::getThisType());
     testRecordFeature.setToDefault();
 
     testUtils::TestComplexRecordTypeFeatureInfo info(testRecordFeature);
@@ -186,7 +186,7 @@ TEST(FeaturePathTest, pathResolve) {
     EXPECT_EQ(pathToInt2.getStep(1).getField().getDiscriminator(), 0);
 
     babelwires::ValueTreeRoot testRecordFeature(testEnvironment.m_typeSystem,
-                                                     testUtils::TestComplexRecordType::getThisIdentifier());
+                                                     testUtils::TestComplexRecordType::getThisType());
     testRecordFeature.setToDefault();
 
     testUtils::TestComplexRecordTypeFeatureInfo info(testRecordFeature);
@@ -223,7 +223,7 @@ TEST(FeaturePathTest, pathTryFollow) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot testRecordFeature(testEnvironment.m_typeSystem,
-                                                     testUtils::TestComplexRecordType::getThisIdentifier());
+                                                     testUtils::TestComplexRecordType::getThisType());
     testRecordFeature.setToDefault();
 
     testUtils::TestComplexRecordTypeFeatureInfo info(testRecordFeature);
@@ -256,7 +256,7 @@ TEST(FeaturePathTest, pathFollowFail) {
     pathValueAsArray.pushStep(babelwires::PathStep(12));
 
     babelwires::ValueTreeRoot testRecordFeature(testEnvironment.m_typeSystem,
-                                                     testUtils::TestComplexRecordType::getThisIdentifier());
+                                                     testUtils::TestComplexRecordType::getThisType());
     testRecordFeature.setToDefault();
 
     testUtils::TestComplexRecordTypeFeatureInfo info(testRecordFeature);

--- a/Tests/BabelWiresLib/mapEntryDataTest.cpp
+++ b/Tests/BabelWiresLib/mapEntryDataTest.cpp
@@ -46,27 +46,27 @@ TEST(MapEntryDataTest, create) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const auto oneToOne = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier(),
+    const auto oneToOne = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisType(),
+                                                           testUtils::TestEnum::getThisType(),
                                                            babelwires::MapEntryData::Kind::One21);
-    const auto allToOne = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier(),
+    const auto allToOne = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisType(),
+                                                           testUtils::TestEnum::getThisType(),
                                                            babelwires::MapEntryData::Kind::All21);
     // source == target for allToSame
-    const auto allToSame = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                                            testUtils::TestType::getThisIdentifier(),
+    const auto allToSame = babelwires::MapEntryData::create(typeSystem, testUtils::TestType::getThisType(),
+                                                            testUtils::TestType::getThisType(),
                                                             babelwires::MapEntryData::Kind::All2Sm);
 
     EXPECT_EQ(oneToOne->getKind(), babelwires::MapEntryData::Kind::One21);
     EXPECT_EQ(allToOne->getKind(), babelwires::MapEntryData::Kind::All21);
     EXPECT_EQ(allToSame->getKind(), babelwires::MapEntryData::Kind::All2Sm);
 
-    EXPECT_TRUE(oneToOne->validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), false));
-    EXPECT_TRUE(allToOne->validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
-    EXPECT_TRUE(allToSame->validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                    testUtils::TestType::getThisIdentifier(), true));
+    EXPECT_TRUE(oneToOne->validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), false));
+    EXPECT_TRUE(allToOne->validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
+    EXPECT_TRUE(allToSame->validate(typeSystem, testUtils::TestType::getThisType(),
+                                    testUtils::TestType::getThisType(), true));
 
     const auto* const oneToOneEntryData = oneToOne->as<babelwires::OneToOneMapEntryData>();
     const auto* const allToOneEntryData = allToOne->as<babelwires::AllToOneFallbackMapEntryData>();
@@ -86,9 +86,9 @@ TEST(MapEntryDataTest, equalityByKind) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                                    testUtils::TestEnum::getThisIdentifier());
-    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                                    testUtils::TestEnum::getThisType());
+    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestEnum::getThisType());
     babelwires::AllToSameFallbackMapEntryData allToSame;
 
     EXPECT_EQ(oneToOne, oneToOne);
@@ -105,11 +105,11 @@ TEST(MapEntryDataTest, oneToOneEqualitySameTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
     EXPECT_EQ(oneToOneA, oneToOneB);
 
@@ -134,17 +134,17 @@ TEST(MapEntryDataTest, oneToOneEqualityDifferentTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestEnum::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneC(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneC(typeSystem, testUtils::TestEnum::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneD(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                               testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneD(typeSystem, testUtils::TestEnum::getThisType(),
+                                               testUtils::TestEnum::getThisType());
 
     EXPECT_NE(oneToOneA, oneToOneB);
     EXPECT_NE(oneToOneA, oneToOneC);
@@ -166,9 +166,9 @@ TEST(MapEntryDataTest, allToOneEqualitySameTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisType());
 
-    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestType::getThisType());
 
     EXPECT_EQ(allToOneA, allToOneB);
 
@@ -187,9 +187,9 @@ TEST(MapEntryDataTest, allToOneEqualityDifferentTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisType());
 
-    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestEnum::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestEnum::getThisType());
 
     EXPECT_NE(allToOneA, allToOneB);
     EXPECT_NE(allToOneB, allToOneA);
@@ -200,9 +200,9 @@ TEST(MapEntryDataTest, hashByKind) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    const babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                                    testUtils::TestEnum::getThisIdentifier());
-    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestEnum::getThisIdentifier());
+    const babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                                    testUtils::TestEnum::getThisType());
+    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestEnum::getThisType());
     babelwires::AllToSameFallbackMapEntryData allToSame;
 
     const auto oneToOneHash = oneToOne.getHash();
@@ -219,11 +219,11 @@ TEST(MapEntryDataTest, oneToOneHashSameTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
     EXPECT_EQ(oneToOneA.getHash(), oneToOneB.getHash());
 
@@ -248,17 +248,17 @@ TEST(MapEntryDataTest, oneToOneHashDifferentTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneA(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneB(typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestEnum::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneC(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                               testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneC(typeSystem, testUtils::TestEnum::getThisType(),
+                                               testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOneD(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                               testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOneD(typeSystem, testUtils::TestEnum::getThisType(),
+                                               testUtils::TestEnum::getThisType());
 
     EXPECT_NE(oneToOneA.getHash(), oneToOneB.getHash());
     EXPECT_NE(oneToOneA.getHash(), oneToOneC.getHash());
@@ -280,9 +280,9 @@ TEST(MapEntryDataTest, allToOneHashSameTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisType());
 
-    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestType::getThisType());
 
     EXPECT_EQ(allToOneA.getHash(), allToOneB.getHash());
 
@@ -301,9 +301,9 @@ TEST(MapEntryDataTest, allToOneHashDifferentTypes) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneA(typeSystem, testUtils::TestType::getThisType());
 
-    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestEnum::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOneB(typeSystem, testUtils::TestEnum::getThisType());
 
     EXPECT_NE(allToOneA.getHash(), allToOneB.getHash());
     EXPECT_NE(allToOneB.getHash(), allToOneA.getHash());
@@ -314,20 +314,20 @@ TEST(MapEntryDataTest, oneToOneValidate) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestEnum::getThisType());
 
-    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                  testUtils::TestType::getThisIdentifier(), false));
-    EXPECT_TRUE(oneToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), false));
-    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestType::getThisIdentifier(), false));
-    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), false));
+    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                  testUtils::TestType::getThisType(), false));
+    EXPECT_TRUE(oneToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), false));
+    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestType::getThisType(), false));
+    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestEnum::getThisType(), false));
 
-    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
+    EXPECT_FALSE(oneToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
 }
 
 TEST(MapEntryDataTest, allToOneValidate) {
@@ -335,19 +335,19 @@ TEST(MapEntryDataTest, allToOneValidate) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisType());
 
-    EXPECT_TRUE(allToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                  testUtils::TestType::getThisIdentifier(), true));
-    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
-    EXPECT_TRUE(allToOne.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestType::getThisIdentifier(), true));
-    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
+    EXPECT_TRUE(allToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                  testUtils::TestType::getThisType(), true));
+    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
+    EXPECT_TRUE(allToOne.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestType::getThisType(), true));
+    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
 
-    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestType::getThisIdentifier(), false));
+    EXPECT_FALSE(allToOne.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestType::getThisType(), false));
 }
 
 TEST(MapEntryDataTest, allToSameValidate) {
@@ -357,17 +357,17 @@ TEST(MapEntryDataTest, allToSameValidate) {
 
     babelwires::AllToSameFallbackMapEntryData allToSame;
 
-    EXPECT_TRUE(allToSame.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                  testUtils::TestType::getThisIdentifier(), true));
-    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
-    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestType::getThisIdentifier(), true));
-    EXPECT_TRUE(allToSame.validate(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                   testUtils::TestEnum::getThisIdentifier(), true));
+    EXPECT_TRUE(allToSame.validate(typeSystem, testUtils::TestType::getThisType(),
+                                  testUtils::TestType::getThisType(), true));
+    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
+    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestType::getThisType(), true));
+    EXPECT_TRUE(allToSame.validate(typeSystem, testUtils::TestEnum::getThisType(),
+                                   testUtils::TestEnum::getThisType(), true));
 
-    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                   testUtils::TestType::getThisIdentifier(), false));
+    EXPECT_FALSE(allToSame.validate(typeSystem, testUtils::TestType::getThisType(),
+                                   testUtils::TestType::getThisType(), false));
 }
 
 TEST(MapEntryDataTest, oneToOneGetAndSetValues) {
@@ -375,8 +375,8 @@ TEST(MapEntryDataTest, oneToOneGetAndSetValues) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestEnum::getThisType());
 
     testUtils::TestValue sourceValue;
     sourceValue.m_value = "source";
@@ -399,7 +399,7 @@ TEST(MapEntryDataTest, allToOneGetAndSetValues) {
     typeSystem.addEntry<testUtils::TestType>();
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisType());
 
     testUtils::TestValue targetValue;
     targetValue.m_value = "source";
@@ -417,8 +417,8 @@ TEST(MapEntryDataTest, oneToOneSerialize) {
         typeSystem.addEntry<testUtils::TestType>();  
         typeSystem.addEntry<testUtils::TestEnum>();
 
-        babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestEnum::getThisIdentifier());
+        babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestEnum::getThisType());
 
         testUtils::TestValue sourceValue;
         sourceValue.m_value = "test serialization";
@@ -462,7 +462,7 @@ TEST(MapEntryDataTest, allToOneSerialize) {
             babelwires::TypeSystem typeSystem;
         typeSystem.addEntry<testUtils::TestType>();  
 
-        babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
+        babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisType());
 
         testUtils::TestValue targetValue;
         targetValue.m_value = "test serialization";
@@ -519,8 +519,8 @@ TEST(MapEntryDataTest, oneToOneClone) {
     typeSystem.addEntry<testUtils::TestType>();  
     typeSystem.addEntry<testUtils::TestEnum>();
 
-    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                            testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                            testUtils::TestEnum::getThisType());
 
     testUtils::TestValue sourceValue;
     sourceValue.m_value = "test serialization";
@@ -552,7 +552,7 @@ TEST(MapEntryDataTest, allToOneClone) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();  
 
-    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisIdentifier());
+    babelwires::AllToOneFallbackMapEntryData allToOne(typeSystem, testUtils::TestType::getThisType());
 
     testUtils::TestValue targetValue;
     targetValue.m_value = "test serialization";

--- a/Tests/BabelWiresLib/mapFeatureTest.cpp
+++ b/Tests/BabelWiresLib/mapFeatureTest.cpp
@@ -26,7 +26,7 @@ namespace {
     template <typename SOURCE_TYPE, typename TARGET_TYPE> babelwires::TypeRef getTestMapTypeRef() {
         return babelwires::TypeRef(babelwires::MapTypeConstructor::getThisIdentifier(),
                                    babelwires::TypeConstructorArguments{
-                                       {SOURCE_TYPE::getThisIdentifier(), TARGET_TYPE::getThisIdentifier()},
+                                       {SOURCE_TYPE::getThisType(), TARGET_TYPE::getThisType()},
                                        {babelwires::EnumValue(babelwires::MapEntryFallbackKind::getIdentifierFromValue(
                                            babelwires::MapEntryFallbackKind::Value::All21))}});
     }
@@ -62,7 +62,7 @@ TEST(MapFeatureTest, isCompatible) {
     babelwires::ValueTreeRoot mapFeature2(testEnvironment.m_typeSystem,
                                                getTestMapTypeRef<testUtils::TestType, babelwires::DefaultIntType>());
     babelwires::ValueTreeRoot intFeature(testEnvironment.m_typeSystem,
-                                              babelwires::DefaultIntType::getThisIdentifier());
+                                              babelwires::DefaultIntType::getThisType());
 
     EXPECT_EQ(mapFeature1.getKind(), mapFeature2.getKind());
     EXPECT_NE(mapFeature1.getKind(), intFeature.getKind());

--- a/Tests/BabelWiresLib/mapHelperTest.cpp
+++ b/Tests/BabelWiresLib/mapHelperTest.cpp
@@ -70,8 +70,8 @@ namespace {
         testUtils::TestValue targetValue3;
         targetValue3.m_value = "zzz";
 
-        return setUpTestMapValue(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                testUtils::TestType::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+        return setUpTestMapValue(typeSystem, testUtils::TestType::getThisType(),
+                                testUtils::TestType::getThisType(), sourceValue1, sourceValue2, targetValue1,
                                 targetValue2, targetValue3, allToOneFallback);
     }
 
@@ -92,8 +92,8 @@ namespace {
         babelwires::EnumValue targetValue3;
         targetValue3.set("Erm");
 
-        return setUpTestMapValue(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+        return setUpTestMapValue(typeSystem, testUtils::TestEnum::getThisType(),
+                                testUtils::TestEnum::getThisType(), sourceValue1, sourceValue2, targetValue1,
                                 targetValue2, targetValue3, allToOneFallback);
     }
 
@@ -114,8 +114,8 @@ namespace {
         babelwires::EnumValue targetValue3;
         targetValue3.set("Erm");
 
-        return setUpTestMapValue(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+        return setUpTestMapValue(typeSystem, testUtils::TestType::getThisType(),
+                                testUtils::TestEnum::getThisType(), sourceValue1, sourceValue2, targetValue1,
                                 targetValue2, targetValue3, true);
     }
 
@@ -136,8 +136,8 @@ namespace {
         testUtils::TestValue targetValue3;
         targetValue3.m_value = "zzz";
 
-        return setUpTestMapValue(typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                testUtils::TestEnum::getThisIdentifier(), sourceValue1, sourceValue2, targetValue1,
+        return setUpTestMapValue(typeSystem, testUtils::TestEnum::getThisType(),
+                                testUtils::TestEnum::getThisType(), sourceValue1, sourceValue2, targetValue1,
                                 targetValue2, targetValue3, true);
     }
 } // namespace

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -24,19 +24,19 @@ TEST(MapProjectTest, mapProjectEntry) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();
 
-    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::MapProjectEntry entry(oneToOne.clone());
 
     EXPECT_EQ(oneToOne, entry.getData());
 
-    entry.validate(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier(),
+    entry.validate(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType(),
                    false);
 
     EXPECT_TRUE(entry.getValidity());
 
-    entry.validate(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier(),
+    entry.validate(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType(),
                    true);
 
     EXPECT_FALSE(entry.getValidity());
@@ -49,11 +49,11 @@ TEST(MapProjectTest, allowedTypes) {
         
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    EXPECT_TRUE(testUtils::unorderedAreEqualSets(mapProject.getAllowedSourceTypeRefs().m_typeRefs, {testUtils::TestType::getThisIdentifier()}));
-    EXPECT_TRUE(testUtils::unorderedAreEqualSets(mapProject.getAllowedTargetTypeRefs().m_typeRefs, {testUtils::TestEnum::getThisIdentifier()}));
+    EXPECT_TRUE(testUtils::unorderedAreEqualSets(mapProject.getAllowedSourceTypeRefs().m_typeRefs, {testUtils::TestType::getThisType()}));
+    EXPECT_TRUE(testUtils::unorderedAreEqualSets(mapProject.getAllowedTargetTypeRefs().m_typeRefs, {testUtils::TestEnum::getThisType()}));
 }
 
 TEST(MapProjectTest, getProjectContext) {
@@ -69,14 +69,14 @@ TEST(MapProjectTest, types) {
         
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    mapProject.setCurrentSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapProject.setCurrentSourceTypeRef(testUtils::TestType::getThisType());
+    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisType());
 
-    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestType::getThisIdentifier());
-    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestEnum::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestType::getThisType());
+    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestEnum::getThisType());
 
     EXPECT_EQ(mapProject.getCurrentSourceType(),
               &environment.m_typeSystem.getEntryByType<testUtils::TestType>());
@@ -89,24 +89,24 @@ TEST(MapProjectTest, badTypes) {
         
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
     EXPECT_TRUE(mapProject.getSourceTypeValidity());
     EXPECT_TRUE(mapProject.getTargetTypeValidity());
 
-    mapProject.setCurrentSourceTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapProject.setCurrentSourceTypeRef(testUtils::TestEnum::getThisType());
 
     EXPECT_FALSE(mapProject.getSourceTypeValidity());
     EXPECT_TRUE(mapProject.getTargetTypeValidity());
 
-    mapProject.setCurrentTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapProject.setCurrentTargetTypeRef(testUtils::TestType::getThisType());
 
     EXPECT_FALSE(mapProject.getSourceTypeValidity());
     EXPECT_FALSE(mapProject.getTargetTypeValidity());
 
-    mapProject.setCurrentSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapProject.setCurrentSourceTypeRef(testUtils::TestType::getThisType());
+    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisType());
     
     EXPECT_TRUE(mapProject.getSourceTypeValidity());
     EXPECT_TRUE(mapProject.getTargetTypeValidity());
@@ -123,24 +123,24 @@ TEST(MapProjectTest, setAndExtractMapValue) {
             
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestSubEnum::getThisType());
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestSubEnum::getThisIdentifier());
+                                                      testUtils::TestSubEnum::getThisType());
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisType());
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
 
     mapProject.setMapValue(mapValue);
 
-    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestType::getThisIdentifier());
-    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubEnum::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestType::getThisType());
+    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubEnum::getThisType());
     EXPECT_EQ(mapProject.extractMapValue(), mapValue);
     EXPECT_EQ(mapProject.getNumMapEntries(), 2);
     EXPECT_EQ(mapProject.getMapEntry(0).getData(), oneToOne);
@@ -152,24 +152,24 @@ TEST(MapProjectTest, modifyMapValue) {
             
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestSubEnum::getThisType());
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestSubEnum::getThisIdentifier());
+                                                      testUtils::TestSubEnum::getThisType());
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisType());
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
 
     mapProject.setMapValue(mapValue);
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestSubEnum::getThisType());
     testUtils::TestValue newSourceValue;
     newSourceValue.m_value = "Source";
     babelwires::EnumValue newTargetValue;
@@ -192,7 +192,7 @@ TEST(MapProjectTest, modifyMapValue) {
     EXPECT_EQ(mapProject.getMapEntry(1).getData(), allToOne);
 
     babelwires::AllToOneFallbackMapEntryData allToOne2(environment.m_typeSystem,
-                                                       testUtils::TestSubEnum::getThisIdentifier());
+                                                       testUtils::TestSubEnum::getThisType());
     babelwires::EnumValue newTargetValue2;
     newTargetValue2.set("Oom");
     allToOne2.setTargetValue(newTargetValue2);
@@ -208,11 +208,11 @@ TEST(MapProjectTest, typeChangeAndValidity) {
             
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestEnum::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestSubEnum::getThisIdentifier(),
-                                              testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestSubEnum::getThisType(),
+                                              testUtils::TestSubEnum::getThisType());
     babelwires::EnumValue newSourceValue;
     newSourceValue.set("Oom");
     babelwires::EnumValue newTargetValue;
@@ -221,14 +221,14 @@ TEST(MapProjectTest, typeChangeAndValidity) {
     oneToOne.setTargetValue(newTargetValue);
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestSubEnum::getThisIdentifier());
+                                                      testUtils::TestSubEnum::getThisType());
     babelwires::EnumValue newTargetValue2;
     newTargetValue2.set("Erm");
     allToOne.setTargetValue(newTargetValue2);
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestSubEnum::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestSubEnum::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisType());
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
 
@@ -237,22 +237,22 @@ TEST(MapProjectTest, typeChangeAndValidity) {
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
 
-    mapProject.setCurrentTargetTypeRef(testUtils::TestSubSubEnum1::getThisIdentifier());
+    mapProject.setCurrentTargetTypeRef(testUtils::TestSubSubEnum1::getThisType());
 
     EXPECT_FALSE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
 
-    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapProject.setCurrentTargetTypeRef(testUtils::TestEnum::getThisType());
 
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
 
-    mapProject.setCurrentSourceTypeRef(testUtils::TestSubSubEnum1::getThisIdentifier());
+    mapProject.setCurrentSourceTypeRef(testUtils::TestSubSubEnum1::getThisType());
 
     EXPECT_FALSE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
 
-    mapProject.setCurrentSourceTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapProject.setCurrentSourceTypeRef(testUtils::TestEnum::getThisType());
 
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
@@ -263,33 +263,33 @@ TEST(MapProjectTest, modifyValidity) {
             
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestSubEnum::getThisType());
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestSubEnum::getThisIdentifier());
+                                                      testUtils::TestSubEnum::getThisType());
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestSubEnum::getThisType());
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
 
     mapProject.setMapValue(mapValue);
 
     // Wrong types
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                               testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestEnum::getThisType(),
+                                               testUtils::TestSubEnum::getThisType());
 
     mapProject.addMapEntry(oneToOne2.clone(), 0);
 
     EXPECT_FALSE(mapProject.getMapEntry(0).getValidity());
 
     // Only fallbacks allowed in the last position.
-    babelwires::OneToOneMapEntryData oneToOne3(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                               testUtils::TestSubEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne3(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                               testUtils::TestSubEnum::getThisType());
 
     mapProject.replaceMapEntry(oneToOne3.clone(), 2);
 
@@ -301,19 +301,19 @@ TEST(MapProjectTest, badMap) {
         
     babelwires::MapProject mapProject(environment.m_projectContext);
 
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
     babelwires::MapValue mapValue;
     mapValue.setSourceTypeRef(testTypeId1);
-    mapValue.setTargetTypeRef(testUtils::TestEnum::getThisIdentifier());
+    mapValue.setTargetTypeRef(testUtils::TestEnum::getThisType());
 
     mapProject.setMapValue(mapValue);
 
     EXPECT_FALSE(mapProject.getSourceTypeValidity());
     EXPECT_TRUE(mapProject.getTargetTypeValidity());
 
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
     mapValue.setTargetTypeRef(testTypeId2);
     mapProject.setMapValue(mapValue);
 

--- a/Tests/BabelWiresLib/mapValueTest.cpp
+++ b/Tests/BabelWiresLib/mapValueTest.cpp
@@ -135,17 +135,17 @@ TEST(MapValueTest, equality) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();
 
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
 
     EXPECT_FALSE(mapValue == mapValue2);
     EXPECT_TRUE(mapValue != mapValue2);
 
-    mapValue2.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue2.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
 
     EXPECT_TRUE(mapValue == mapValue2);
     EXPECT_FALSE(mapValue != mapValue2);
 
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
     mapValue2.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
 
     EXPECT_FALSE(mapValue == mapValue2);
@@ -179,15 +179,15 @@ TEST(MapValueTest, getHash) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();
 
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
 
     EXPECT_NE(mapValue.getHash(), mapValue2.getHash());
 
-    mapValue2.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue2.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
 
     EXPECT_EQ(mapValue.getHash(), mapValue2.getHash());
 
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
     mapValue2.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
 
     EXPECT_NE(mapValue.getHash(), mapValue2.getHash());
@@ -199,9 +199,9 @@ TEST(MapValueTest, isInvalid_validMap) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();  
 
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
     mapValue.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
 
     EXPECT_TRUE(mapValue.isValid(typeSystem));
@@ -218,9 +218,9 @@ TEST(MapValueTest, isInvalid_outOfPlaceFallback) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();  
 
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
     mapValue.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
     mapValue.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
 
@@ -233,9 +233,9 @@ TEST(MapValueTest, isInvalid_noFallback) {
     babelwires::TypeSystem typeSystem;
     typeSystem.addEntry<testUtils::TestType>();  
 
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
 
     EXPECT_FALSE(mapValue.isValid(typeSystem));
 }
@@ -247,8 +247,8 @@ TEST(MapValueTest, isValid_typeMismatch) {
     typeSystem.addEntry<testUtils::TestType>();  
 
     mapValue.setSourceTypeRef(testTypeId1);
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier()));
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
+    mapValue.emplaceBack(std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType()));
     mapValue.emplaceBack(std::make_unique<babelwires::AllToSameFallbackMapEntryData>());
 
     EXPECT_FALSE(mapValue.isValid(typeSystem));
@@ -265,7 +265,7 @@ TEST(MapValueTest, serializationTest) {
         typeSystem.addEntry<testUtils::TestType>();  
 
         // Note: We want to be able to serialize when entries do not match the types, as in this case.
-        auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier());
+        auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType());
         testUtils::TestValue entrySourceValue;
         entrySourceValue.m_value = "test mapValue serialization";
         entryData->setSourceValue(entrySourceValue);
@@ -308,7 +308,7 @@ TEST(MapValueTest, cloneTest) {
     typeSystem.addEntry<testUtils::TestType>();  
 
     // Note: We want to be able to clone when entries do not match the types, as in this case.
-    auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisIdentifier(), testUtils::TestType::getThisIdentifier());
+    auto entryData = std::make_unique<babelwires::OneToOneMapEntryData>(typeSystem, testUtils::TestType::getThisType(), testUtils::TestType::getThisType());
     auto entryDataPtr = entryData.get();
     testUtils::TestValue entrySourceValue;
     entrySourceValue.m_value = "test mapValue serialization";

--- a/Tests/BabelWiresLib/modifierDataTest.cpp
+++ b/Tests/BabelWiresLib/modifierDataTest.cpp
@@ -26,7 +26,7 @@ TEST(ModifierDataTest, arrayInitializationApply) {
     babelwires::ArraySizeModifierData data;
     data.m_size = testUtils::TestSimpleArrayType::s_nonDefaultSize;
 
-    babelwires::ValueTreeRoot arrayFeature(testEnvironment.m_typeSystem, testUtils::TestSimpleArrayType::getThisIdentifier());
+    babelwires::ValueTreeRoot arrayFeature(testEnvironment.m_typeSystem, testUtils::TestSimpleArrayType::getThisType());
     arrayFeature.setToDefault();
 
     EXPECT_EQ(arrayFeature.getNumChildren(), testUtils::TestSimpleArrayType::s_defaultSize);
@@ -34,7 +34,7 @@ TEST(ModifierDataTest, arrayInitializationApply) {
     data.apply(&arrayFeature);
     EXPECT_EQ(arrayFeature.getNumChildren(), testUtils::TestSimpleArrayType::s_nonDefaultSize);
 
-    babelwires::ValueTreeRoot notArrayFeature(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisIdentifier());
+    babelwires::ValueTreeRoot notArrayFeature(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisType());
     EXPECT_THROW(data.apply(&notArrayFeature), babelwires::ModelException);
 }
 
@@ -76,9 +76,9 @@ TEST(ModifierDataTest, assignFromFeatureApply) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot srcFeature{testEnvironment.m_typeSystem,
-                                              babelwires::DefaultIntType::getThisIdentifier()};
+                                              babelwires::DefaultIntType::getThisType()};
     babelwires::ValueTreeRoot targetFeature{testEnvironment.m_typeSystem,
-                                                 babelwires::DefaultIntType::getThisIdentifier()};
+                                                 babelwires::DefaultIntType::getThisType()};
 
     srcFeature.setToDefault();
     targetFeature.setToDefault();
@@ -116,9 +116,9 @@ TEST(ModifierDataTest, assignFromFeatureBadConnectionApply) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot srcFeature{testEnvironment.m_typeSystem,
-                                              babelwires::DefaultIntType::getThisIdentifier()};
+                                              babelwires::DefaultIntType::getThisType()};
     babelwires::ValueTreeRoot targetFeature{testEnvironment.m_typeSystem,
-                                                 babelwires::StringType::getThisIdentifier()};
+                                                 babelwires::StringType::getThisType()};
 
     srcFeature.setToDefault();
     targetFeature.setToDefault();

--- a/Tests/BabelWiresLib/modifierTest.cpp
+++ b/Tests/BabelWiresLib/modifierTest.cpp
@@ -86,7 +86,7 @@ TEST(ModifierTest, localApplySuccess) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot recordFeature{testEnvironment.m_projectContext.m_typeSystem,
-                                                 testUtils::TestSimpleRecordType::getThisIdentifier()};
+                                                 testUtils::TestSimpleRecordType::getThisType()};
     recordFeature.setToDefault();
 
     babelwires::Path path;
@@ -113,7 +113,7 @@ TEST(ModifierTest, localApplyFailureWrongType) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot recordFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                 testUtils::TestSimpleRecordType::getThisType());
     recordFeature.setToDefault();
 
     babelwires::Path path;
@@ -139,7 +139,7 @@ TEST(ModifierTest, localApplyFailureNoTarget) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot recordFeature{testEnvironment.m_projectContext.m_typeSystem,
-                                                 testUtils::TestSimpleRecordType::getThisIdentifier()};
+                                                 testUtils::TestSimpleRecordType::getThisType()};
     recordFeature.setToDefault();
 
     babelwires::Path path;
@@ -168,7 +168,7 @@ TEST(ModifierTest, arraySizeModifierSuccess) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot recordFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
     recordFeature.setToDefault();
 
     auto arrayModData = std::make_unique<babelwires::ArraySizeModifierData>();
@@ -200,7 +200,7 @@ TEST(ModifierTest, arraySizeModifierFailure) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot recordFeature(testEnvironment.m_typeSystem,
-                                                 testUtils::TestComplexRecordType::getThisIdentifier());
+                                                 testUtils::TestComplexRecordType::getThisType());
     recordFeature.setToDefault();
 
     testUtils::TestComplexRecordType::ConstInstance record(recordFeature);
@@ -238,7 +238,7 @@ TEST(ModifierTest, connectionModifierSuccess) {
     const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(elementData);
 
     babelwires::ValueTreeRoot targetRecordFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                       testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                       testUtils::TestSimpleRecordType::getThisType());
     targetRecordFeature.setToDefault();
 
     babelwires::Path targetPath;
@@ -264,7 +264,7 @@ TEST(ModifierTest, connectionModifierTargetPathFailure) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot targetRecordFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                       testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                       testUtils::TestSimpleRecordType::getThisType());
     targetRecordFeature.setToDefault();
 
     const babelwires::Path sourcePath = babelwires::Path::deserializeFromString("aa");
@@ -294,7 +294,7 @@ TEST(ModifierTest, connectionModifierSourceIdFailure) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::ValueTreeRoot targetRecordFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                       testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                       testUtils::TestSimpleRecordType::getThisType());
     targetRecordFeature.setToDefault();
 
     const babelwires::Path sourcePath = babelwires::Path::deserializeFromString("aa");
@@ -334,7 +334,7 @@ TEST(ModifierTest, connectionModifierSourcePathFailure) {
     const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(elementData);
 
     babelwires::ValueTreeRoot targetRecordFeature(testEnvironment.m_projectContext.m_typeSystem,
-                                                       testUtils::TestSimpleRecordType::getThisIdentifier());
+                                                       testUtils::TestSimpleRecordType::getThisType());
     targetRecordFeature.setToDefault();
 
     babelwires::Path targetPath;
@@ -364,7 +364,7 @@ TEST(ModifierTest, connectionModifierSourcePathFailure) {
 TEST(ModifierTest, connectionModifierApplicationFailure) {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueElementData elementData{testUtils::TestComplexRecordType::getThisIdentifier()};
+    babelwires::ValueElementData elementData{testUtils::TestComplexRecordType::getThisType()};
 
     const babelwires::Path sourcePath{
         std::vector<babelwires::PathStep>{babelwires::PathStep(testUtils::TestComplexRecordType::getSubrecordId()),
@@ -377,7 +377,7 @@ TEST(ModifierTest, connectionModifierApplicationFailure) {
     const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(elementData);
 
     babelwires::ValueTreeRoot targetRecordFeature(testEnvironment.m_typeSystem,
-                                                       testUtils::TestComplexRecordType::getThisIdentifier());
+                                                       testUtils::TestComplexRecordType::getThisType());
     targetRecordFeature.setToDefault();
     testUtils::TestComplexRecordType::Instance targetInstance{targetRecordFeature};
     targetInstance.getstring().set("Hello");

--- a/Tests/BabelWiresLib/parallelProcessorTest.cpp
+++ b/Tests/BabelWiresLib/parallelProcessorTest.cpp
@@ -47,8 +47,8 @@ namespace {
 
     struct TestParallelProcessor : babelwires::ParallelProcessor {
         TestParallelProcessor(const babelwires::ProjectContext& context)
-            : babelwires::ParallelProcessor(context, TestParallelProcessorInput::getThisIdentifier(),
-                                            TestParallelProcessorOutput::getThisIdentifier()) {}
+            : babelwires::ParallelProcessor(context, TestParallelProcessorInput::getThisType(),
+                                            TestParallelProcessorOutput::getThisType()) {}
 
         void processEntry(babelwires::UserLogger& userLogger, const babelwires::ValueTreeNode& input,
                           const babelwires::ValueTreeNode& inputEntry,

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -254,13 +254,13 @@ TEST(ProjectBundleTest, factoryIdentifiers) {
 
     // Prepopulate the identifierRegistry with clashing factory identifier.
     // I don't expect duplicate factory identifiers, but this will make it easier to test
-    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestProcessorFactory::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestProcessorFactory::getThisType(),
                                                              "Other test processor",
 "41000000-1111-2222-3333-888888888888", babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestSourceFileFormat::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestSourceFileFormat::getThisType(),
                                                              "Other test source factory",
 "41000000-1111-2222-3333-999999999999", babelwires::IdentifierRegistry::Authority::isAuthoritative);
-    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestTargetFileFormat::getThisIdentifier(),
+    babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(testUtils::TestTargetFileFormat::getThisType(),
                                                              "Other test target factory",
 "41000000-1111-2222-3333-aaaaaaaaaaaa", babelwires::IdentifierRegistry::Authority::isAuthoritative);
 

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -308,61 +308,61 @@ TEST(RecordTypeTest, subtype)
 
     struct RecordA0 : babelwires::RecordType {
         RecordA0() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA", 1), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 1), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordA0"), 1);
     };
 
     struct RecordA1 : babelwires::RecordType {
         RecordA1() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA", 2), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 2), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordA1"), 1);
     };
 
     struct RecordB : babelwires::RecordType {
         RecordB() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordB"), 1);
     };
 
     struct RecordAB : babelwires::RecordType {
         RecordAB() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAB"), 1);
     };
 
     struct RecordAS : babelwires::RecordType {
         RecordAS() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA", 3), babelwires::StringType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 3), babelwires::StringType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAS"), 1);
     };
 
     struct RecordAOpt : babelwires::RecordType {
         RecordAOpt() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::DefaultIntType::getThisIdentifier(), babelwires::RecordType::Optionality::optionalDefaultInactive}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::DefaultIntType::getThisType(), babelwires::RecordType::Optionality::optionalDefaultInactive}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAOpt"), 1);
     };
 
     struct RecordABOpt : babelwires::RecordType {
         RecordABOpt() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::DefaultIntType::getThisIdentifier(), babelwires::RecordType::Optionality::optionalDefaultInactive}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::DefaultIntType::getThisType(), babelwires::RecordType::Optionality::optionalDefaultInactive}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordABOpt"), 1);
     };
 
     struct RecordAOptS : babelwires::RecordType {
         RecordAOptS() : RecordType({
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::StringType::getThisIdentifier(), babelwires::RecordType::Optionality::optionalDefaultInactive}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fOpt"), babelwires::StringType::getThisType(), babelwires::RecordType::Optionality::optionalDefaultInactive}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAOptS"), 1);
     };
@@ -377,35 +377,35 @@ TEST(RecordTypeTest, subtype)
     testEnvironment.m_typeSystem.addEntry<RecordABOpt>();
     testEnvironment.m_typeSystem.addEntry<RecordAOptS>();
 
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordWithNoFields::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordWithNoFields::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordA1::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA1::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordB::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordWithNoFields::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordWithNoFields::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordA1::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA1::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordB::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsSupertype);
 
     // Incompatible types
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAS::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAS::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
     
     // With optionals: Optional fields do not impact subtyping since they are not part of the type's contract,
     // unless the types are incompatible (see next sequence of tests, below).
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAOpt::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOpt::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordABOpt::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABOpt::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAOpt::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOpt::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordABOpt::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABOpt::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSubtype);
 
     // Incompatible and optional
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOpt::getThisIdentifier(), RecordAOptS::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOptS::getThisIdentifier(), RecordAOpt::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);    
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOpt::getThisType(), RecordAOptS::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAOptS::getThisType(), RecordAOpt::getThisType()), babelwires::SubtypeOrder::IsUnrelated);    
 }
 
 TEST(RecordTypeTest, featureChanges)
 {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueTreeRoot valueFeature(testEnvironment.m_typeSystem, testUtils::TestComplexRecordType::getThisIdentifier());
+    babelwires::ValueTreeRoot valueFeature(testEnvironment.m_typeSystem, testUtils::TestComplexRecordType::getThisType());
     valueFeature.setToDefault();
 
     const testUtils::TestComplexRecordType* recordType = valueFeature.getType().as<testUtils::TestComplexRecordType>();

--- a/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
@@ -313,71 +313,71 @@ TEST(RecordWithVariantsTypeTest, subtype)
 
     struct RecordA0 : babelwires::RecordWithVariantsType {
         RecordA0() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA", 1), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 1), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordA0"), 1);
     };
 
     struct RecordA1 : babelwires::RecordWithVariantsType {
         RecordA1() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA", 2), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 2), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordA1"), 1);
     };
 
     struct RecordB : babelwires::RecordWithVariantsType {
         RecordB() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordB"), 1);
     };
 
     struct RecordAB : babelwires::RecordWithVariantsType {
         RecordAB() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAB"), 1);
     };
 
     struct RecordAS : babelwires::RecordWithVariantsType {
         RecordAS() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA", 3), babelwires::StringType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA", 3), babelwires::StringType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAS"), 1);
     };
 
     struct RecordAV0 : babelwires::RecordWithVariantsType {
         RecordAV0() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1), testUtils::getTestRegisteredIdentifier("tag0", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisIdentifier(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisType(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAV0"), 1);
     };
 
     struct RecordABV0 : babelwires::RecordWithVariantsType {
         RecordABV0() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1), testUtils::getTestRegisteredIdentifier("tag0", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisIdentifier(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisType(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordABV0"), 1);
     };
 
     struct RecordABV01 : babelwires::RecordWithVariantsType {
         RecordABV01() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1), testUtils::getTestRegisteredIdentifier("tag0", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisIdentifier(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("field1"), babelwires::DefaultIntType::getThisIdentifier(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("field0"), babelwires::DefaultIntType::getThisType(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("field1"), babelwires::DefaultIntType::getThisType(), {testUtils::getTestRegisteredIdentifier("tag0", 1)}}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordABV01"), 1);
     };
 
     struct RecordAVB : babelwires::RecordWithVariantsType {
         RecordAVB() : RecordWithVariantsType({testUtils::getTestRegisteredIdentifier("dtag", 1), testUtils::getTestRegisteredIdentifier("tag0", 1)}, {
-            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisIdentifier()},
-            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisIdentifier(), {testUtils::getTestRegisteredIdentifier("dtag", 1)}}
+            {testUtils::getTestRegisteredIdentifier("fieldA"), babelwires::DefaultIntType::getThisType()},
+            {testUtils::getTestRegisteredIdentifier("fieldB"), babelwires::DefaultIntType::getThisType(), {testUtils::getTestRegisteredIdentifier("dtag", 1)}}
         }) {}
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("RecordAVB"), 1);
     };
@@ -393,39 +393,39 @@ TEST(RecordWithVariantsTypeTest, subtype)
     testEnvironment.m_typeSystem.addEntry<RecordABV01>();
     testEnvironment.m_typeSystem.addEntry<RecordAVB>();
 
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordWithNoFields::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordWithNoFields::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordA1::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA1::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsEquivalent);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordB::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordWithNoFields::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordWithNoFields::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordA1::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA1::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsEquivalent);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordB::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsSupertype);
 
     // Incompatible types
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAS::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAS::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAS::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
 
     // With variants
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAV0::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAV0::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordABV0::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAB::getThisIdentifier(), RecordABV0::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisIdentifier(), RecordABV01::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV01::getThisIdentifier(), RecordABV0::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAV0::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAV0::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordABV0::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAB::getThisType(), RecordABV0::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV0::getThisType(), RecordABV01::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordABV01::getThisType(), RecordABV0::getThisType()), babelwires::SubtypeOrder::IsSubtype);
 
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisIdentifier(), RecordAVB::getThisIdentifier()), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAVB::getThisIdentifier(), RecordA0::getThisIdentifier()), babelwires::SubtypeOrder::IsSubtype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAB::getThisIdentifier(), RecordAVB::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAVB::getThisIdentifier(), RecordAB::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordA0::getThisType(), RecordAVB::getThisType()), babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAVB::getThisType(), RecordA0::getThisType()), babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAB::getThisType(), RecordAVB::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(RecordAVB::getThisType(), RecordAB::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
 }
 
 TEST(RecordWithVariantsTypeTest, featureChanges)
 {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::ValueTreeRoot valueFeature(testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisIdentifier());
+    babelwires::ValueTreeRoot valueFeature(testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisType());
     valueFeature.setToDefault();
 
     const testUtils::TestRecordWithVariantsType* recordWithVariantsType = valueFeature.getType().as<testUtils::TestRecordWithVariantsType>();

--- a/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
@@ -17,18 +17,18 @@ TEST(RemoveEntryFromMapCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
 
@@ -65,18 +65,18 @@ TEST(RemoveEntryFromMapCommandTest, removeInvalid) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
@@ -112,18 +112,18 @@ TEST(RemoveEntryFromMapCommandTest, failAtEnd) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());

--- a/Tests/BabelWiresLib/removeModifierCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeModifierCommandTest.cpp
@@ -119,12 +119,12 @@ TEST(RemoveModifierCommandTest, executeAndUndoOptionals) {
     testUtils::TestEnvironment testEnvironment;
 
     const babelwires::ElementId elementId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestComplexRecordType::getThisType()));
 
     const babelwires::ElementId sourceId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisType()));
     const babelwires::ElementId targetId = testEnvironment.m_project.addFeatureElement(
-        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisIdentifier()));
+        babelwires::ValueElementData(testUtils::TestSimpleRecordType::getThisType()));
 
     const babelwires::ValueElement* const element =
         testEnvironment.m_project.getFeatureElement(elementId)->as<babelwires::ValueElement>();

--- a/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
+++ b/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
@@ -17,18 +17,18 @@ TEST(ReplaceMapEntryCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
 
@@ -43,8 +43,8 @@ TEST(ReplaceMapEntryCommandTest, executeAndUndo) {
     mapValue.emplaceBack(allToOne.clone());
     mapProject.setMapValue(mapValue);
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
     newSourceValue.m_value = "Source2";
     newTargetValue.m_value = "Target2";
     oneToOne2.setSourceValue(newSourceValue);
@@ -72,18 +72,18 @@ TEST(ReplaceMapEntryCommandTest, failBeyondEnd) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
@@ -97,18 +97,18 @@ TEST(ReplaceMapEntryCommandTest, replaceInvalid) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());
@@ -119,8 +119,8 @@ TEST(ReplaceMapEntryCommandTest, replaceInvalid) {
     EXPECT_FALSE(mapProject.getMapEntry(1).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(2).getValidity());
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
     testUtils::TestValue newSourceValue;
     testUtils::TestValue newTargetValue;
     newSourceValue.m_value = "Source2";
@@ -155,18 +155,18 @@ TEST(ReplaceMapEntryCommandTest, failInvalid) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
     mapValue.emplaceBack(allToOne.clone());

--- a/Tests/BabelWiresLib/selectRecordVariantModifierDataTest.cpp
+++ b/Tests/BabelWiresLib/selectRecordVariantModifierDataTest.cpp
@@ -18,7 +18,7 @@
 TEST(SelectRecordVariantModifierDataTest, apply) {
     testUtils::TestEnvironment testEnvironment;
     babelwires::ValueTreeRoot valueFeature(
-        testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisIdentifier());
+        testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisType());
     valueFeature.setToDefault();
     const auto* type = valueFeature.getType().as<testUtils::TestRecordWithVariantsType>();
 
@@ -45,7 +45,7 @@ TEST(SelectRecordVariantModifierDataTest, failureNotATag) {
 
     testUtils::TestEnvironment testEnvironment;
     babelwires::ValueTreeRoot valueFeature(
-        testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisIdentifier());
+        testEnvironment.m_typeSystem, testUtils::TestRecordWithVariantsType::getThisType());
 
     valueFeature.setToDefault();
 
@@ -58,7 +58,7 @@ TEST(SelectRecordVariantModifierDataTest, failureNotAUnion) {
     data.m_tagToSelect = "tag";
 
     babelwires::ValueTreeRoot notARecordWithVariants(
-        testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisIdentifier());
+        testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisType());
 
     EXPECT_THROW(data.apply(&notARecordWithVariants), babelwires::ModelException);
 }

--- a/Tests/BabelWiresLib/setMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapCommandTest.cpp
@@ -17,18 +17,18 @@ TEST(SetMapCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     mapValue.emplaceBack(oneToOne.clone());
 
@@ -49,12 +49,12 @@ TEST(SetMapCommandTest, executeAndUndo) {
     EXPECT_EQ(mapProject.getMapEntry(1).getData(), oneToOne);
     EXPECT_EQ(mapProject.getMapEntry(2).getData().getKind(), babelwires::MapEntryData::Kind::All21);
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::MapValue mapValue2;
-    mapValue2.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue2.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue2.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue2.setTargetTypeRef(testUtils::TestType::getThisType());
     newSourceValue.m_value = "Source2";
     newTargetValue.m_value = "Target2";
     oneToOne2.setSourceValue(newSourceValue);
@@ -84,18 +84,18 @@ TEST(SetMapCommandTest, invalidOldMap) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     testUtils::TestValue newSourceValue;
     newSourceValue.m_value = "Source";
@@ -118,12 +118,12 @@ TEST(SetMapCommandTest, invalidOldMap) {
     EXPECT_FALSE(mapProject.getMapEntry(1).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(2).getValidity());
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::MapValue mapValue2;
-    mapValue2.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue2.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue2.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue2.setTargetTypeRef(testUtils::TestType::getThisType());
     newSourceValue.m_value = "Source2";
     newTargetValue.m_value = "Target2";
     oneToOne2.setSourceValue(newSourceValue);
@@ -158,18 +158,18 @@ TEST(SetMapCommandTest, invalidNewMap) {
     testUtils::TestEnvironment environment;
     
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
 
     testUtils::TestValue newSourceValue;
     newSourceValue.m_value = "Source";
@@ -189,12 +189,12 @@ TEST(SetMapCommandTest, invalidNewMap) {
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
 
-    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne2(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::MapValue mapValue2;
-    mapValue2.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue2.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue2.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue2.setTargetTypeRef(testUtils::TestType::getThisType());
     newSourceValue.m_value = "Source2";
     newTargetValue.m_value = "Target2";
     oneToOne2.setSourceValue(newSourceValue);

--- a/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
@@ -19,18 +19,18 @@ TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
 
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestEnum::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestSubSubEnum1::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestSubSubEnum1::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestEnum::getThisIdentifier(),
-                                              testUtils::TestType::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestEnum::getThisType(),
+                                              testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestType::getThisIdentifier());
+                                                      testUtils::TestType::getThisType());
 
     babelwires::EnumValue newSourceValue;
     newSourceValue.set("Erm");
@@ -49,18 +49,18 @@ TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
 
     mapProject.setMapValue(mapValue);
 
-    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum1::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum1::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(3).getValidity());
 
-    babelwires::SetMapSourceTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisIdentifier());
+    babelwires::SetMapSourceTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisType());
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);
 
-    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum2::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum2::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(1).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(2).getValidity());
@@ -68,7 +68,7 @@ TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
 
     command.undo(mapProject);
 
-    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum1::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentSourceTypeRef(), testUtils::TestSubSubEnum1::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
@@ -79,20 +79,20 @@ TEST(SetMapSourceTypeCommandTest, failWithUnallowedType) {
     testUtils::TestEnvironment environment;
         
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                      testUtils::TestType::getThisIdentifier());
+                                                      testUtils::TestType::getThisType());
     mapValue.emplaceBack(allToOne.clone());
 
     mapProject.setMapValue(mapValue);
 
-    babelwires::SetMapSourceTypeCommand command("Set type", testUtils::TestEnum::getThisIdentifier());
+    babelwires::SetMapSourceTypeCommand command("Set type", testUtils::TestEnum::getThisType());
 
     EXPECT_FALSE(command.initialize(mapProject));
 }

--- a/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
@@ -19,18 +19,18 @@ TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
     testUtils::TestEnvironment environment;
 
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestEnum::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestSubSubEnum1::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestSubSubEnum1::getThisType());
 
-    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisIdentifier(),
-                                              testUtils::TestEnum::getThisIdentifier());
+    babelwires::OneToOneMapEntryData oneToOne(environment.m_typeSystem, testUtils::TestType::getThisType(),
+                                              testUtils::TestEnum::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestEnum::getThisIdentifier());
+                                                       testUtils::TestEnum::getThisType());
 
     babelwires::EnumValue newTargetValue;
     newTargetValue.set("Erm");
@@ -51,18 +51,18 @@ TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
 
     mapProject.setMapValue(mapValue);
 
-    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum1::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum1::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(3).getValidity());
 
-    babelwires::SetMapTargetTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisIdentifier());
+    babelwires::SetMapTargetTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisType());
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);
 
-    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum2::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum2::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(1).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(2).getValidity());
@@ -70,7 +70,7 @@ TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
 
     command.undo(mapProject);
 
-    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum1::getThisIdentifier());
+    EXPECT_EQ(mapProject.getCurrentTargetTypeRef(), testUtils::TestSubSubEnum1::getThisType());
     EXPECT_TRUE(mapProject.getMapEntry(0).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(1).getValidity());
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
@@ -81,20 +81,20 @@ TEST(SetMapTargetTypeCommandTest, failWithUnallowedType) {
     testUtils::TestEnvironment environment;
         
     babelwires::MapProject mapProject(environment.m_projectContext);
-    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisIdentifier()}});
-    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisIdentifier()}});
+    mapProject.setAllowedSourceTypeRefs({{testUtils::TestType::getThisType()}});
+    mapProject.setAllowedTargetTypeRefs({{testUtils::TestType::getThisType()}});
 
     babelwires::MapValue mapValue;
-    mapValue.setSourceTypeRef(testUtils::TestType::getThisIdentifier());
-    mapValue.setTargetTypeRef(testUtils::TestType::getThisIdentifier());
+    mapValue.setSourceTypeRef(testUtils::TestType::getThisType());
+    mapValue.setTargetTypeRef(testUtils::TestType::getThisType());
 
     babelwires::AllToOneFallbackMapEntryData allToOne(environment.m_typeSystem,
-                                                       testUtils::TestType::getThisIdentifier());
+                                                       testUtils::TestType::getThisType());
     mapValue.emplaceBack(allToOne.clone());
 
     mapProject.setMapValue(mapValue);
 
-    babelwires::SetMapTargetTypeCommand command("Set type", testUtils::TestEnum::getThisIdentifier());
+    babelwires::SetMapTargetTypeCommand command("Set type", testUtils::TestEnum::getThisType());
 
     EXPECT_FALSE(command.initialize(mapProject));
 }

--- a/Tests/BabelWiresLib/sumOfMapsTypeTest.cpp
+++ b/Tests/BabelWiresLib/sumOfMapsTypeTest.cpp
@@ -19,9 +19,9 @@ namespace {
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("TestSumOfMapsType"), 1);
         TestSumOfMapsType()
             : babelwires::SumOfMapsType(
-                  {babelwires::DefaultIntType::getThisIdentifier(),
-                   babelwires::DefaultRationalType::getThisIdentifier()},
-                  {babelwires::DefaultIntType::getThisIdentifier(), babelwires::StringType::getThisIdentifier()}, 1,
+                  {babelwires::DefaultIntType::getThisType(),
+                   babelwires::DefaultRationalType::getThisType()},
+                  {babelwires::DefaultIntType::getThisType(), babelwires::StringType::getThisType()}, 1,
                   0) {}
     };
 } // namespace
@@ -34,11 +34,11 @@ TEST(SumOfMapsTypeTest, sumOfMapsTypeConstructor) {
     EXPECT_EQ(sumOfMapsType.getSummands().size(), 2 * 2);
 
     EXPECT_EQ(sumOfMapsType.getSourceTypes().size(), 2);
-    EXPECT_EQ(sumOfMapsType.getSourceTypes()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumOfMapsType.getSourceTypes()[1], babelwires::DefaultRationalType::getThisIdentifier());
+    EXPECT_EQ(sumOfMapsType.getSourceTypes()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumOfMapsType.getSourceTypes()[1], babelwires::DefaultRationalType::getThisType());
     EXPECT_EQ(sumOfMapsType.getTargetTypes().size(), 2);
-    EXPECT_EQ(sumOfMapsType.getTargetTypes()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumOfMapsType.getTargetTypes()[1], babelwires::StringType::getThisIdentifier());
+    EXPECT_EQ(sumOfMapsType.getTargetTypes()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumOfMapsType.getTargetTypes()[1], babelwires::StringType::getThisType());
     EXPECT_EQ(sumOfMapsType.getIndexOfDefaultSourceType(), 1);
     EXPECT_EQ(sumOfMapsType.getIndexOfDefaultTargetType(), 0);
 }
@@ -56,8 +56,8 @@ TEST(SumOfMapsTypeTest, sumOfMapsTypeCreateValue) {
     const auto* mapValue = newValue->as<babelwires::MapValue>();
     EXPECT_NE(mapValue, nullptr);
 
-    EXPECT_EQ(mapValue->getSourceTypeRef(), babelwires::DefaultRationalType::getThisIdentifier());
-    EXPECT_EQ(mapValue->getTargetTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
+    EXPECT_EQ(mapValue->getSourceTypeRef(), babelwires::DefaultRationalType::getThisType());
+    EXPECT_EQ(mapValue->getTargetTypeRef(), babelwires::DefaultIntType::getThisType());
 }
 
 TEST(SumOfMapsTypeTest, validValues) {
@@ -65,14 +65,14 @@ TEST(SumOfMapsTypeTest, validValues) {
 
     TestSumOfMapsType sumOfMapsType;
 
-    babelwires::MapValue map0(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisIdentifier(),
-                              babelwires::DefaultIntType::getThisIdentifier(), babelwires::MapEntryData::Kind::All2Sm);
-    babelwires::MapValue map1(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisIdentifier(),
-                              babelwires::StringType::getThisIdentifier(), babelwires::MapEntryData::Kind::All21);
-    babelwires::MapValue map2(testEnvironment.m_typeSystem, babelwires::DefaultRationalType::getThisIdentifier(),
-                              babelwires::DefaultIntType::getThisIdentifier(), babelwires::MapEntryData::Kind::All21);
-    babelwires::MapValue map3(testEnvironment.m_typeSystem, babelwires::DefaultRationalType::getThisIdentifier(),
-                              babelwires::StringType::getThisIdentifier(), babelwires::MapEntryData::Kind::All21);
+    babelwires::MapValue map0(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisType(),
+                              babelwires::DefaultIntType::getThisType(), babelwires::MapEntryData::Kind::All2Sm);
+    babelwires::MapValue map1(testEnvironment.m_typeSystem, babelwires::DefaultIntType::getThisType(),
+                              babelwires::StringType::getThisType(), babelwires::MapEntryData::Kind::All21);
+    babelwires::MapValue map2(testEnvironment.m_typeSystem, babelwires::DefaultRationalType::getThisType(),
+                              babelwires::DefaultIntType::getThisType(), babelwires::MapEntryData::Kind::All21);
+    babelwires::MapValue map3(testEnvironment.m_typeSystem, babelwires::DefaultRationalType::getThisType(),
+                              babelwires::StringType::getThisType(), babelwires::MapEntryData::Kind::All21);
 
     EXPECT_TRUE(sumOfMapsType.isValidValue(testEnvironment.m_typeSystem, map0));
     EXPECT_TRUE(sumOfMapsType.isValidValue(testEnvironment.m_typeSystem, map1));

--- a/Tests/BabelWiresLib/sumTypeTest.cpp
+++ b/Tests/BabelWiresLib/sumTypeTest.cpp
@@ -17,8 +17,8 @@ namespace {
       public:
         PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("TestSumType"), 1);
         TestSumType(unsigned int defaultType)
-            : babelwires::SumType({babelwires::DefaultIntType::getThisIdentifier(),
-                                   babelwires::DefaultRationalType::getThisIdentifier()},
+            : babelwires::SumType({babelwires::DefaultIntType::getThisType(),
+                                   babelwires::DefaultRationalType::getThisType()},
                                   defaultType) {}
     };
 } // namespace
@@ -29,8 +29,8 @@ TEST(SumTypeTest, sumTypeDefault0) {
     TestSumType sumType(0);
 
     EXPECT_EQ(sumType.getSummands().size(), 2);
-    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisIdentifier());
+    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisType());
     EXPECT_EQ(sumType.getIndexOfDefaultSummand(), 0);
 
     babelwires::ValueHolder newValue = sumType.createValue(testEnvironment.m_typeSystem);
@@ -54,8 +54,8 @@ TEST(SumTypeTest, sumTypeDefault1) {
     TestSumType sumType(1);
 
     EXPECT_EQ(sumType.getSummands().size(), 2);
-    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisIdentifier());
+    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisType());
     EXPECT_EQ(sumType.getIndexOfDefaultSummand(), 1);
 
     babelwires::ValueHolder newValue = sumType.createValue(testEnvironment.m_typeSystem);
@@ -77,8 +77,8 @@ TEST(SumTypeTest, sumTypeConstructorNoDefaultIndex) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::TypeRef sumTypeRef(babelwires::SumTypeConstructor::getThisIdentifier(),
-                                   babelwires::DefaultIntType::getThisIdentifier(),
-                                   babelwires::DefaultRationalType::getThisIdentifier());
+                                   babelwires::DefaultIntType::getThisType(),
+                                   babelwires::DefaultRationalType::getThisType());
 
     const babelwires::Type* const type = sumTypeRef.tryResolve(testEnvironment.m_typeSystem);
 
@@ -87,8 +87,8 @@ TEST(SumTypeTest, sumTypeConstructorNoDefaultIndex) {
 
     const babelwires::SumType& sumType = type->is<babelwires::SumType>();
     EXPECT_EQ(sumType.getSummands().size(), 2);
-    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisIdentifier());
+    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisType());
     EXPECT_EQ(sumType.getIndexOfDefaultSummand(), 0);
 }
 
@@ -97,7 +97,7 @@ TEST(SumTypeTest, sumTypeConstructorDefault1) {
 
     babelwires::TypeRef sumTypeRef(
         babelwires::SumTypeConstructor::getThisIdentifier(),
-        {{babelwires::DefaultIntType::getThisIdentifier(), babelwires::DefaultRationalType::getThisIdentifier()},
+        {{babelwires::DefaultIntType::getThisType(), babelwires::DefaultRationalType::getThisType()},
          {babelwires::IntValue(1)}});
 
     const babelwires::Type* const type = sumTypeRef.tryResolve(testEnvironment.m_typeSystem);
@@ -107,8 +107,8 @@ TEST(SumTypeTest, sumTypeConstructorDefault1) {
 
     const babelwires::SumType& sumType = type->is<babelwires::SumType>();
     EXPECT_EQ(sumType.getSummands().size(), 2);
-    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisIdentifier());
-    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisIdentifier());
+    EXPECT_EQ(sumType.getSummands()[0], babelwires::DefaultIntType::getThisType());
+    EXPECT_EQ(sumType.getSummands()[1], babelwires::DefaultRationalType::getThisType());
     EXPECT_EQ(sumType.getIndexOfDefaultSummand(), 1);
 }
 
@@ -117,30 +117,30 @@ TEST(SumTypeTest, sumTypeConstructorMalformed) {
 
     // Just one summand
     EXPECT_THROW(babelwires::TypeRef(babelwires::SumTypeConstructor::getThisIdentifier(),
-                                     babelwires::DefaultIntType::getThisIdentifier())
+                                     babelwires::DefaultIntType::getThisType())
                      .resolve(testEnvironment.m_typeSystem),
                  babelwires::TypeSystemException);
 
     // Wrong value argument
     EXPECT_THROW(babelwires::TypeRef(babelwires::SumTypeConstructor::getThisIdentifier(),
-                                     {{babelwires::DefaultIntType::getThisIdentifier(),
-                                       babelwires::DefaultRationalType::getThisIdentifier()},
+                                     {{babelwires::DefaultIntType::getThisType(),
+                                       babelwires::DefaultRationalType::getThisType()},
                                       {babelwires::RationalValue(1)}})
                      .resolve(testEnvironment.m_typeSystem),
                  babelwires::TypeSystemException);
 
     // Too many value arguments
     EXPECT_THROW(babelwires::TypeRef(babelwires::SumTypeConstructor::getThisIdentifier(),
-                                     {{babelwires::DefaultIntType::getThisIdentifier(),
-                                       babelwires::DefaultRationalType::getThisIdentifier()},
+                                     {{babelwires::DefaultIntType::getThisType(),
+                                       babelwires::DefaultRationalType::getThisType()},
                                       {babelwires::IntValue(1), babelwires::IntValue(1)}})
                      .resolve(testEnvironment.m_typeSystem),
                  babelwires::TypeSystemException);
 
     // value argument out of range
     EXPECT_THROW(babelwires::TypeRef(babelwires::SumTypeConstructor::getThisIdentifier(),
-                                     {{babelwires::DefaultIntType::getThisIdentifier(),
-                                       babelwires::DefaultRationalType::getThisIdentifier()},
+                                     {{babelwires::DefaultIntType::getThisType(),
+                                       babelwires::DefaultRationalType::getThisType()},
                                       {babelwires::IntValue(2)}})
                      .resolve(testEnvironment.m_typeSystem),
                  babelwires::TypeSystemException);

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -81,11 +81,11 @@ TEST(TypeRefTest, resolve) {
     const testUtils::TestUnaryTypeConstructor* unaryConstructor =
         typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
 
-    babelwires::TypeRef typeRef(testUtils::TestType::getThisIdentifier());
+    babelwires::TypeRef typeRef(testUtils::TestType::getThisType());
 
     EXPECT_EQ(testType, &typeRef.resolve(typeSystem));
     babelwires::TypeRef constructedTypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                           testUtils::TestType::getThisIdentifier());
+                                           testUtils::TestType::getThisType());
     const babelwires::Type& newType = constructedTypeRef.resolve(typeSystem);
     EXPECT_EQ(newType.getTypeRef(), constructedTypeRef);
     EXPECT_EQ(&constructedTypeRef.resolve(typeSystem), &constructedTypeRef.resolve(typeSystem));
@@ -99,11 +99,11 @@ TEST(TypeRefTest, tryResolveSuccess) {
     const testUtils::TestUnaryTypeConstructor* unaryConstructor =
         typeSystem.addTypeConstructor<testUtils::TestUnaryTypeConstructor>();
 
-    babelwires::TypeRef typeRef(testUtils::TestType::getThisIdentifier());
+    babelwires::TypeRef typeRef(testUtils::TestType::getThisType());
     EXPECT_EQ(testType, typeRef.tryResolve(typeSystem));
 
     babelwires::TypeRef constructedTypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                           testUtils::TestType::getThisIdentifier());
+                                           testUtils::TestType::getThisType());
     const babelwires::Type* newType = constructedTypeRef.tryResolve(typeSystem);
     EXPECT_NE(newType, nullptr);
     EXPECT_EQ(newType->getTypeRef(), constructedTypeRef);
@@ -130,7 +130,7 @@ TEST(TypeRefTest, tryResolveParallel) {
         testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
         babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
                             babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                                                testUtils::TestType::getThisIdentifier())));
+                                                testUtils::TestType::getThisType())));
 
     std::vector<std::tuple<babelwires::TypeRef, const babelwires::Type*>> vectorOfResolutions;
     for (int i = 0; i < 1000; ++i) {
@@ -163,7 +163,7 @@ TEST(TypeRefTest, tryResolveMixed) {
     babelwires::TypeRef constructedTestTypeRef(
         testUtils::TestMixedTypeConstructor::getThisIdentifier(),
         {{babelwires::TypeRef(testUtils::TestUnaryTypeConstructor::getThisIdentifier(),
-                              testUtils::TestType::getThisIdentifier())},
+                              testUtils::TestType::getThisType())},
          {babelwires::StringValue(" is this string")}});
 
     const babelwires::Type& constructedTestType = constructedTestTypeRef.resolve(typeSystem);

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -14,106 +14,106 @@
 TEST(TypeSystemTest, isSubTypesPrimitives) {
     testUtils::TestEnvironment testEnvironment;
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestType::getThisIdentifier(),
-                                                       testUtils::TestType::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestType::getThisIdentifier(),
-                                                        testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisIdentifier(),
-                                                        testUtils::TestType::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestType::getThisType(),
+                                                       testUtils::TestType::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestType::getThisType(),
+                                                        testUtils::TestEnum::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisType(),
+                                                        testUtils::TestType::getThisType()));
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisIdentifier(),
-                                                       testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                       testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                       testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                       testUtils::TestSubSubEnum2::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisType(),
+                                                       testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisType(),
+                                                       testUtils::TestSubEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisType(),
+                                                       testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisType(),
+                                                       testUtils::TestSubSubEnum2::getThisType()));
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                       testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                       testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                       testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                       testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                       testUtils::TestSubEnum::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisType(),
+                                                       testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisType(),
+                                                       testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisType(),
+                                                       testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisType(),
+                                                       testUtils::TestSubEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisType(),
+                                                       testUtils::TestSubEnum::getThisType()));
 
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisIdentifier(),
-                                                        testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum2::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum2::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum2::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                        testUtils::TestSubSubEnum1::getThisIdentifier()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisType(),
+                                                        testUtils::TestSubEnum::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisType(),
+                                                        testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestEnum::getThisType(),
+                                                        testUtils::TestSubSubEnum2::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisType(),
+                                                        testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubEnum::getThisType(),
+                                                        testUtils::TestSubSubEnum2::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum1::getThisType(),
+                                                        testUtils::TestSubSubEnum2::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isSubType(testUtils::TestSubSubEnum2::getThisType(),
+                                                        testUtils::TestSubSubEnum1::getThisType()));
 }
 
 TEST(TypeSystemTest, compareSubtype) {
     testUtils::TestEnvironment testEnvironment;
 
-    const babelwires::TypeRef testType4(testUtils::TestMixedTypeConstructor::getThisIdentifier(), babelwires::TypeConstructorArguments{{testUtils::TestType::getThisIdentifier()}, {babelwires::StringValue("xxxx")}});
-    const babelwires::TypeRef testType6(testUtils::TestMixedTypeConstructor::getThisIdentifier(), babelwires::TypeConstructorArguments{{testUtils::TestType::getThisIdentifier()}, {babelwires::StringValue("xxxxxx")}});
+    const babelwires::TypeRef testType4(testUtils::TestMixedTypeConstructor::getThisIdentifier(), babelwires::TypeConstructorArguments{{testUtils::TestType::getThisType()}, {babelwires::StringValue("xxxx")}});
+    const babelwires::TypeRef testType6(testUtils::TestMixedTypeConstructor::getThisIdentifier(), babelwires::TypeConstructorArguments{{testUtils::TestType::getThisType()}, {babelwires::StringValue("xxxxxx")}});
 
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testType4, testType4), babelwires::SubtypeOrder::IsEquivalent);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testType4, testType6), babelwires::SubtypeOrder::IsSubtype);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testType6, testType4), babelwires::SubtypeOrder::IsSupertype);
-    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testType6, testUtils::TestEnum::getThisIdentifier()), babelwires::SubtypeOrder::IsUnrelated);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testType6, testUtils::TestEnum::getThisType()), babelwires::SubtypeOrder::IsUnrelated);
 }
 
 TEST(TypeSystemTest, isRelatedTypes) {
     testUtils::TestEnvironment testEnvironment;
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestType::getThisIdentifier(),
-                                                           testUtils::TestType::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestType::getThisIdentifier(),
-                                                            testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisIdentifier(),
-                                                            testUtils::TestType::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestType::getThisType(),
+                                                           testUtils::TestType::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestType::getThisType(),
+                                                            testUtils::TestEnum::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisType(),
+                                                            testUtils::TestType::getThisType()));
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                           testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum2::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisType(),
+                                                           testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisType(),
+                                                           testUtils::TestSubEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisType(),
+                                                           testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisType(),
+                                                           testUtils::TestSubSubEnum2::getThisType()));
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                           testUtils::TestEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                           testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                           testUtils::TestSubEnum::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisType(),
+                                                           testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisType(),
+                                                           testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisType(),
+                                                           testUtils::TestEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisType(),
+                                                           testUtils::TestSubEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisType(),
+                                                           testUtils::TestSubEnum::getThisType()));
 
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisIdentifier(),
-                                                           testUtils::TestSubEnum::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum2::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum1::getThisIdentifier()));
-    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisIdentifier(),
-                                                           testUtils::TestSubSubEnum2::getThisIdentifier()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisType(),
+                                                           testUtils::TestSubEnum::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisType(),
+                                                           testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestEnum::getThisType(),
+                                                           testUtils::TestSubSubEnum2::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisType(),
+                                                           testUtils::TestSubSubEnum1::getThisType()));
+    EXPECT_TRUE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubEnum::getThisType(),
+                                                           testUtils::TestSubSubEnum2::getThisType()));
 
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisIdentifier(),
-                                                            testUtils::TestSubSubEnum2::getThisIdentifier()));
-    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisIdentifier(),
-                                                            testUtils::TestSubSubEnum1::getThisIdentifier()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum1::getThisType(),
+                                                            testUtils::TestSubSubEnum2::getThisType()));
+    EXPECT_FALSE(testEnvironment.m_typeSystem.isRelatedType(testUtils::TestSubSubEnum2::getThisType(),
+                                                            testUtils::TestSubSubEnum1::getThisType()));
 }
 
 TEST(TypeSystemTest, getTaggedTypes) {
@@ -122,5 +122,5 @@ TEST(TypeSystemTest, getTaggedTypes) {
     auto types = testEnvironment.m_typeSystem.getTaggedPrimitiveTypes(testUtils::TestType::getTestTypeTag());
 
     EXPECT_EQ(types.size(), 1);
-    EXPECT_EQ(types[0], testUtils::TestType::getThisIdentifier());
+    EXPECT_EQ(types[0], testUtils::TestType::getThisType());
 }

--- a/Tests/BabelWiresLib/valueElementTest.cpp
+++ b/Tests/BabelWiresLib/valueElementTest.cpp
@@ -18,7 +18,7 @@ TEST(ValueElementTest, simpleType) {
 
     babelwires::ValueAssignmentData assignmentData(babelwires::EditableValueHolder::makeValue<babelwires::IntValue>(-4));
 
-    babelwires::ValueElementData data(babelwires::DefaultIntType::getThisIdentifier());
+    babelwires::ValueElementData data(babelwires::DefaultIntType::getThisType());
     data.m_modifiers.emplace_back(assignmentData.clone());
 
     auto newElement = data.createFeatureElement(testEnvironment.m_projectContext, testEnvironment.m_log, 10);
@@ -31,7 +31,7 @@ TEST(ValueElementTest, simpleType) {
         valueElement->getElementData().as<babelwires::ValueElementData>();
     ASSERT_NE(valueElementData, nullptr);
     EXPECT_EQ(valueElement->getElementData().m_id, 10);
-    EXPECT_EQ(valueElementData->getTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
+    EXPECT_EQ(valueElementData->getTypeRef(), babelwires::DefaultIntType::getThisType());
 
     const babelwires::ValueTreeNode* const input = valueElement->getInput();
     const babelwires::ValueTreeNode* const output = valueElement->getOutput();
@@ -40,7 +40,7 @@ TEST(ValueElementTest, simpleType) {
     ASSERT_NE(output, nullptr);
     EXPECT_EQ(input, output);
 
-    EXPECT_EQ(input->getTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
+    EXPECT_EQ(input->getTypeRef(), babelwires::DefaultIntType::getThisType());
     const babelwires::ValueHolder value = input->getValue();
     const babelwires::IntValue* intValue = value->as<babelwires::IntValue>();
     ASSERT_NE(intValue, nullptr);
@@ -52,7 +52,7 @@ TEST(ValueElementTest, valueElementDataSerialization) {
 
     std::string serializedContents;
     {
-        babelwires::ValueElementData data(babelwires::DefaultIntType::getThisIdentifier());
+        babelwires::ValueElementData data(babelwires::DefaultIntType::getThisType());
         data.m_id = 2;
         data.m_uiData.m_uiSize.m_width = 300;
         data.m_modifiers.emplace_back(std::make_unique<babelwires::ValueAssignmentData>(
@@ -74,7 +74,7 @@ TEST(ValueElementTest, valueElementDataSerialization) {
     ASSERT_NE(dataPtr, nullptr);
     EXPECT_EQ(dataPtr->m_id, 2);
     EXPECT_EQ(dataPtr->m_uiData.m_uiSize.m_width, 300);
-    EXPECT_EQ(dataPtr->getTypeRef(), babelwires::DefaultIntType::getThisIdentifier());
+    EXPECT_EQ(dataPtr->getTypeRef(), babelwires::DefaultIntType::getThisType());
     ASSERT_EQ(dataPtr->m_modifiers.size(), 1);
     const babelwires::ValueAssignmentData* const assignmentData =
         dataPtr->m_modifiers[0]->as<babelwires::ValueAssignmentData>();


### PR DESCRIPTION
This is a cleaner way to construct a FileType when you don't want to register a new primitive type and shows how this can be done in general.

As part of this, it's worth distinguishing getThisIdentifier calls which need a primitive type id and those which just need a type ref. The latter have been converted to using getThisType.