### PR TITLE
Provide makeTypeRef convenience functions for several TypeConstructors

### DIFF
--- a/BabelWiresLib/Processors/parallelProcessor.cpp
+++ b/BabelWiresLib/Processors/parallelProcessor.cpp
@@ -11,13 +11,13 @@
 #include <BabelWiresLib/Path/path.hpp>
 #include <BabelWiresLib/ValueTree/Utilities/modelUtilities.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeRoot.hpp>
 #include <BabelWiresLib/Instance/instanceUtils.hpp>
 #include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
 #include <BabelWiresLib/Types/Array/arrayTypeConstructor.hpp>
 #include <BabelWiresLib/Types/Array/arrayValue.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeRoot.hpp>
 
 #include <algorithm>
 #include <array>
@@ -26,9 +26,7 @@
 
 namespace {
     babelwires::TypeRef getParallelArray(babelwires::TypeRef&& entryType) {
-        return babelwires::TypeRef{
-            babelwires::ArrayTypeConstructor::getThisIdentifier(),
-            {{std::move(entryType)}, {babelwires::IntValue(1), babelwires::IntValue(16), babelwires::IntValue(1)}}};
+        return babelwires::ArrayTypeConstructor::makeTypeRef(std::move(entryType), 1, 16);
     }
 
     std::vector<babelwires::RecordType::Field>&& addArray(std::vector<babelwires::RecordType::Field>&& commonData,
@@ -115,8 +113,7 @@ void babelwires::ParallelProcessor::processValue(UserLogger& userLogger, const V
 #ifndef __APPLE__
         std::execution::par,
 #endif
-        entriesToProcess.begin(), entriesToProcess.end(),
-        [this, &input, &userLogger, &isFailed](EntryData& data) {
+        entriesToProcess.begin(), entriesToProcess.end(), [this, &input, &userLogger, &isFailed](EntryData& data) {
             try {
                 processEntry(userLogger, input, data.m_inputEntry, *(data.m_outputEntry));
             } catch (const BaseException& e) {

--- a/BabelWiresLib/Types/Array/arrayTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Array/arrayTypeConstructor.cpp
@@ -59,3 +59,14 @@ babelwires::ArrayTypeConstructor::constructType(const TypeSystem& typeSystem, Ty
 
     return std::make_unique<ConstructedType<ArrayType>>(std::move(newTypeRef), typeArguments[0]->getTypeRef(), minimumSize, maximumSize, defaultSize);
 }
+
+babelwires::TypeRef babelwires::ArrayTypeConstructor::makeTypeRef(TypeRef entryType, unsigned int minSize, unsigned int maxSize, unsigned int defaultSize) {
+    assert(minSize <= maxSize);
+    assert(defaultSize <= maxSize);
+    if (defaultSize < minSize) {
+        defaultSize = minSize;
+    }
+    return babelwires::TypeRef{getThisIdentifier(),
+                                {{std::move(entryType)},
+                                 {babelwires::IntValue(minSize), babelwires::IntValue(maxSize), babelwires::IntValue(defaultSize)}}};
+}

--- a/BabelWiresLib/Types/Array/arrayTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Array/arrayTypeConstructor.hpp
@@ -14,11 +14,15 @@ namespace babelwires {
     /// Construct a new ArrayType from a TypeRef and three IntValues: min size, max size and default size.
     class ArrayTypeConstructor : public TypeConstructor {
       public:
-        /// Note that the default is not represented in the name.
+        /// Note that the default size is not represented in the name.
         TYPE_CONSTRUCTOR("Array", "Array<{0}>[{1}..{2}]", "3f8cac9a-2c0b-439f-97ed-bde16874b994", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;
+
+        /// Convenience method.
+        /// If defaultSize is less than minimumSize, the minimumSize is used.
+        static TypeRef makeTypeRef(TypeRef entryType, unsigned int minSize, unsigned int maxSize, unsigned int defaultSize = 0);
 
       private:
         /// Throws a TypeSystem exception if the arguments are not of the expected type.

--- a/BabelWiresLib/Types/Enum/addBlankToEnum.cpp
+++ b/BabelWiresLib/Types/Enum/addBlankToEnum.cpp
@@ -16,7 +16,8 @@ babelwires::ShortId babelwires::AddBlankToEnum::getBlankValue() {
 }
 
 std::unique_ptr<babelwires::Type>
-babelwires::AddBlankToEnum::constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
+babelwires::AddBlankToEnum::constructType(const TypeSystem& typeSystem, TypeRef newTypeRef,
+                                          const std::vector<const Type*>& typeArguments,
                                           const std::vector<EditableValueHolder>& valueArguments) const {
     if (typeArguments.size() != 1) {
         throw TypeSystemException() << "AddBlankToEnum expects one type argument but got " << typeArguments.size();
@@ -30,7 +31,7 @@ babelwires::AddBlankToEnum::constructType(const TypeSystem& typeSystem, TypeRef 
                                     << " provided to AddBlankToEnum";
     }
     return std::make_unique<ConstructedType<EnumType>>(std::move(newTypeRef), ensureBlankValue(srcEnum->getValueSet()),
-                                                   srcEnum->getIndexOfDefaultValue());
+                                                       srcEnum->getIndexOfDefaultValue());
 }
 
 babelwires::EnumType::ValueSet babelwires::AddBlankToEnum::ensureBlankValue(const EnumType::ValueSet& srcValues) {
@@ -44,4 +45,8 @@ babelwires::EnumType::ValueSet babelwires::AddBlankToEnum::ensureBlankValue(cons
     babelwires::EnumType::ValueSet newValues = srcValues;
     newValues.emplace_back(AddBlankToEnum::getBlankValue());
     return newValues;
+}
+
+babelwires::TypeRef babelwires::AddBlankToEnum::makeTypeRef(TypeRef enumTypeRef) {
+    return TypeRef{getThisIdentifier(), std::move(enumTypeRef)};
 }

--- a/BabelWiresLib/Types/Enum/addBlankToEnum.hpp
+++ b/BabelWiresLib/Types/Enum/addBlankToEnum.hpp
@@ -26,6 +26,9 @@ namespace babelwires {
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;
 
+        /// Convenience method.
+        static TypeRef makeTypeRef(TypeRef enumTypeRef);
+
         /// Add a blank to the values unless one is already there.
         static EnumType::ValueSet ensureBlankValue(const EnumType::ValueSet& srcValues);
     };

--- a/BabelWiresLib/Types/Map/mapTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Map/mapTypeConstructor.cpp
@@ -7,16 +7,17 @@
  **/
 #include <BabelWiresLib/Types/Map/mapTypeConstructor.hpp>
 
-#include <BabelWiresLib/Types/Map/mapType.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 #include <BabelWiresLib/TypeSystem/typeSystemException.hpp>
 #include <BabelWiresLib/Types/Enum/enumValue.hpp>
+#include <BabelWiresLib/Types/Map/mapType.hpp>
 
 babelwires::MapEntryData::Kind
 babelwires::MapTypeConstructor::extractValueArguments(const TypeSystem& typeSystem,
                                                       const std::vector<EditableValueHolder>& valueArguments) {
     if (valueArguments.size() > 1) {
-        throw TypeSystemException() << "MapTypeConstructor expects at most 1 value argument but got " << valueArguments.size();
+        throw TypeSystemException() << "MapTypeConstructor expects at most 1 value argument but got "
+                                    << valueArguments.size();
     } else if (valueArguments.size() == 0) {
         return babelwires::MapEntryData::Kind::All21;
     }
@@ -41,11 +42,11 @@ babelwires::MapTypeConstructor::constructType(const TypeSystem& typeSystem, Type
                                                       typeArguments[1]->getTypeRef(), kind);
 }
 
-babelwires::TypeRef babelwires::MapTypeConstructor::makeTypeRef(TypeRef sourceTypeRef, TypeRef targetTypeRef, MapEntryData::Kind fallbackKind) {
-    return babelwires::TypeRef{
-                babelwires::MapTypeConstructor::getThisIdentifier(),
-                babelwires::TypeConstructorArguments{
-                    {std::move(sourceTypeRef), std::move(targetTypeRef)},
-                    {babelwires::EnumValue(babelwires::MapEntryFallbackKind::getIdentifierFromValue(
-                        fallbackKind))}}};
+babelwires::TypeRef babelwires::MapTypeConstructor::makeTypeRef(TypeRef sourceTypeRef, TypeRef targetTypeRef,
+                                                                MapEntryData::Kind fallbackKind) {
+    return TypeRef{
+        getThisIdentifier(),
+        TypeConstructorArguments{
+            {std::move(sourceTypeRef), std::move(targetTypeRef)},
+            {EnumValue(MapEntryFallbackKind::getIdentifierFromValue(fallbackKind))}}};
 }

--- a/BabelWiresLib/Types/Map/mapTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Map/mapTypeConstructor.cpp
@@ -41,3 +41,11 @@ babelwires::MapTypeConstructor::constructType(const TypeSystem& typeSystem, Type
                                                       typeArguments[1]->getTypeRef(), kind);
 }
 
+babelwires::TypeRef babelwires::MapTypeConstructor::makeTypeRef(TypeRef sourceTypeRef, TypeRef targetTypeRef, MapEntryData::Kind fallbackKind) {
+    return babelwires::TypeRef{
+                babelwires::MapTypeConstructor::getThisIdentifier(),
+                babelwires::TypeConstructorArguments{
+                    {std::move(sourceTypeRef), std::move(targetTypeRef)},
+                    {babelwires::EnumValue(babelwires::MapEntryFallbackKind::getIdentifierFromValue(
+                        fallbackKind))}}};
+}

--- a/BabelWiresLib/Types/Map/mapTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Map/mapTypeConstructor.hpp
@@ -20,6 +20,9 @@ namespace babelwires {
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;
 
+        /// Convenience method.
+        static TypeRef makeTypeRef(TypeRef sourceTypeRef, TypeRef targetTypeRef, MapEntryData::Kind fallbackKind = MapEntryData::Kind::All21);
+
       private:
         /// Throws a TypeSystem exception if the arguments are not of the expected type.
         static MapEntryData::Kind extractValueArguments(const TypeSystem& typeSystem, const std::vector<EditableValueHolder>& valueArguments);

--- a/BabelWiresLib/Types/Rational/rationalTypeConstructor.cpp
+++ b/BabelWiresLib/Types/Rational/rationalTypeConstructor.cpp
@@ -39,3 +39,9 @@ babelwires::RationalTypeConstructor::constructType(const TypeSystem& typeSystem,
     auto [range, defaultValue] = extractValueArguments(valueArguments);
     return std::make_unique<ConstructedType<RationalType>>(std::move(newTypeRef), range, defaultValue);
 }
+
+babelwires::TypeRef babelwires::RationalTypeConstructor::makeTypeRef(Rational min, Rational max, Rational defaultValue) {
+    assert(min <= defaultValue);
+    assert(defaultValue <= max);
+    return TypeRef(getThisIdentifier(), RationalValue(min), RationalValue(max), RationalValue(defaultValue));
+}

--- a/BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp
@@ -22,6 +22,9 @@ namespace babelwires {
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;
 
+        /// Convenience method.
+        static TypeRef makeTypeRef(Rational min, Rational max, Rational defaultValue = 0);
+
       private:
         /// Throws a TypeSystem exception if the arguments are not of the expect type.
         static std::tuple<Range<Rational>, Rational>

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,18 @@
-Structured Data Flow WIP:
-1. Records, Unions and Optionals Types
-1. Unit tests: Array values, New feature types, ValuePath, commands
+Structured Data Flow:
 1. Optimization: Try to avoid excess copies of values. Remove constructor from ValueHolder which copies its value argument.
+1. Consider replacing NewValueHolder by a unique_ptr variant inside ValueHolder. This might allow unique ownership to last a bit longer and avoid some unnecessary clones. (Threading probably means we can never return to this state after sharing.)
+1. New UI Workflows
 
 Bugs:
-* Crash when wiring the tracks array of excerpt to the tracks array of repeat in the sample.
-* Three test record values. 
+* Moving compound connections targets between nodes does not work properly.
+  e.g. Three test record values. 
   1. Wire two together. 
   1. Expand and collapse the target node.
   1. Move the target connection to the third
   1. Expand the third record
   1. Observe that the connection gets removed.
+* Connecting to a array which already has a size modifier will remove any modifiers above its default size.
+  * When the array size modifier removed, it removes those modifiers even though the new connection might set the array to a sufficiently large size.
 * Moving a target connection from a valid record target to a record target of a different type does not cause the modifier to fail.
 * The "*" suffix of a target feature label is not always removed directly after saving.
 * Array element modifications can be wrongly removed when an array value of non-default size is set from another array of equivalent size.

--- a/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
+++ b/Tests/BabelWiresLib/TestUtils/testProcessor.cpp
@@ -1,7 +1,7 @@
 #include <Tests/BabelWiresLib/TestUtils/testProcessor.hpp>
 
-#include <BabelWiresLib/ValueTree/Utilities/modelUtilities.hpp>
 #include <BabelWiresLib/Types/Array/arrayTypeConstructor.hpp>
+#include <BabelWiresLib/ValueTree/Utilities/modelUtilities.hpp>
 
 babelwires::ShortId testUtils::TestProcessorInputOutputType::getIntId() {
     return BW_SHORT_ID(s_intIdInitializer, s_intFieldName, s_intUuid);
@@ -20,14 +20,11 @@ babelwires::ShortId testUtils::TestProcessorInputOutputType::getRecordId() {
 }
 
 testUtils::TestProcessorInputOutputType::TestProcessorInputOutputType()
-    : RecordType(
-          {{getIntId(), babelwires::DefaultIntType::getThisType()},
-           {getOptIntId(), babelwires::DefaultIntType::getThisType(), Optionality::optionalDefaultInactive},
-           {getArrayId(),
-            babelwires::TypeRef{babelwires::ArrayTypeConstructor::getThisIdentifier(),
-                                {{babelwires::DefaultIntType::getThisType()},
-                                 {babelwires::IntValue(2), babelwires::IntValue(8), babelwires::IntValue(2)}}}},
-           {getRecordId(), TestSimpleRecordType::getThisType()}}) {}
+    : RecordType({{getIntId(), babelwires::DefaultIntType::getThisType()},
+                  {getOptIntId(), babelwires::DefaultIntType::getThisType(), Optionality::optionalDefaultInactive},
+                  {getArrayId(),
+                   babelwires::ArrayTypeConstructor::makeTypeRef(babelwires::DefaultIntType::getThisType(), 2, 8)},
+                  {getRecordId(), TestSimpleRecordType::getThisType()}}) {}
 
 const babelwires::Path testUtils::TestProcessorInputOutputType::s_pathToInt =
     babelwires::Path::deserializeFromString("Int");
@@ -50,11 +47,10 @@ const babelwires::Path testUtils::TestProcessorInputOutputType::s_pathToInt2 =
 
 testUtils::TestProcessor::TestProcessor(const babelwires::ProjectContext& context)
     : babelwires::Processor(context, testUtils::TestProcessorInputOutputType::getThisType(),
-                                 testUtils::TestProcessorInputOutputType::getThisType()) {}
+                            testUtils::TestProcessorInputOutputType::getThisType()) {}
 
-void testUtils::TestProcessor::processValue(babelwires::UserLogger& userLogger,
-                                             const babelwires::ValueTreeNode& input,
-                                             babelwires::ValueTreeNode& output) const {
+void testUtils::TestProcessor::processValue(babelwires::UserLogger& userLogger, const babelwires::ValueTreeNode& input,
+                                            babelwires::ValueTreeNode& output) const {
     TestProcessorInputOutputType::ConstInstance in{input};
     TestProcessorInputOutputType::Instance out{output};
 

--- a/Tests/BabelWiresLib/addBlankToEnumTest.cpp
+++ b/Tests/BabelWiresLib/addBlankToEnumTest.cpp
@@ -57,6 +57,26 @@ TEST(AddBlankToEnum, constructType) {
     EXPECT_EQ(newEnum->getIndexOfDefaultValue(), testEnum.getIndexOfDefaultValue());
 }
 
+TEST(AddBlankToEnum, makeTypeRef) {
+    testUtils::TestEnvironment testEnvironment;
+    const testUtils::TestEnum& testEnum = testEnvironment.m_typeSystem.getEntryByType<testUtils::TestEnum>();
+
+    const babelwires::TypeRef enumWithBlankTypeRef = babelwires::AddBlankToEnum::makeTypeRef(testUtils::TestEnum::getThisType());
+
+    const babelwires::Type *const newType = enumWithBlankTypeRef.tryResolve(testEnvironment.m_typeSystem);
+    ASSERT_NE(newType, nullptr);
+
+    const babelwires::EnumType* const newEnum = newType->as<babelwires::EnumType>();
+    ASSERT_NE(newEnum, nullptr);
+    
+    EXPECT_EQ(newEnum->getValueSet().size(), testEnum.getValueSet().size() + 1);
+    for (int i = 0; i < testEnum.getValueSet().size(); ++i) {
+        EXPECT_EQ(newEnum->getValueSet()[i], testEnum.getValueSet()[i]);
+    }
+    EXPECT_EQ(newEnum->getValueSet()[newEnum->getValueSet().size() - 1], babelwires::AddBlankToEnum::getBlankValue());
+    EXPECT_EQ(newEnum->getIndexOfDefaultValue(), testEnum.getIndexOfDefaultValue());
+}
+
 TEST(AddBlankToEnum, idempotency) {
     testUtils::TestEnvironment testEnvironment;
     const testUtils::TestEnum& testEnum = testEnvironment.m_typeSystem.getEntryByType<testUtils::TestEnum>();

--- a/Tests/BabelWiresLib/intTypeTest.cpp
+++ b/Tests/BabelWiresLib/intTypeTest.cpp
@@ -111,6 +111,28 @@ TEST(IntTypeTest, constructedIntTypeIsValidValue) {
     EXPECT_FALSE(type->isValidValue(testEnvironment.m_typeSystem, babelwires::RationalValue(3)));
 }
 
+TEST(IntTypeTest, makeTypeRef) {
+    testUtils::TestEnvironment testEnvironment;
+
+    babelwires::TypeRef intTypeRef = babelwires::IntTypeConstructor::makeTypeRef(-120, 140, -30);
+
+    const babelwires::Type* const type = intTypeRef.tryResolve(testEnvironment.m_typeSystem);
+
+    const babelwires::IntType* const intType = type->as<babelwires::IntType>();
+    ASSERT_NE(intType, nullptr);
+
+    auto range = intType->getRange();
+    EXPECT_EQ(range.m_min, -120);
+    EXPECT_EQ(range.m_max, 140);
+
+    babelwires::ValueHolder newValue = intType->createValue(testEnvironment.m_typeSystem);
+    EXPECT_TRUE(newValue);
+
+    const auto* const newIntValue = newValue->as<babelwires::IntValue>();
+    EXPECT_NE(newIntValue, nullptr);
+    EXPECT_EQ(newIntValue->get(), -30);
+}
+
 TEST(IntTypeTest, sameKind) {
     testUtils::TestEnvironment testEnvironment;
 

--- a/Tests/BabelWiresLib/mapFeatureTest.cpp
+++ b/Tests/BabelWiresLib/mapFeatureTest.cpp
@@ -24,11 +24,7 @@
 namespace {
     // Describes an IntType -> IntType map.
     template <typename SOURCE_TYPE, typename TARGET_TYPE> babelwires::TypeRef getTestMapTypeRef() {
-        return babelwires::TypeRef(babelwires::MapTypeConstructor::getThisIdentifier(),
-                                   babelwires::TypeConstructorArguments{
-                                       {SOURCE_TYPE::getThisType(), TARGET_TYPE::getThisType()},
-                                       {babelwires::EnumValue(babelwires::MapEntryFallbackKind::getIdentifierFromValue(
-                                           babelwires::MapEntryFallbackKind::Value::All21))}});
+        return babelwires::MapTypeConstructor::makeTypeRef(SOURCE_TYPE::getThisType(), TARGET_TYPE::getThisType());
     }
 } // namespace
 

--- a/Tests/BabelWiresLib/parallelProcessorTest.cpp
+++ b/Tests/BabelWiresLib/parallelProcessorTest.cpp
@@ -17,10 +17,7 @@
 namespace {
 
     babelwires::TypeRef getLimitedIntType() {
-        return babelwires::TypeRef(
-            babelwires::IntTypeConstructor::getThisIdentifier(),
-            babelwires::TypeConstructorArguments{
-                {}, {babelwires::IntValue(-20), babelwires::IntValue(20), babelwires::IntValue(0)}});
+        return babelwires::IntTypeConstructor::makeTypeRef(-20, 20, 0);
     }
 
     babelwires::ShortId getCommonArrayId() {

--- a/Tests/BabelWiresLib/rationalTypeTest.cpp
+++ b/Tests/BabelWiresLib/rationalTypeTest.cpp
@@ -114,6 +114,29 @@ TEST(RationalTypeTest, constructedRationalTypeIsValidValue) {
     EXPECT_FALSE(type->isValidValue(testEnvironment.m_typeSystem, babelwires::IntValue(3)));
 }
 
+TEST(RationalTypeTest, makeTypeRef) {
+    testUtils::TestEnvironment testEnvironment;
+
+    babelwires::TypeRef rationalTypeRef = babelwires::RationalTypeConstructor::makeTypeRef(babelwires::Rational(2, 3),
+        babelwires::Rational(4, 3), 1);
+
+    const babelwires::Type* const type = rationalTypeRef.tryResolve(testEnvironment.m_typeSystem);
+
+    const babelwires::RationalType* const rationalType = type->as<babelwires::RationalType>();
+    ASSERT_NE(rationalType, nullptr);
+
+    auto range = rationalType->getRange();
+    EXPECT_EQ(range.m_min, babelwires::Rational(2, 3));
+    EXPECT_EQ(range.m_max, babelwires::Rational(4, 3));
+
+    babelwires::ValueHolder newValue = type->createValue(testEnvironment.m_typeSystem);
+    EXPECT_TRUE(newValue);
+
+    const auto* const newRationalValue = newValue->as<babelwires::RationalValue>();
+    EXPECT_NE(newRationalValue, nullptr);
+    EXPECT_EQ(newRationalValue->get(), 1);
+}
+
 TEST(RationalTypeTest, sameKind) {
     testUtils::TestEnvironment testEnvironment;
 


### PR DESCRIPTION
The explicit way of creating a TypeRef is general but very verbose. For most of the TypeConstructor classes in the system, provide a nicer "makeTypeRef" function that allows a TypeRef to be built using built-in types.

Example: IntTypeConstructor::makeTypeRef(0, 127, 15)