### PR TITLE
Require commands to be cloneable

### DIFF
--- a/BabelWiresLib/Commands/commands.hpp
+++ b/BabelWiresLib/Commands/commands.hpp
@@ -10,6 +10,7 @@
 #include <BabelWiresLib/Commands/commandTimestamp.hpp>
 
 #include <Common/types.hpp>
+#include <Common/Cloning/cloneable.hpp>
 
 #include <chrono>
 #include <memory>
@@ -21,9 +22,10 @@
 namespace babelwires {
     /// Commands define undoable ways of mutating the a COMMAND_TARGET.
     template<typename COMMAND_TARGET>
-    class Command {
+    class Command : public Cloneable {
       public:
         DOWNCASTABLE_TYPE_HIERARCHY(Command);
+        CLONEABLE_ABSTRACT(Command);
 
         /// CommandName should be a displayable name
         /// The timestamp is set to the current time.
@@ -98,7 +100,9 @@ namespace babelwires {
     template<typename COMMAND_TARGET>
     class CompoundCommand : public Command<COMMAND_TARGET> {
       public:
+        CLONEABLE(CompoundCommand);
         CompoundCommand(std::string commandName);
+        CompoundCommand(const CompoundCommand& other);
 
         void addSubCommand(std::unique_ptr<Command<COMMAND_TARGET>> subCommand);
 

--- a/BabelWiresLib/Commands/commands_inl.hpp
+++ b/BabelWiresLib/Commands/commands_inl.hpp
@@ -2,7 +2,7 @@
  * Commands define undoable ways of mutating the a COMMAND_TARGET.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -56,6 +56,15 @@ bool babelwires::SimpleCommand<COMMAND_TARGET>::initializeAndExecute(COMMAND_TAR
 template <typename COMMAND_TARGET>
 babelwires::CompoundCommand<COMMAND_TARGET>::CompoundCommand(std::string commandName)
     : Command<COMMAND_TARGET>(std::move(commandName)) {}
+
+template <typename COMMAND_TARGET>
+babelwires::CompoundCommand<COMMAND_TARGET>::CompoundCommand(const CompoundCommand& other)
+    : Command<COMMAND_TARGET>(other) {
+    m_subCommands.reserve(other.m_subCommands.size());
+    for (const auto& c : other.m_subCommands) {
+        m_subCommands.emplace_back(c->clone());
+    };
+}
 
 template <typename COMMAND_TARGET>
 void babelwires::CompoundCommand<COMMAND_TARGET>::addSubCommand(std::unique_ptr<Command<COMMAND_TARGET>> subCommand) {

--- a/BabelWiresLib/Project/Commands/Subcommands/adjustModifiersInArraySubcommand.hpp
+++ b/BabelWiresLib/Project/Commands/Subcommands/adjustModifiersInArraySubcommand.hpp
@@ -17,6 +17,8 @@ namespace babelwires {
     /// Adjust modifiers and connections which point into an array to adapt to shifted array elements.
     class AdjustModifiersInArraySubcommand : public CompoundCommand<Project> {
       public:
+        CLONEABLE(AdjustModifiersInArraySubcommand);
+
         /// If adjustments is negative, then the range startIndex to (startIndex - adjustment) is considered as being
         /// removed.
         AdjustModifiersInArraySubcommand(NodeId elementId,

--- a/BabelWiresLib/Project/Commands/Subcommands/removeAllEditsSubcommand.hpp
+++ b/BabelWiresLib/Project/Commands/Subcommands/removeAllEditsSubcommand.hpp
@@ -15,10 +15,11 @@ namespace babelwires {
     class Project;
     struct ModifierData;
 
-    /// Remove all modifiers and expanded paths at and beneath a given feature.
+    /// Remove all modifiers and expanded paths at and beneath a given TreeValueNode.
     class RemoveAllEditsSubcommand : public CompoundCommand<Project> {
       public:
-        RemoveAllEditsSubcommand(NodeId elementId, Path pathToFeature);
+        CLONEABLE(RemoveAllEditsSubcommand);
+        RemoveAllEditsSubcommand(NodeId elementId, Path path);
 
         virtual bool initializeAndExecute(Project& project) override;
         virtual void execute(Project& project) const override;
@@ -27,6 +28,8 @@ namespace babelwires {
       private:
         NodeId m_nodeId;
         Path m_path;
+
+        // Post initialization data
 
         std::vector<Path> m_expandedPathsRemoved;
 

--- a/BabelWiresLib/Project/Commands/Subcommands/removeSimpleModifierSubcommand.cpp
+++ b/BabelWiresLib/Project/Commands/Subcommands/removeSimpleModifierSubcommand.cpp
@@ -7,28 +7,33 @@
  **/
 #include <BabelWiresLib/Project/Commands/Subcommands/removeSimpleModifierSubcommand.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
-#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
 #include <BabelWiresLib/Project/Commands/addEntriesToArrayCommand.hpp>
 #include <BabelWiresLib/Project/Commands/deactivateOptionalCommand.hpp>
 #include <BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.hpp>
-#include <BabelWiresLib/Project/Nodes/node.hpp>
-#include <BabelWiresLib/Project/Nodes/nodeData.hpp>
 #include <BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp>
 #include <BabelWiresLib/Project/Modifiers/arraySizeModifierData.hpp>
 #include <BabelWiresLib/Project/Modifiers/connectionModifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
+#include <BabelWiresLib/Project/Nodes/node.hpp>
+#include <BabelWiresLib/Project/Nodes/nodeData.hpp>
 #include <BabelWiresLib/Project/project.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
 
 #include <cassert>
 
-babelwires::RemoveSimpleModifierSubcommand::RemoveSimpleModifierSubcommand(NodeId targetId,
-                                                                     Path featurePath)
+babelwires::RemoveSimpleModifierSubcommand::RemoveSimpleModifierSubcommand(NodeId targetId, Path featurePath)
     : SimpleCommand("RemoveSimpleModifierSubcommand")
     , m_targetNodeId(targetId)
     , m_targetPath(std::move(featurePath)) {}
+
+babelwires::RemoveSimpleModifierSubcommand::RemoveSimpleModifierSubcommand(const RemoveSimpleModifierSubcommand& other)
+    : SimpleCommand(other)
+    , m_targetNodeId(other.m_targetNodeId)
+    , m_targetPath(other.m_targetPath)
+    , m_modifierToRestore(other.m_modifierToRestore ? other.m_modifierToRestore->clone() : nullptr) {}
 
 bool babelwires::RemoveSimpleModifierSubcommand::initialize(const Project& project) {
     const Node* node = project.getNode(m_targetNodeId);

--- a/BabelWiresLib/Project/Commands/Subcommands/removeSimpleModifierSubcommand.hpp
+++ b/BabelWiresLib/Project/Commands/Subcommands/removeSimpleModifierSubcommand.hpp
@@ -20,7 +20,9 @@ namespace babelwires {
     /// an array size modifier. See RemoveModifierCommand.
     class RemoveSimpleModifierSubcommand : public SimpleCommand<Project> {
       public:
+        CLONEABLE(RemoveSimpleModifierSubcommand);
         RemoveSimpleModifierSubcommand(NodeId targetId, Path featurePath);
+        RemoveSimpleModifierSubcommand(const RemoveSimpleModifierSubcommand& other);
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
         virtual void undo(Project& project) const override;

--- a/BabelWiresLib/Project/Commands/activateOptionalCommand.cpp
+++ b/BabelWiresLib/Project/Commands/activateOptionalCommand.cpp
@@ -2,27 +2,25 @@
  * The command which activates optionals in a RecordType.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
 #include <BabelWiresLib/Project/Commands/activateOptionalCommand.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
-#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
-#include <BabelWiresLib/Project/Nodes/node.hpp>
-#include <BabelWiresLib/Project/Modifiers/localModifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/activateOptionalsModifierData.hpp>
+#include <BabelWiresLib/Project/Modifiers/localModifier.hpp>
+#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/project.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
 
-babelwires::ActivateOptionalCommand::ActivateOptionalCommand(std::string commandName, NodeId nodeId, Path featurePath,
-                               ShortId optional)
+babelwires::ActivateOptionalCommand::ActivateOptionalCommand(std::string commandName, NodeId nodeId, Path pathToRecord,
+                                                             ShortId optional)
     : SimpleCommand(commandName)
     , m_nodeId(nodeId)
-    , m_pathToRecord(std::move(featurePath))
-    , m_optional(optional)
-{
-}
+    , m_pathToRecord(std::move(pathToRecord))
+    , m_optional(optional) {}
 
 bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
     const Node* nodeToModify = project.getNode(m_nodeId);
@@ -39,11 +37,11 @@ bool babelwires::ActivateOptionalCommand::initialize(const Project& project) {
         ValueTreeHelper::getInfoFromRecordWithOptionals(m_pathToRecord.tryFollow(*input));
 
     if (!compoundFeature) {
-        return false;   
+        return false;
     }
 
     auto it = optionals.find(m_optional);
-    
+
     if (it == optionals.end()) {
         return false;
     }

--- a/BabelWiresLib/Project/Commands/activateOptionalCommand.hpp
+++ b/BabelWiresLib/Project/Commands/activateOptionalCommand.hpp
@@ -2,7 +2,7 @@
  * The command which activates optionals in a RecordType.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -18,8 +18,8 @@ namespace babelwires {
     /// Activate an optional in a RecordType
     class ActivateOptionalCommand : public SimpleCommand<Project> {
       public:
-        ActivateOptionalCommand(std::string commandName, NodeId elementId, Path featurePath,
-                               ShortId optional);
+        CLONEABLE(ActivateOptionalCommand);
+        ActivateOptionalCommand(std::string commandName, NodeId nodeId, Path pathToRecord, ShortId optional);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
@@ -29,6 +29,8 @@ namespace babelwires {
         NodeId m_nodeId;
         Path m_pathToRecord;
         ShortId m_optional;
+
+        // Post initialization data
 
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;

--- a/BabelWiresLib/Project/Commands/addEntriesToArrayCommand.cpp
+++ b/BabelWiresLib/Project/Commands/addEntriesToArrayCommand.cpp
@@ -8,23 +8,23 @@
 
 #include <BabelWiresLib/Project/Commands/addEntriesToArrayCommand.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
-#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
 #include <BabelWiresLib/Project/Commands/Subcommands/adjustModifiersInArraySubcommand.hpp>
-#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/Modifiers/arraySizeModifierData.hpp>
 #include <BabelWiresLib/Project/Modifiers/modifier.hpp>
+#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/project.hpp>
 #include <BabelWiresLib/Project/projectUtilities.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
 
 #include <cassert>
 
-babelwires::AddEntriesToArrayCommand::AddEntriesToArrayCommand(std::string commandName, NodeId elementId,
+babelwires::AddEntriesToArrayCommand::AddEntriesToArrayCommand(std::string commandName, NodeId nodeId,
                                                                Path featurePath, unsigned int indexOfNewEntries,
                                                                unsigned int numEntriesToAdd)
     : CompoundCommand(commandName)
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_pathToArray(std::move(featurePath))
     , m_indexOfNewEntries(indexOfNewEntries)
     , m_numEntriesToAdd(numEntriesToAdd) {}

--- a/BabelWiresLib/Project/Commands/addEntriesToArrayCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addEntriesToArrayCommand.hpp
@@ -18,7 +18,8 @@ namespace babelwires {
     /// Add an element to an array.
     class AddEntriesToArrayCommand : public CompoundCommand<Project> {
       public:
-        AddEntriesToArrayCommand(std::string commandName, NodeId elementId, Path featurePath,
+        CLONEABLE(AddEntriesToArrayCommand);
+        AddEntriesToArrayCommand(std::string commandName, NodeId nodeId, Path featurePath,
                                unsigned int indexOfNewEntries, unsigned int numEntriesToAdd = 1);
 
         virtual bool initializeAndExecute(Project& project) override;
@@ -30,6 +31,8 @@ namespace babelwires {
         Path m_pathToArray;
         unsigned int m_indexOfNewEntries;
         unsigned int m_numEntriesToAdd;
+
+        // Post initialization data
 
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;

--- a/BabelWiresLib/Project/Commands/addModifierCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addModifierCommand.hpp
@@ -19,7 +19,9 @@ namespace babelwires {
     /// Add a modifier to a Node.
     class AddModifierCommand : public CompoundCommand<Project> {
       public:
+        CLONEABLE(AddModifierCommand);
         AddModifierCommand(std::string commandName, NodeId targetId, std::unique_ptr<ModifierData> modifierToAdd);
+        AddModifierCommand(const AddModifierCommand& other);
 
         virtual bool initializeAndExecute(Project& project) override;
         virtual void execute(Project& project) const override;

--- a/BabelWiresLib/Project/Commands/addNodeCommand.cpp
+++ b/BabelWiresLib/Project/Commands/addNodeCommand.cpp
@@ -9,19 +9,26 @@
 #include <BabelWiresLib/Project/Commands/addNodeCommand.hpp>
 
 #include <BabelWiresLib/Project/Commands/moveNodeCommand.hpp>
+#include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
 #include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/Nodes/nodeData.hpp>
-#include <BabelWiresLib/Project/Modifiers/modifierData.hpp>
 #include <BabelWiresLib/Project/project.hpp>
 
 #include <cassert>
 
-babelwires::AddNodeCommand::AddNodeCommand(std::string commandName, std::unique_ptr<NodeData> elementToAdd)
+babelwires::AddNodeCommand::AddNodeCommand(std::string commandName, std::unique_ptr<NodeData> nodeToAdd)
     : SimpleCommand(std::move(commandName))
-    , m_elementToAdd(std::move(elementToAdd)) {
-    assert((std::find(m_elementToAdd->m_expandedPaths.begin(), m_elementToAdd->m_expandedPaths.end(), Path()) == m_elementToAdd->m_expandedPaths.end()) && "The root is always expanded by default.");
+    , m_elementToAdd(std::move(nodeToAdd)) {
+    assert(m_elementToAdd);
+    assert((std::find(m_elementToAdd->m_expandedPaths.begin(), m_elementToAdd->m_expandedPaths.end(), Path()) ==
+            m_elementToAdd->m_expandedPaths.end()) &&
+           "The root is always expanded by default.");
     m_elementToAdd->m_expandedPaths.emplace_back(Path());
 }
+
+babelwires::AddNodeCommand::AddNodeCommand(const AddNodeCommand& other)
+    : SimpleCommand(other)
+    , m_elementToAdd(other.m_elementToAdd->clone()) {}
 
 void babelwires::AddNodeCommand::execute(Project& project) const {
     NodeId newId = project.addNode(*m_elementToAdd);

--- a/BabelWiresLib/Project/Commands/addNodeCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addNodeCommand.hpp
@@ -19,9 +19,11 @@ namespace babelwires {
     /// Add a Node to the project.
     class AddNodeCommand : public SimpleCommand<Project> {
       public:
+        CLONEABLE(AddNodeCommand);
         /// Create a command which adds the given node.
         /// NOTE: An expanded path entry is always added for the root path, so the constructor asserts it is not already present.
-        AddNodeCommand(std::string commandName, std::unique_ptr<NodeData> elementToAdd);
+        AddNodeCommand(std::string commandName, std::unique_ptr<NodeData> nodeToAdd);
+        AddNodeCommand(const AddNodeCommand& other);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;

--- a/BabelWiresLib/Project/Commands/addNodeForInputTreeValueCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addNodeForInputTreeValueCommand.hpp
@@ -21,6 +21,8 @@ namespace babelwires {
     /// Create a new node using the data in an existing input row in the project,
     class AddNodeForInputTreeValueCommand : public AddNodeForTreeValueCommandBase {
       public:
+        CLONEABLE(AddNodeForInputTreeValueCommand);
+
         enum class RelationshipToOldNode {
             /// The old value will now be assigned its value from the new node. All modifiers move to the new node.
             Source,

--- a/BabelWiresLib/Project/Commands/addNodeForOutputTreeValueCommand.hpp
+++ b/BabelWiresLib/Project/Commands/addNodeForOutputTreeValueCommand.hpp
@@ -21,6 +21,8 @@ namespace babelwires {
     /// Create a new node using the data in an existing input row in the project,
     class AddNodeForOutputTreeValueCommand : public AddNodeForTreeValueCommandBase {
       public:
+        CLONEABLE(AddNodeForOutputTreeValueCommand);
+
         enum class RelationshipToDependentNodes {
             /// Nodes with connections to the old node will now connect to the new node.
             NewParent,

--- a/BabelWiresLib/Project/Commands/addNodeForTreeValueCommandBase.hpp
+++ b/BabelWiresLib/Project/Commands/addNodeForTreeValueCommandBase.hpp
@@ -20,6 +20,7 @@ namespace babelwires {
     /// Create a new node using the data in an existing input row in the project,
     class AddNodeForTreeValueCommandBase : public Command<Project> {
       public:
+        CLONEABLE_ABSTRACT(AddNodeForTreeValueCommandBase);
 
         AddNodeForTreeValueCommandBase(std::string commandName, NodeId originalNodeId, Path pathToValue, UiPosition positionForNewNode);
 
@@ -33,6 +34,8 @@ namespace babelwires {
         NodeId m_originalNodeId;
         Path m_pathToValue;
         UiPosition m_positionForNewNode;
+
+        // Post initialization data
 
         /// This is only set after the command is executed.
         NodeId m_newNodeId = INVALID_NODE_ID;

--- a/BabelWiresLib/Project/Commands/changeFileCommand.cpp
+++ b/BabelWiresLib/Project/Commands/changeFileCommand.cpp
@@ -12,9 +12,9 @@
 
 #include <cassert>
 
-babelwires::ChangeFileCommand::ChangeFileCommand(std::string commandName, NodeId elementId, std::filesystem::path newFilePath)
+babelwires::ChangeFileCommand::ChangeFileCommand(std::string commandName, NodeId nodeId, std::filesystem::path newFilePath)
     : SimpleCommand(commandName)
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_newFilePath(std::move(newFilePath)) {}
 
 bool babelwires::ChangeFileCommand::initialize(const Project& project) {

--- a/BabelWiresLib/Project/Commands/changeFileCommand.hpp
+++ b/BabelWiresLib/Project/Commands/changeFileCommand.hpp
@@ -19,7 +19,8 @@ namespace babelwires {
     /// Change the source file of a FileNode.
     class ChangeFileCommand : public SimpleCommand<Project> {
       public:
-        ChangeFileCommand(std::string commandName, NodeId elementId, std::filesystem::path newFilePath);
+        CLONEABLE(ChangeFileCommand);
+        ChangeFileCommand(std::string commandName, NodeId nodeId, std::filesystem::path newFilePath);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
@@ -28,6 +29,9 @@ namespace babelwires {
       private:
         NodeId m_nodeId;
         std::filesystem::path m_newFilePath;
+
+        // Post initialization data
+
         std::filesystem::path m_oldFilePath;
     };
 

--- a/BabelWiresLib/Project/Commands/deactivateOptionalCommand.cpp
+++ b/BabelWiresLib/Project/Commands/deactivateOptionalCommand.cpp
@@ -16,10 +16,10 @@
 #include <BabelWiresLib/Project/Commands/Subcommands/removeAllEditsSubcommand.hpp>
 #include <BabelWiresLib/Project/project.hpp>
 
-babelwires::DeactivateOptionalCommand::DeactivateOptionalCommand(std::string commandName, NodeId elementId, Path featurePath,
+babelwires::DeactivateOptionalCommand::DeactivateOptionalCommand(std::string commandName, NodeId nodeId, Path featurePath,
                                ShortId optional)
     : CompoundCommand(commandName)
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_pathToRecord(std::move(featurePath))
     , m_optional(optional)
 {

--- a/BabelWiresLib/Project/Commands/deactivateOptionalCommand.hpp
+++ b/BabelWiresLib/Project/Commands/deactivateOptionalCommand.hpp
@@ -18,7 +18,8 @@ namespace babelwires {
     /// Deactivate an optional in a RecordType
     class DeactivateOptionalCommand : public CompoundCommand<Project> {
       public:
-        DeactivateOptionalCommand(std::string commandName, NodeId elementId, Path featurePath,
+        CLONEABLE(DeactivateOptionalCommand);
+        DeactivateOptionalCommand(std::string commandName, NodeId nodeId, Path featurePath,
                                ShortId optional);
 
         virtual bool initializeAndExecute(Project& project) override;
@@ -29,6 +30,8 @@ namespace babelwires {
         NodeId m_nodeId;
         Path m_pathToRecord;
         ShortId m_optional;
+
+        // Post initialization data
 
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;

--- a/BabelWiresLib/Project/Commands/moveNodeCommand.cpp
+++ b/BabelWiresLib/Project/Commands/moveNodeCommand.cpp
@@ -2,7 +2,7 @@
  * The command which changes the UiPosition of a Node.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <BabelWiresLib/Project/Commands/moveNodeCommand.hpp>
@@ -12,30 +12,30 @@
 
 #include <cassert>
 
-babelwires::MoveNodeCommand::MoveNodeCommand(std::string commandName, NodeId elementId, UiPosition newPosition)
+babelwires::MoveNodeCommand::MoveNodeCommand(std::string commandName, NodeId nodeId, UiPosition newPosition)
     : SimpleCommand(std::move(commandName))
-    , m_newPositions{std::pair{elementId, newPosition}} {}
+    , m_newPositions{std::pair{nodeId, newPosition}} {}
 
 bool babelwires::MoveNodeCommand::initialize(const Project& project) {
-    for (const auto& [elementId, _] : m_newPositions) {
-        const Node* node = project.getNode(elementId);
+    for (const auto& [nodeId, _] : m_newPositions) {
+        const Node* node = project.getNode(nodeId);
         if (!node) {
             return false;
         }
-        m_oldPositions.insert(std::pair{elementId, node->getUiPosition()});
+        m_oldPositions.insert(std::pair{nodeId, node->getUiPosition()});
     }
     return true;
 }
 
 void babelwires::MoveNodeCommand::execute(Project& project) const {
-    for (const auto& [elementId, newPosition] : m_newPositions) {
-        project.setNodePosition(elementId, newPosition);
+    for (const auto& [nodeId, newPosition] : m_newPositions) {
+        project.setNodePosition(nodeId, newPosition);
     }
 }
 
 void babelwires::MoveNodeCommand::undo(Project& project) const {
-    for (const auto& [elementId, oldPosition] : m_oldPositions) {
-        project.setNodePosition(elementId, oldPosition);
+    for (const auto& [nodeId, oldPosition] : m_oldPositions) {
+        project.setNodePosition(nodeId, oldPosition);
     }
 }
 
@@ -69,8 +69,7 @@ void babelwires::MoveNodeCommand::subsume(std::unique_ptr<Command> subsequentCom
     setTimestamp(moveNodeCommand->getTimestamp());
 }
 
-std::optional<babelwires::UiPosition>
-babelwires::MoveNodeCommand::getPositionForOnlyNode(NodeId elementId) const {
+std::optional<babelwires::UiPosition> babelwires::MoveNodeCommand::getPositionForOnlyNode(NodeId nodeId) const {
     if (m_newPositions.size() == 1) {
         return {m_newPositions.begin()->second};
     } else {

--- a/BabelWiresLib/Project/Commands/moveNodeCommand.hpp
+++ b/BabelWiresLib/Project/Commands/moveNodeCommand.hpp
@@ -21,7 +21,8 @@ namespace babelwires {
     /// The command which changes the UiPosition of a Node.
     class MoveNodeCommand : public SimpleCommand<Project> {
       public:
-        MoveNodeCommand(std::string commandName, NodeId elementId, UiPosition newPosition);
+        CLONEABLE(MoveNodeCommand);
+        MoveNodeCommand(std::string commandName, NodeId nodeId, UiPosition newPosition);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
@@ -35,6 +36,9 @@ namespace babelwires {
 
       private:
         std::map<NodeId, UiPosition> m_newPositions;
+
+        // Post initialization data
+
         std::map<NodeId, UiPosition> m_oldPositions;
     };
 

--- a/BabelWiresLib/Project/Commands/pasteNodesCommand.hpp
+++ b/BabelWiresLib/Project/Commands/pasteNodesCommand.hpp
@@ -17,6 +17,7 @@ namespace babelwires {
     /// The command which pastes content into a project.
     class PasteNodesCommand : public SimpleCommand<Project> {
       public:
+        CLONEABLE(PasteNodesCommand);
         PasteNodesCommand(std::string commandName, ProjectData dataToPaste);
 
         virtual bool initialize(const Project& project) override;

--- a/BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.cpp
+++ b/BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.cpp
@@ -7,29 +7,28 @@
  **/
 #include <BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
-#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
 #include <BabelWiresLib/Project/Commands/Subcommands/adjustModifiersInArraySubcommand.hpp>
-#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/Modifiers/arraySizeModifierData.hpp>
 #include <BabelWiresLib/Project/Modifiers/connectionModifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/connectionModifierData.hpp>
+#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/project.hpp>
 #include <BabelWiresLib/Project/projectUtilities.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeNode.hpp>
 
 #include <cassert>
 
-babelwires::RemoveEntryFromArrayCommand::RemoveEntryFromArrayCommand(std::string commandName, NodeId elementId,
-                                                                     Path featurePath,
+babelwires::RemoveEntryFromArrayCommand::RemoveEntryFromArrayCommand(std::string commandName, NodeId nodeId,
+                                                                     Path pathToArray,
                                                                      unsigned int indexOfEntryToRemove,
                                                                      unsigned int numEntriesToRemove)
     : CompoundCommand(commandName)
-    , m_nodeId(elementId)
-    , m_pathToArray(std::move(featurePath))
+    , m_nodeId(nodeId)
+    , m_pathToArray(std::move(pathToArray))
     , m_indexOfEntryToRemove(indexOfEntryToRemove)
-    , m_numEntriesToRemove(numEntriesToRemove)
-    , m_isSubcommand(false) {
+    , m_numEntriesToRemove(numEntriesToRemove) {
     assert((numEntriesToRemove > 0) && "numEntriesToRemove must be strictly positive");
 }
 
@@ -73,7 +72,8 @@ bool babelwires::RemoveEntryFromArrayCommand::initializeAndExecute(Project& proj
         }
     }
 
-    addSubCommand(std::make_unique<AdjustModifiersInArraySubcommand>(m_nodeId, m_pathToArray, m_indexOfEntryToRemove, -m_numEntriesToRemove));
+    addSubCommand(std::make_unique<AdjustModifiersInArraySubcommand>(m_nodeId, m_pathToArray, m_indexOfEntryToRemove,
+                                                                     -m_numEntriesToRemove));
 
     if (!CompoundCommand::initializeAndExecute(project)) {
         return false;

--- a/BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.hpp
+++ b/BabelWiresLib/Project/Commands/removeEntryFromArrayCommand.hpp
@@ -17,7 +17,8 @@ namespace babelwires {
     /// Remove an element from an array.
     class RemoveEntryFromArrayCommand : public CompoundCommand<Project> {
       public:
-        RemoveEntryFromArrayCommand(std::string commandName, NodeId elementId, Path featurePath,
+        CLONEABLE(RemoveEntryFromArrayCommand);
+        RemoveEntryFromArrayCommand(std::string commandName, NodeId nodeId, Path featurePath,
                                     unsigned int indexOfEntryToRemove, unsigned int numEntriesToRemove);
 
         virtual bool initializeAndExecute(Project& project) override;
@@ -30,9 +31,11 @@ namespace babelwires {
         unsigned int m_indexOfEntryToRemove;
         unsigned int m_numEntriesToRemove;
 
+        // Post initialization data
+
         /// Did an old modifier get replaced (otherwise this is the first modification).
         bool m_wasModifier = false;
-        bool m_isSubcommand;
+        bool m_isSubcommand = false;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Project/Commands/removeFailedModifiersCommand.hpp
+++ b/BabelWiresLib/Project/Commands/removeFailedModifiersCommand.hpp
@@ -17,6 +17,7 @@ namespace babelwires {
     /// Remove all failed modifiers at or beneath the given path.
     class RemoveFailedModifiersCommand : public CompoundCommand<Project> {
       public:
+        CLONEABLE(RemoveFailedModifiersCommand);
         RemoveFailedModifiersCommand(std::string commandName, NodeId targetId, Path featurePath);
 
         virtual bool initializeAndExecute(Project& project) override;

--- a/BabelWiresLib/Project/Commands/removeModifierCommand.hpp
+++ b/BabelWiresLib/Project/Commands/removeModifierCommand.hpp
@@ -18,6 +18,7 @@ namespace babelwires {
     /// Remove the modifier, and restore any other modifiers removed when an array's size changes.
     class RemoveModifierCommand : public CompoundCommand<Project> {
       public:
+        CLONEABLE(RemoveModifierCommand);
         RemoveModifierCommand(std::string commandName, NodeId targetId, Path featurePath);
 
         virtual bool initializeAndExecute(Project& project) override;

--- a/BabelWiresLib/Project/Commands/removeNodeCommand.hpp
+++ b/BabelWiresLib/Project/Commands/removeNodeCommand.hpp
@@ -27,15 +27,18 @@ namespace babelwires {
     /// executed in a consistent way.
     class RemoveNodeCommand : public SimpleCommand<Project> {
       public:
-        /// A default constructed object cannot be initiatialized until addElementToRemove
+        CLONEABLE(RemoveNodeCommand);
+        /// A default constructed object cannot be initiatialized until addNodeToRemove
         /// is called or it subsumes a command with data.
         RemoveNodeCommand(std::string commandName);
 
-        /// Remove the given element.
-        RemoveNodeCommand(std::string commandName, NodeId elementId);
+        /// Remove the given node.
+        RemoveNodeCommand(std::string commandName, NodeId nodeId);
 
         /// Remove the described connection.
         RemoveNodeCommand(std::string commandName, ConnectionDescription connection);
+
+        RemoveNodeCommand(const RemoveNodeCommand& other);
 
         virtual ~RemoveNodeCommand();
 
@@ -45,7 +48,7 @@ namespace babelwires {
         virtual bool shouldSubsume(const Command& subsequentCommand, bool thisIsAlreadyExecuted) const override;
         virtual void subsume(std::unique_ptr<Command> subsequentCommand) override;
 
-        void addElementToRemove(NodeId elementId);
+        void addNodeToRemove(NodeId nodeId);
 
       private:
         using ConnectionSet = std::unordered_set<ConnectionDescription>;
@@ -57,11 +60,14 @@ namespace babelwires {
                            const babelwires::Project& project);
 
       private:
-        std::vector<NodeId> m_elementIds;
+        std::vector<NodeId> m_nodeIds;
 
-        std::vector<std::unique_ptr<NodeData>> m_elementsToRestore;
-
+        // Note: This can be expanded during initialization.
         std::vector<ConnectionDescription> m_connections;
+
+        // Post initialization data
+
+        std::vector<std::unique_ptr<NodeData>> m_nodesToRestore;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Project/Commands/resizeNodeCommand.cpp
+++ b/BabelWiresLib/Project/Commands/resizeNodeCommand.cpp
@@ -12,9 +12,9 @@
 
 #include <cassert>
 
-babelwires::ResizeNodeCommand::ResizeNodeCommand(std::string commandName, NodeId elementId, UiSize newSize)
+babelwires::ResizeNodeCommand::ResizeNodeCommand(std::string commandName, NodeId nodeId, UiSize newSize)
     : SimpleCommand(std::move(commandName))
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_newSize(newSize) {}
 
 bool babelwires::ResizeNodeCommand::initialize(const Project& project) {

--- a/BabelWiresLib/Project/Commands/resizeNodeCommand.hpp
+++ b/BabelWiresLib/Project/Commands/resizeNodeCommand.hpp
@@ -20,7 +20,8 @@ namespace babelwires {
 
     class ResizeNodeCommand : public SimpleCommand<Project> {
       public:
-        ResizeNodeCommand(std::string commandName, NodeId elementId, UiSize newSize);
+        CLONEABLE(ResizeNodeCommand);
+        ResizeNodeCommand(std::string commandName, NodeId nodeId, UiSize newSize);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;
@@ -31,6 +32,9 @@ namespace babelwires {
       private:
         NodeId m_nodeId;
         UiSize m_newSize;
+        
+        // Post initialization data
+        
         UiSize m_oldSize;
     };
 

--- a/BabelWiresLib/Project/Commands/selectRecordVariantCommand.cpp
+++ b/BabelWiresLib/Project/Commands/selectRecordVariantCommand.cpp
@@ -8,19 +8,27 @@
 
 #include <BabelWiresLib/Project/Commands/selectRecordVariantCommand.hpp>
 
-#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
 #include <BabelWiresLib/Project/Commands/Subcommands/removeAllEditsSubcommand.hpp>
-#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/Modifiers/localModifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/selectRecordVariantModifierData.hpp>
+#include <BabelWiresLib/Project/Nodes/node.hpp>
 #include <BabelWiresLib/Project/project.hpp>
+#include <BabelWiresLib/ValueTree/valueTreeHelper.hpp>
 
-babelwires::SelectRecordVariantCommand::SelectRecordVariantCommand(std::string commandName, NodeId elementId,
-                                                               Path featurePath, ShortId tagToSelect)
+babelwires::SelectRecordVariantCommand::SelectRecordVariantCommand(std::string commandName, NodeId nodeId,
+                                                                   Path pathToRecord, ShortId tagToSelect)
     : CompoundCommand(commandName)
-    , m_nodeId(elementId)
-    , m_pathToRecord(std::move(featurePath))
+    , m_nodeId(nodeId)
+    , m_pathToRecord(std::move(pathToRecord))
     , m_tagToSelect(tagToSelect) {}
+
+babelwires::SelectRecordVariantCommand::SelectRecordVariantCommand(const SelectRecordVariantCommand& other)
+    : CompoundCommand(other)
+    , m_nodeId(other.m_nodeId)
+    , m_pathToRecord(other.m_pathToRecord)
+    , m_tagToSelect(other.m_tagToSelect)
+    , m_recordModifierToAdd(other.m_recordModifierToAdd ? other.m_recordModifierToAdd->clone() : nullptr)
+    , m_recordModifierToRemove(other.m_recordModifierToRemove ? other.m_recordModifierToRemove->clone() : nullptr) {}
 
 babelwires::SelectRecordVariantCommand::~SelectRecordVariantCommand() = default;
 
@@ -39,7 +47,7 @@ bool babelwires::SelectRecordVariantCommand::initializeAndExecute(Project& proje
         ValueTreeHelper::getInfoFromRecordWithVariants(m_pathToRecord.tryFollow(*input), m_tagToSelect);
 
     if (!compoundFeature) {
-        return false;   
+        return false;
     }
 
     if (isCurrentTag) {

--- a/BabelWiresLib/Project/Commands/selectRecordVariantCommand.hpp
+++ b/BabelWiresLib/Project/Commands/selectRecordVariantCommand.hpp
@@ -2,7 +2,7 @@
  * The command which selects the variant in a RecordWithVariantType.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -19,8 +19,9 @@ namespace babelwires {
     /// Activate an optional in a RecordWithVariantType
     class SelectRecordVariantCommand : public CompoundCommand<Project> {
       public:
-        SelectRecordVariantCommand(std::string commandName, NodeId elementId, Path featurePath,
-                               ShortId tagToSelect);
+        CLONEABLE(SelectRecordVariantCommand);
+        SelectRecordVariantCommand(std::string commandName, NodeId nodeId, Path pathToRecord, ShortId tagToSelect);
+        SelectRecordVariantCommand(const SelectRecordVariantCommand& other);
         virtual ~SelectRecordVariantCommand();
 
         virtual bool initializeAndExecute(Project& project) override;
@@ -31,6 +32,8 @@ namespace babelwires {
         NodeId m_nodeId;
         Path m_pathToRecord;
         ShortId m_tagToSelect;
+
+        // Post initialization data
 
         std::unique_ptr<ModifierData> m_recordModifierToAdd;
         std::unique_ptr<ModifierData> m_recordModifierToRemove;

--- a/BabelWiresLib/Project/Commands/setArraySizeCommand.cpp
+++ b/BabelWiresLib/Project/Commands/setArraySizeCommand.cpp
@@ -18,10 +18,10 @@
 
 #include <cassert>
 
-babelwires::SetArraySizeCommand::SetArraySizeCommand(std::string commandName, NodeId elementId,
+babelwires::SetArraySizeCommand::SetArraySizeCommand(std::string commandName, NodeId nodeId,
                                                      Path featurePath, int newSize)
     : CompoundCommand(commandName)
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_pathToArray(std::move(featurePath))
     , m_newSize(newSize) {}
 

--- a/BabelWiresLib/Project/Commands/setArraySizeCommand.hpp
+++ b/BabelWiresLib/Project/Commands/setArraySizeCommand.hpp
@@ -17,7 +17,8 @@ namespace babelwires {
     /// Set the size of an array.
     class SetArraySizeCommand : public CompoundCommand<Project> {
       public:
-        SetArraySizeCommand(std::string commandName, NodeId elementId, Path featurePath,
+        CLONEABLE(SetArraySizeCommand);
+        SetArraySizeCommand(std::string commandName, NodeId nodeId, Path featurePath,
                                     int newSize);
 
         virtual bool initializeAndExecute(Project& project) override;
@@ -31,6 +32,9 @@ namespace babelwires {
         NodeId m_nodeId;
         Path m_pathToArray;
         unsigned int m_newSize;
+
+        // Post initialization data
+
         unsigned int m_oldSize;
 
         /// Did an old modifier get replaced (otherwise this is the first modification).

--- a/BabelWiresLib/Project/Commands/setExpandedCommand.cpp
+++ b/BabelWiresLib/Project/Commands/setExpandedCommand.cpp
@@ -13,10 +13,10 @@
 
 #include <cassert>
 
-babelwires::SetExpandedCommand::SetExpandedCommand(std::string commandName, NodeId elementId,
+babelwires::SetExpandedCommand::SetExpandedCommand(std::string commandName, NodeId nodeId,
                                                    Path pathToCompound, bool expanded)
     : SimpleCommand(std::move(commandName))
-    , m_nodeId(elementId)
+    , m_nodeId(nodeId)
     , m_pathToCompound(std::move(pathToCompound))
     , m_expanded(expanded) {}
 

--- a/BabelWiresLib/Project/Commands/setExpandedCommand.hpp
+++ b/BabelWiresLib/Project/Commands/setExpandedCommand.hpp
@@ -16,7 +16,8 @@ namespace babelwires {
 
     class SetExpandedCommand : public SimpleCommand<Project> {
       public:
-        SetExpandedCommand(std::string commandName, NodeId elementId, Path pathToCompound, bool expanded);
+        CLONEABLE(SetExpandedCommand);
+        SetExpandedCommand(std::string commandName, NodeId nodeId, Path pathToCompound, bool expanded);
 
         virtual bool initialize(const Project& project) override;
         virtual void execute(Project& project) const override;

--- a/BabelWiresLib/Project/projectData.cpp
+++ b/BabelWiresLib/Project/projectData.cpp
@@ -2,13 +2,20 @@
  * ProjectData carries data sufficient to reconstruct the project.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #include <BabelWiresLib/Project/projectData.hpp>
 
 #include <Common/Serialization/deserializer.hpp>
 #include <Common/Serialization/serializer.hpp>
+
+babelwires::ProjectData::ProjectData(const ProjectData& other) {
+    m_nodes.reserve(other.m_nodes.size());
+    for (const auto& n : other.m_nodes) {
+        m_nodes.emplace_back(n->clone());
+    }
+}
 
 void babelwires::ProjectData::serializeContents(Serializer& serializer) const {
     serializer.serializeValue("id", m_projectId);

--- a/BabelWiresLib/Project/projectData.hpp
+++ b/BabelWiresLib/Project/projectData.hpp
@@ -2,13 +2,14 @@
  * ProjectData carries data sufficient to reconstruct the project.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
 
 #include <BabelWiresLib/Project/Nodes/nodeData.hpp>
 
+#include <Common/Cloning/cloneable.hpp>
 #include <Common/Serialization/serializable.hpp>
 
 namespace babelwires {
@@ -18,10 +19,7 @@ namespace babelwires {
         SERIALIZABLE(ProjectData, "projectData", void, 1);
         ProjectData() = default;
         ProjectData(ProjectData&&) = default;
-
-        /// Deleted, to stop ProjectData being unnecessarily copied.
-        /// If required, the m_nodes will need to be cloned.
-        ProjectData(const ProjectData& other) = delete;
+        ProjectData(const ProjectData& other);
 
         ProjectData& operator=(const ProjectData&) = delete;
 

--- a/BabelWiresLib/Types/Map/Commands/addEntryToMapCommand.cpp
+++ b/BabelWiresLib/Types/Map/Commands/addEntryToMapCommand.cpp
@@ -2,21 +2,29 @@
  * The command which adds entries to arrays.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
 #include <BabelWiresLib/Types/Map/Commands/addEntryToMapCommand.hpp>
 
-#include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 #include <BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp>
+#include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 
 #include <cassert>
 
-babelwires::AddEntryToMapCommand::AddEntryToMapCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry, unsigned int indexOfNewEntry)
+babelwires::AddEntryToMapCommand::AddEntryToMapCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry,
+                                                       unsigned int indexOfNewEntry)
     : SimpleCommand(commandName)
     , m_newEntry(std::move(newEntry))
-    , m_indexOfNewEntry(indexOfNewEntry) {}
+    , m_indexOfNewEntry(indexOfNewEntry) {
+    assert(m_newEntry);
+}
+
+babelwires::AddEntryToMapCommand::AddEntryToMapCommand(const AddEntryToMapCommand& other)
+    : SimpleCommand(other)
+    , m_newEntry(other.m_newEntry->clone())
+    , m_indexOfNewEntry(other.m_indexOfNewEntry) {}
 
 bool babelwires::AddEntryToMapCommand::initialize(const MapProject& map) {
     // You can't "add" to the last entry, since it should be always be a fallback entry.

--- a/BabelWiresLib/Types/Map/Commands/addEntryToMapCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/addEntryToMapCommand.hpp
@@ -2,7 +2,7 @@
  * The command which adds entries to arrays.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -17,7 +17,10 @@ namespace babelwires {
     /// Add an element to an array.
     class AddEntryToMapCommand : public SimpleCommand<MapProject> {
       public:
-        AddEntryToMapCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry, unsigned int indexOfNewEntry);
+        CLONEABLE(AddEntryToMapCommand);
+        AddEntryToMapCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry,
+                             unsigned int indexOfNewEntry);
+        AddEntryToMapCommand(const AddEntryToMapCommand& other);
 
         virtual bool initialize(const MapProject& map) override;
         virtual void execute(MapProject& map) const override;

--- a/BabelWiresLib/Types/Map/Commands/changeEntryKindCommand.cpp
+++ b/BabelWiresLib/Types/Map/Commands/changeEntryKindCommand.cpp
@@ -8,10 +8,10 @@
 
 #include <BabelWiresLib/Types/Map/Commands/changeEntryKindCommand.hpp>
 
+#include <BabelWiresLib/Project/projectContext.hpp>
 #include <BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp>
 #include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 #include <BabelWiresLib/Types/Map/MapProject/mapProjectEntry.hpp>
-#include <BabelWiresLib/Project/projectContext.hpp>
 
 #include <cassert>
 
@@ -20,6 +20,12 @@ babelwires::ChangeEntryKindCommand::ChangeEntryKindCommand(std::string commandNa
     : SimpleCommand(commandName)
     , m_kind(kind)
     , m_indexOfEntry(indexOfEntry) {}
+
+babelwires::ChangeEntryKindCommand::ChangeEntryKindCommand(const ChangeEntryKindCommand& other)
+    : SimpleCommand(other)
+    , m_kind(other.m_kind)
+    , m_indexOfEntry(other.m_indexOfEntry)
+    , m_replacedEntry(other.m_replacedEntry ? other.m_replacedEntry->clone() : nullptr) {}
 
 bool babelwires::ChangeEntryKindCommand::initialize(const MapProject& map) {
     const int numEntries = map.getNumMapEntries();

--- a/BabelWiresLib/Types/Map/Commands/changeEntryKindCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/changeEntryKindCommand.hpp
@@ -3,7 +3,7 @@
  * The command which changes the kind of entry in a map.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -18,8 +18,9 @@ namespace babelwires {
     /// Add an element to an array.
     class ChangeEntryKindCommand : public SimpleCommand<MapProject> {
       public:
-
+        CLONEABLE(ChangeEntryKindCommand);
         ChangeEntryKindCommand(std::string commandName, MapEntryData::Kind kind, unsigned int indexOfEntry);
+        ChangeEntryKindCommand(const ChangeEntryKindCommand& other);
 
         virtual bool initialize(const MapProject& map) override;
         virtual void execute(MapProject& map) const override;
@@ -28,8 +29,11 @@ namespace babelwires {
       private:
         MapEntryData::Kind m_kind;
         std::unique_ptr<MapEntryData> m_newEntry;
-        std::unique_ptr<MapEntryData> m_replacedEntry;
         unsigned int m_indexOfEntry;
+
+        // Post initialization data
+
+        std::unique_ptr<MapEntryData> m_replacedEntry;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Types/Map/Commands/removeEntryFromMapCommand.cpp
+++ b/BabelWiresLib/Types/Map/Commands/removeEntryFromMapCommand.cpp
@@ -2,21 +2,27 @@
  * The command to remove entries from arrays.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
 #include <BabelWiresLib/Types/Map/Commands/removeEntryFromMapCommand.hpp>
 
+#include <BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp>
 #include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 #include <BabelWiresLib/Types/Map/MapProject/mapProjectEntry.hpp>
-#include <BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp>
 
 #include <cassert>
 
-babelwires::RemoveEntryFromMapCommand::RemoveEntryFromMapCommand(std::string commandName, unsigned int indexOfEntryToRemove)
+babelwires::RemoveEntryFromMapCommand::RemoveEntryFromMapCommand(std::string commandName,
+                                                                 unsigned int indexOfEntryToRemove)
     : SimpleCommand(commandName)
     , m_indexOfEntryToRemove(indexOfEntryToRemove) {}
+
+babelwires::RemoveEntryFromMapCommand::RemoveEntryFromMapCommand(const RemoveEntryFromMapCommand& other)
+    : SimpleCommand(other)
+    , m_indexOfEntryToRemove(other.m_indexOfEntryToRemove)
+    , m_removedEntry(other.m_removedEntry ? other.m_removedEntry->clone() : nullptr) {}
 
 babelwires::RemoveEntryFromMapCommand::~RemoveEntryFromMapCommand() = default;
 

--- a/BabelWiresLib/Types/Map/Commands/removeEntryFromMapCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/removeEntryFromMapCommand.hpp
@@ -2,7 +2,7 @@
  * The command to remove entries from arrays.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
@@ -17,7 +17,9 @@ namespace babelwires {
     /// Add an element to an array.
     class RemoveEntryFromMapCommand : public SimpleCommand<MapProject> {
       public:
+        CLONEABLE(RemoveEntryFromMapCommand);
         RemoveEntryFromMapCommand(std::string commandName, unsigned int indexOfEntryToRemove);
+        RemoveEntryFromMapCommand(const RemoveEntryFromMapCommand& other);
         ~RemoveEntryFromMapCommand();
 
         virtual bool initialize(const MapProject& map) override;
@@ -26,6 +28,9 @@ namespace babelwires {
 
       private:
         unsigned int m_indexOfEntryToRemove;
+
+        // Post initialization data
+
         std::unique_ptr<MapEntryData> m_removedEntry;
     };
 

--- a/BabelWiresLib/Types/Map/Commands/replaceMapEntryCommand.cpp
+++ b/BabelWiresLib/Types/Map/Commands/replaceMapEntryCommand.cpp
@@ -2,22 +2,32 @@
  * The command which adds entries to arrays.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
 #include <BabelWiresLib/Types/Map/Commands/replaceMapEntryCommand.hpp>
 
-#include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 #include <BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp>
+#include <BabelWiresLib/Types/Map/MapProject/mapProject.hpp>
 #include <BabelWiresLib/Types/Map/MapProject/mapProjectEntry.hpp>
 
 #include <cassert>
 
-babelwires::ReplaceMapEntryCommand::ReplaceMapEntryCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry, unsigned int indexOfReplacement)
+babelwires::ReplaceMapEntryCommand::ReplaceMapEntryCommand(std::string commandName,
+                                                           std::unique_ptr<MapEntryData> newEntry,
+                                                           unsigned int indexOfReplacement)
     : SimpleCommand(commandName)
     , m_newEntry(std::move(newEntry))
-    , m_indexOfReplacement(indexOfReplacement) {}
+    , m_indexOfReplacement(indexOfReplacement) {
+    assert(m_newEntry);
+}
+
+babelwires::ReplaceMapEntryCommand::ReplaceMapEntryCommand(const ReplaceMapEntryCommand& other)
+    : SimpleCommand(other)
+    , m_newEntry(other.m_newEntry->clone())
+    , m_replacedEntry(other.m_replacedEntry ? other.m_replacedEntry->clone() : nullptr)
+    , m_indexOfReplacement(other.m_indexOfReplacement) {}
 
 bool babelwires::ReplaceMapEntryCommand::initialize(const MapProject& map) {
     const int numEntries = map.getNumMapEntries();

--- a/BabelWiresLib/Types/Map/Commands/replaceMapEntryCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/replaceMapEntryCommand.hpp
@@ -17,7 +17,9 @@ namespace babelwires {
     /// Add an element to an array.
     class ReplaceMapEntryCommand : public SimpleCommand<MapProject> {
       public:
+        CLONEABLE(ReplaceMapEntryCommand);
         ReplaceMapEntryCommand(std::string commandName, std::unique_ptr<MapEntryData> newEntry, unsigned int indexOfReplacement);
+        ReplaceMapEntryCommand(const ReplaceMapEntryCommand& other);
 
         virtual bool initialize(const MapProject& map) override;
         virtual void execute(MapProject& map) const override;
@@ -25,8 +27,11 @@ namespace babelwires {
 
       private:
         std::unique_ptr<MapEntryData> m_newEntry;
-        std::unique_ptr<MapEntryData> m_replacedEntry;
         unsigned int m_indexOfReplacement;
+
+        // Post initialization data
+
+        std::unique_ptr<MapEntryData> m_replacedEntry;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/Types/Map/Commands/setMapCommand.cpp
+++ b/BabelWiresLib/Types/Map/Commands/setMapCommand.cpp
@@ -13,9 +13,10 @@
 #include <BabelWiresLib/Types/Map/MapProject/mapProjectEntry.hpp>
 
 babelwires::SetMapCommand::SetMapCommand(std::string commandName, ValueHolderTemplate<MapValue> newData)
-    : SimpleCommand(commandName), m_newContents(std::move(newData)) {
-        assert(m_newContents->as<MapValue>() && "SetMapCommand given non-map value");
-    }
+    : SimpleCommand(commandName)
+    , m_newContents(std::move(newData)) {
+    assert(m_newContents->as<MapValue>() && "SetMapCommand given non-map value");
+}
 
 bool babelwires::SetMapCommand::initialize(const MapProject& map) {
     m_oldContents = map.extractMapValue();

--- a/BabelWiresLib/Types/Map/Commands/setMapCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/setMapCommand.hpp
@@ -2,15 +2,15 @@
  * The command which sets a map to its default state.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 
 #pragma once
 
-#include <BabelWiresLib/Types/Map/mapValue.hpp>
-#include <BabelWiresLib/TypeSystem/valueHolder.hpp>
 #include <BabelWiresLib/Commands/commands.hpp>
+#include <BabelWiresLib/TypeSystem/valueHolder.hpp>
+#include <BabelWiresLib/Types/Map/mapValue.hpp>
 
 namespace babelwires {
     class MapProject;
@@ -18,6 +18,7 @@ namespace babelwires {
     /// Add an element to an array.
     class SetMapCommand : public SimpleCommand<MapProject> {
       public:
+        CLONEABLE(SetMapCommand);
         SetMapCommand(std::string commandName, ValueHolderTemplate<MapValue> newData);
 
         virtual bool initialize(const MapProject& map) override;
@@ -26,6 +27,9 @@ namespace babelwires {
 
       private:
         ValueHolderTemplate<MapValue> m_newContents;
+
+        // Post initialization data
+
         ValueHolderTemplate<MapValue> m_oldContents;
     };
 

--- a/BabelWiresLib/Types/Map/Commands/setMapSourceTypeCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/setMapSourceTypeCommand.hpp
@@ -20,6 +20,7 @@ namespace babelwires {
     /// Add an element to an array.
     class SetMapSourceTypeCommand : public SimpleCommand<MapProject> {
       public:
+        CLONEABLE(SetMapSourceTypeCommand);
         SetMapSourceTypeCommand(std::string commandName, TypeRef newSourceTypeRef);
 
         virtual bool initialize(const MapProject& map) override;
@@ -28,6 +29,9 @@ namespace babelwires {
 
       private:
         TypeRef m_newSourceTypeRef;
+
+        // Post initialization data
+
         TypeRef m_oldSourceTypeRef;
     };
 

--- a/BabelWiresLib/Types/Map/Commands/setMapTargetTypeCommand.hpp
+++ b/BabelWiresLib/Types/Map/Commands/setMapTargetTypeCommand.hpp
@@ -20,6 +20,7 @@ namespace babelwires {
     /// Add an element to an array feature.
     class SetMapTargetTypeCommand : public SimpleCommand<MapProject> {
       public:
+        CLONEABLE(SetMapTargetTypeCommand);
         SetMapTargetTypeCommand(std::string commandName, TypeRef newTargetTypeRef);
 
         virtual bool initialize(const MapProject& map) override;
@@ -28,6 +29,9 @@ namespace babelwires {
 
       private:
         TypeRef m_newTargetTypeRef;
+
+        // Post initialization data
+
         TypeRef m_oldTargetTypeRef;
     };
 

--- a/BabelWiresQtUi/mainWindow.cpp
+++ b/BabelWiresQtUi/mainWindow.cpp
@@ -413,7 +413,7 @@ void babelwires::MainWindow::cut() {
 
     auto command = std::make_unique<RemoveNodeCommand>("Cut elements");
     for (const auto& node : projectData.m_nodes) {
-        command->addElementToRemove(node->m_id);
+        command->addNodeToRemove(node->m_id);
     }
 
     writeToClipboard(std::move(projectData));

--- a/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/activateOptionalCommandTest.cpp
@@ -28,8 +28,9 @@ TEST(ActivateOptionalsCommandTest, executeAndUndo) {
 
     const babelwires::Path pathToValue;
 
-    babelwires::ActivateOptionalCommand command("Test command", elementId, pathToValue,
+    babelwires::ActivateOptionalCommand testCopyConstructor("Test command", elementId, pathToValue,
                                                 testUtils::TestComplexRecordType::getOpRecId());
+    babelwires::ActivateOptionalCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/addEntryToArrayCommandTest.cpp
+++ b/Tests/BabelWiresLib/addEntryToArrayCommandTest.cpp
@@ -35,8 +35,9 @@ TEST(AddEntryToArrayCommandTest, executeAndUndoAtIndex) {
     EXPECT_EQ(element->getInput()->getNumChildren(), testUtils::TestSimpleArrayType::s_defaultSize);
     checkModifiers(false);
 
-    babelwires::AddEntriesToArrayCommand command("Test command", elementId,
+    babelwires::AddEntriesToArrayCommand testCopyConstructor("Test command", elementId,
                                                  testUtils::TestArrayElementData::getPathToArray(), 1);
+    babelwires::AddEntriesToArrayCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/addEntryToMapCommandTest.cpp
@@ -41,7 +41,8 @@ TEST(AddEntryToMapCommandTest, executeAndUndo) {
     oneToOne.setSourceValue(newSourceValue);
     oneToOne.setTargetValue(newTargetValue);
 
-    babelwires::AddEntryToMapCommand command("Add entry", oneToOne.clone(), 1);
+    babelwires::AddEntryToMapCommand testCopyConstructor("Add entry", oneToOne.clone(), 1);
+    babelwires::AddEntryToMapCommand command = testCopyConstructor;
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);

--- a/Tests/BabelWiresLib/addModifierCommandTest.cpp
+++ b/Tests/BabelWiresLib/addModifierCommandTest.cpp
@@ -30,7 +30,8 @@ TEST(AddModifierCommandTest, executeAndUndo) {
     babelwires::ValueAssignmentData modData(babelwires::IntValue(8));
     modData.m_targetPath = elementData.getPathToRecordInt1();
 
-    babelwires::AddModifierCommand command("Test command", elementId, modData.clone());
+    babelwires::AddModifierCommand testCopyConstructor("Test command", elementId, modData.clone());
+    babelwires::AddModifierCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/addNodeCommandTest.cpp
+++ b/Tests/BabelWiresLib/addNodeCommandTest.cpp
@@ -14,7 +14,8 @@
 TEST(AddNodeCommandTest, executeAndUndo) {
     testUtils::TestEnvironment testEnvironment;
 
-    babelwires::AddNodeCommand command("Test command", std::make_unique<testUtils::TestSimpleRecordElementData>());
+    babelwires::AddNodeCommand testCopyConstructor("Test command", std::make_unique<testUtils::TestSimpleRecordElementData>());
+    babelwires::AddNodeCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/addNodeForInputTreeValueCommandTest.cpp
+++ b/Tests/BabelWiresLib/addNodeForInputTreeValueCommandTest.cpp
@@ -3,11 +3,11 @@
 #include <BabelWiresLib/Project/Commands/addNodeForInputTreeValueCommand.hpp>
 
 #include <BabelWiresLib/Project/Commands/moveNodeCommand.hpp>
-#include <BabelWiresLib/Project/Nodes/ValueNode/valueNode.hpp>
-#include <BabelWiresLib/Project/project.hpp>
 #include <BabelWiresLib/Project/Modifiers/connectionModifier.hpp>
 #include <BabelWiresLib/Project/Modifiers/connectionModifierData.hpp>
 #include <BabelWiresLib/Project/Modifiers/valueAssignmentData.hpp>
+#include <BabelWiresLib/Project/Nodes/ValueNode/valueNode.hpp>
+#include <BabelWiresLib/Project/project.hpp>
 
 #include <Common/Identifiers/identifierRegistry.hpp>
 
@@ -15,7 +15,8 @@
 #include <Tests/BabelWiresLib/TestUtils/testProjectDataWithCompoundConnection.hpp>
 #include <Tests/BabelWiresLib/TestUtils/testRecordType.hpp>
 
-class AddNodeForInputTreeValueCommandTest : public testing::TestWithParam<babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode> {};
+class AddNodeForInputTreeValueCommandTest
+    : public testing::TestWithParam<babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode> {};
 
 TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
     testUtils::TestEnvironment testEnvironment;
@@ -31,17 +32,18 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
     // Expected later.
     ASSERT_TRUE(targetNode->isExpanded(testUtils::TestComplexRecordElementData::getPathToRecordSubrecord()));
 
-    babelwires::AddNodeForInputTreeValueCommand command(
+    babelwires::AddNodeForInputTreeValueCommand testCopyConstructor(
         "test command", projectData.m_targetNodeId, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(),
         {-10, -20}, GetParam());
-    
+    babelwires::AddNodeForInputTreeValueCommand command = testCopyConstructor;
+
     EXPECT_EQ(command.getName(), "test command");
     EXPECT_TRUE(command.initializeAndExecute(testEnvironment.m_project));
 
     const babelwires::NodeId newNodeId = command.getNodeId();
     EXPECT_NE(newNodeId, babelwires::INVALID_NODE_ID);
 
-    auto checkNodeHasIntModifier = [] (const babelwires::Node* node, const babelwires::Path& path) {
+    auto checkNodeHasIntModifier = [](const babelwires::Node* node, const babelwires::Path& path) {
         if (const babelwires::Modifier* const modifier = node->findModifier(path)) {
             if (auto data = modifier->getModifierData().as<babelwires::ValueAssignmentData>()) {
                 if (data->getValue().asValueHolder<babelwires::IntValue>()) {
@@ -52,7 +54,7 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
         return false;
     };
 
-    auto testWhenExecuted = [&] () {
+    auto testWhenExecuted = [&]() {
         const babelwires::Node* const newNode = testEnvironment.m_project.getNode(newNodeId);
         ASSERT_NE(newNode, nullptr);
         EXPECT_NE(newNode->as<babelwires::ValueNode>(), nullptr);
@@ -61,7 +63,8 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
             const babelwires::Modifier* const modifierAtNewNode = newNode->findModifier(babelwires::Path());
             ASSERT_NE(modifierAtNewNode, nullptr);
 
-            const babelwires::ConnectionModifier* const connectionAtNewNode = modifierAtNewNode->as<babelwires::ConnectionModifier>();
+            const babelwires::ConnectionModifier* const connectionAtNewNode =
+                modifierAtNewNode->as<babelwires::ConnectionModifier>();
             ASSERT_NE(connectionAtNewNode, nullptr);
 
             const babelwires::ConnectionModifierData& connectionData = connectionAtNewNode->getModifierData();
@@ -72,10 +75,12 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
         EXPECT_TRUE(newNode->isExpanded(babelwires::Path()));
 
         {
-            const babelwires::Modifier* const modifierAtTargetNode = targetNode->findModifier(testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
+            const babelwires::Modifier* const modifierAtTargetNode =
+                targetNode->findModifier(testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
             ASSERT_NE(modifierAtTargetNode, nullptr);
 
-            const babelwires::ConnectionModifier* const connectionAtTargetNode = modifierAtTargetNode->as<babelwires::ConnectionModifier>();
+            const babelwires::ConnectionModifier* const connectionAtTargetNode =
+                modifierAtTargetNode->as<babelwires::ConnectionModifier>();
             ASSERT_NE(connectionAtTargetNode, nullptr);
 
             const babelwires::ConnectionModifierData& connectionData = connectionAtTargetNode->getModifierData();
@@ -83,13 +88,18 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
             if (GetParam() == babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode::Source) {
                 EXPECT_EQ(connectionData.m_sourcePath, babelwires::Path());
                 EXPECT_EQ(connectionData.m_sourceId, newNodeId);
-                EXPECT_TRUE(checkNodeHasIntModifier(newNode, testUtils::TestSimpleRecordElementData::getPathToRecordInt1()));
-                EXPECT_FALSE(checkNodeHasIntModifier(targetNode, testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
+                EXPECT_TRUE(
+                    checkNodeHasIntModifier(newNode, testUtils::TestSimpleRecordElementData::getPathToRecordInt1()));
+                EXPECT_FALSE(checkNodeHasIntModifier(
+                    targetNode, testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
             } else {
-                EXPECT_EQ(connectionData.m_sourcePath, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
+                EXPECT_EQ(connectionData.m_sourcePath,
+                          testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
                 EXPECT_EQ(connectionData.m_sourceId, projectData.m_sourceNodeId);
-                EXPECT_TRUE(checkNodeHasIntModifier(newNode, testUtils::TestSimpleRecordElementData::getPathToRecordInt1()));
-                EXPECT_TRUE(checkNodeHasIntModifier(targetNode, testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
+                EXPECT_TRUE(
+                    checkNodeHasIntModifier(newNode, testUtils::TestSimpleRecordElementData::getPathToRecordInt1()));
+                EXPECT_TRUE(checkNodeHasIntModifier(
+                    targetNode, testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
             }
         }
     };
@@ -99,24 +109,26 @@ TEST_P(AddNodeForInputTreeValueCommandTest, executeAndUndo) {
 
     ASSERT_EQ(testEnvironment.m_project.getNode(newNodeId), nullptr);
     {
-        const babelwires::Modifier* const modifierAtTargetNode = targetNode->findModifier(testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
+        const babelwires::Modifier* const modifierAtTargetNode =
+            targetNode->findModifier(testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
         ASSERT_NE(modifierAtTargetNode, nullptr);
 
-        const babelwires::ConnectionModifier* const connectionAtTargetNode = modifierAtTargetNode->as<babelwires::ConnectionModifier>();
+        const babelwires::ConnectionModifier* const connectionAtTargetNode =
+            modifierAtTargetNode->as<babelwires::ConnectionModifier>();
         ASSERT_NE(connectionAtTargetNode, nullptr);
 
         const babelwires::ConnectionModifierData& connectionData = connectionAtTargetNode->getModifierData();
         EXPECT_EQ(connectionData.m_sourcePath, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord());
         EXPECT_EQ(connectionData.m_sourceId, projectData.m_sourceNodeId);
-        
-        EXPECT_TRUE(checkNodeHasIntModifier(targetNode, testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
+
+        EXPECT_TRUE(checkNodeHasIntModifier(targetNode,
+                                            testUtils::TestComplexRecordElementData::getPathToRecordSubrecordInt1()));
     }
 
     command.execute(testEnvironment.m_project);
 
     testWhenExecuted();
 }
-
 
 TEST_P(AddNodeForInputTreeValueCommandTest, subsumeMoves) {
     testUtils::TestEnvironment testEnvironment;
@@ -130,8 +142,8 @@ TEST_P(AddNodeForInputTreeValueCommandTest, subsumeMoves) {
 
     EXPECT_TRUE(command.initializeAndExecute(testEnvironment.m_project));
 
-    auto moveCommand = std::make_unique<babelwires::MoveNodeCommand>("Test Move", command.getNodeId(),
-                                                                        babelwires::UiPosition{14, 88});
+    auto moveCommand =
+        std::make_unique<babelwires::MoveNodeCommand>("Test Move", command.getNodeId(), babelwires::UiPosition{14, 88});
 
     EXPECT_TRUE(command.shouldSubsume(*moveCommand, true));
 
@@ -140,8 +152,7 @@ TEST_P(AddNodeForInputTreeValueCommandTest, subsumeMoves) {
     // Confirm that the move was subsumed
     command.undo(testEnvironment.m_project);
     command.execute(testEnvironment.m_project);
-    const auto* element =
-        testEnvironment.m_project.getNode(command.getNodeId())->as<babelwires::ValueNode>();
+    const auto* element = testEnvironment.m_project.getNode(command.getNodeId())->as<babelwires::ValueNode>();
     ASSERT_NE(element, nullptr);
     EXPECT_EQ(element->getUiPosition().m_x, 14);
     EXPECT_EQ(element->getUiPosition().m_y, 88);
@@ -151,8 +162,8 @@ TEST_P(AddNodeForInputTreeValueCommandTest, failSafelyNoTargetNode) {
     testUtils::TestEnvironment testEnvironment;
 
     babelwires::AddNodeForInputTreeValueCommand command(
-        "test command", 32, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(),
-        {-10, -20}, GetParam());
+        "test command", 32, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(), {-10, -20},
+        GetParam());
 
     EXPECT_FALSE(command.initializeAndExecute(testEnvironment.m_project));
 }
@@ -163,14 +174,13 @@ TEST_P(AddNodeForInputTreeValueCommandTest, failSafelyNoTargetValue) {
     testUtils::TestProjectDataWithCompoundConnection projectData;
     testEnvironment.m_project.setProjectData(projectData);
 
-    babelwires::AddNodeForInputTreeValueCommand command(
-        "test command", projectData.m_sourceNodeId, babelwires::Path::deserializeFromString("aaa/bbb"),
-        {-10, -20}, GetParam());
+    babelwires::AddNodeForInputTreeValueCommand command("test command", projectData.m_sourceNodeId,
+                                                        babelwires::Path::deserializeFromString("aaa/bbb"), {-10, -20},
+                                                        GetParam());
 
     EXPECT_FALSE(command.initializeAndExecute(testEnvironment.m_project));
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    AddNodeForInputTreeValueCommandTest, AddNodeForInputTreeValueCommandTest,
-    testing::Values(babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode::Source, babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode::Copy)
-);
+INSTANTIATE_TEST_SUITE_P(AddNodeForInputTreeValueCommandTest, AddNodeForInputTreeValueCommandTest,
+                         testing::Values(babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode::Source,
+                                         babelwires::AddNodeForInputTreeValueCommand::RelationshipToOldNode::Copy));

--- a/Tests/BabelWiresLib/addNodeForOutputTreeValueCommandTest.cpp
+++ b/Tests/BabelWiresLib/addNodeForOutputTreeValueCommandTest.cpp
@@ -30,9 +30,10 @@ TEST_P(AddNodeForOutputTreeValueCommandTest, executeAndUndo) {
     const babelwires::Node* const targetNode = testEnvironment.m_project.getNode(projectData.m_targetNodeId);
     ASSERT_NE(targetNode, nullptr);
 
-    babelwires::AddNodeForOutputTreeValueCommand command(
+    babelwires::AddNodeForOutputTreeValueCommand testCopyConstructor(
         "test command", projectData.m_sourceNodeId, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(),
         {-10, -20}, GetParam());
+    babelwires::AddNodeForOutputTreeValueCommand command = testCopyConstructor;
     
     EXPECT_EQ(command.getName(), "test command");
     EXPECT_TRUE(command.initializeAndExecute(testEnvironment.m_project));

--- a/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
+++ b/Tests/BabelWiresLib/changeEntryKindCommandTest.cpp
@@ -35,7 +35,9 @@ TEST(ChangeEntryKindCommandTest, executeAndUndo) {
     mapValue.emplaceBack(allToOne.clone());
     mapProject.setMapValue(mapValue);
 
-    babelwires::ChangeEntryKindCommand command("Set kind", babelwires::MapEntryData::Kind::One21, 1);
+    babelwires::ChangeEntryKindCommand testCopyConstructor("Set kind", babelwires::MapEntryData::Kind::One21, 1);
+    babelwires::ChangeEntryKindCommand command = testCopyConstructor;
+
     EXPECT_EQ(mapProject.getMapEntry(1).getData().getKind(), babelwires::MapEntryData::Kind::All21);
     EXPECT_NE(mapProject.getMapEntry(1).getData().as<babelwires::AllToOneFallbackMapEntryData>(), nullptr);
 

--- a/Tests/BabelWiresLib/changeFileCommandTest.cpp
+++ b/Tests/BabelWiresLib/changeFileCommandTest.cpp
@@ -48,7 +48,8 @@ namespace {
             EXPECT_EQ(getOutput().getintR0().get(), 'x');
         }
 
-        babelwires::ChangeFileCommand command("Test command", elementId, filePath2.m_filePath);
+        babelwires::ChangeFileCommand testCopyConstructor("Test command", elementId, filePath2.m_filePath);
+        babelwires::ChangeFileCommand command = testCopyConstructor;
 
         EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/commandManagerTest.cpp
+++ b/Tests/BabelWiresLib/commandManagerTest.cpp
@@ -10,10 +10,19 @@
 
 namespace {
     struct TestCommand : babelwires::Command<babelwires::Project> {
+        CLONEABLE(TestCommand);
         TestCommand(std::string commandName, bool shouldApply, bool isSubsumable = false)
             : Command<babelwires::Project>(std::move(commandName))
             , m_shouldApply(shouldApply)
             , m_isSubsumable(isSubsumable) {}
+
+        TestCommand(const TestCommand& other)
+            : Command(other)
+            , m_shouldApply(other.m_shouldApply)
+            , m_isSubsumable(other.m_isSubsumable)
+        {
+            // TODO Clone subsumed commands here.
+        }
 
         bool initializeAndExecute(babelwires::Project& project) override {
             if (m_shouldApply) {

--- a/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
+++ b/Tests/BabelWiresLib/deactivateOptionalCommandTest.cpp
@@ -69,8 +69,9 @@ TEST(DeactivateOptionalsCommandTest, executeAndUndo) {
     ASSERT_NE(input, nullptr);
     const testUtils::TestComplexRecordType* const type = input->getType().as<testUtils::TestComplexRecordType>();
 
-    babelwires::DeactivateOptionalCommand command("Test command", elementId, pathToValue,
-                                                  testUtils::TestComplexRecordType::getOpRecId());
+    babelwires::DeactivateOptionalCommand testCopyConstructor("Test command", elementId, pathToValue,
+        testUtils::TestComplexRecordType::getOpRecId());
+    babelwires::DeactivateOptionalCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/moveNodeCommandTest.cpp
+++ b/Tests/BabelWiresLib/moveNodeCommandTest.cpp
@@ -24,7 +24,8 @@ TEST(MoveNodeCommandTest, executeAndUndo) {
     EXPECT_EQ(node->getUiPosition().m_x, -14);
     EXPECT_EQ(node->getUiPosition().m_y, -15);
 
-    babelwires::MoveNodeCommand command("Test command", elementId, babelwires::UiPosition{100, 12});
+    babelwires::MoveNodeCommand testCopyConstructor("Test command", elementId, babelwires::UiPosition{100, 12});
+    babelwires::MoveNodeCommand command = testCopyConstructor;
     EXPECT_EQ(command.getName(), "Test command");
 
     EXPECT_TRUE(command.initialize(testEnvironment.m_project));

--- a/Tests/BabelWiresLib/pasteNodesCommandTest.cpp
+++ b/Tests/BabelWiresLib/pasteNodesCommandTest.cpp
@@ -32,7 +32,8 @@ TEST(PasteNodesCommandTest, executeAndUndoEmptyProject) {
                              babelwires::pathToString(targetFilePath.m_filePath));
     testUtils::TestSourceFileFormat::writeToTestFile(sourceFilePath);
 
-    babelwires::PasteNodesCommand command("Test command", std::move(projectData));
+    babelwires::PasteNodesCommand testCopyConstructor("Test command", std::move(projectData));
+    babelwires::PasteNodesCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/removeEntryFromArrayCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeEntryFromArrayCommandTest.cpp
@@ -83,8 +83,9 @@ TEST(RemoveEntryFromArrayCommandTest, executeAndUndoNonDefaultArray) {
 
     EXPECT_EQ(element->getInput()->getNumChildren(), 5);
 
-    babelwires::RemoveEntryFromArrayCommand command("Test command", elementId,
-                                                    testUtils::TestArrayElementData::getPathToArray(), 1, 1);
+    babelwires::RemoveEntryFromArrayCommand testCopyConstructor("Test command", elementId,
+        testUtils::TestArrayElementData::getPathToArray(), 1, 1);
+    babelwires::RemoveEntryFromArrayCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeEntryFromMapCommandTest.cpp
@@ -45,7 +45,8 @@ TEST(RemoveEntryFromMapCommandTest, executeAndUndo) {
 
     EXPECT_EQ(mapProject.getNumMapEntries(), 3);
 
-    babelwires::RemoveEntryFromMapCommand command("Remove", 1);
+    babelwires::RemoveEntryFromMapCommand testCopyConstructor("Remove", 1);
+    babelwires::RemoveEntryFromMapCommand command = testCopyConstructor;
     
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);

--- a/Tests/BabelWiresLib/removeFailedModifiersCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeFailedModifiersCommandTest.cpp
@@ -87,7 +87,9 @@ namespace {
 
         const babelwires::Path commandPath =
             isWholeRecord ? babelwires::Path() : testUtils::TestComplexRecordElementData::getPathToRecordArray();
-        babelwires::RemoveFailedModifiersCommand command("Test command", elementId, commandPath);
+
+        babelwires::RemoveFailedModifiersCommand testCopyConstructor("Test command", elementId, commandPath);
+        babelwires::RemoveFailedModifiersCommand command = testCopyConstructor;
 
         EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/removeModifierCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeModifierCommandTest.cpp
@@ -89,8 +89,9 @@ TEST(RemoveModifierCommandTest, executeAndUndoArray) {
 
     EXPECT_EQ(element->getInput()->getNumChildren(), initialArraySize);
 
-    babelwires::RemoveModifierCommand command("Test command", elementId,
-                                              testUtils::TestArrayElementData::getPathToArray());
+    babelwires::RemoveModifierCommand testCopyConstructor("Test command", elementId,
+        testUtils::TestArrayElementData::getPathToArray());
+    babelwires::RemoveModifierCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/removeNodeCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeNodeCommandTest.cpp
@@ -60,7 +60,8 @@ TEST(RemoveNodeCommandTest, executeAndUndo) {
 
     checkElements(false);
 
-    babelwires::RemoveNodeCommand command("Test command", testUtils::TestProjectData::c_processorId);
+    babelwires::RemoveNodeCommand testCopyConstructor("Test command", testUtils::TestProjectData::c_processorId);
+    babelwires::RemoveNodeCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/removeSimpleModifierCommandTest.cpp
+++ b/Tests/BabelWiresLib/removeSimpleModifierCommandTest.cpp
@@ -45,7 +45,8 @@ TEST(RemoveSimpleModifierCommandTest, executeAndUndo) {
 
     checkModifiers(false);
 
-    babelwires::RemoveSimpleModifierSubcommand command(elementId, testUtils::TestComplexRecordElementData::getPathToRecordArrayEntry(1));
+    babelwires::RemoveSimpleModifierSubcommand testCopyConstructor(elementId, testUtils::TestComplexRecordElementData::getPathToRecordArrayEntry(1));
+    babelwires::RemoveSimpleModifierSubcommand command = testCopyConstructor;
 
     EXPECT_TRUE(command.initializeAndExecute(testEnvironment.m_project));
 

--- a/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
+++ b/Tests/BabelWiresLib/replaceMapEntryCommandTest.cpp
@@ -50,7 +50,8 @@ TEST(ReplaceMapEntryCommandTest, executeAndUndo) {
     oneToOne2.setSourceValue(newSourceValue);
     oneToOne2.setTargetValue(newTargetValue);
 
-    babelwires::ReplaceMapEntryCommand command("Replace", oneToOne2.clone(), 1);
+    babelwires::ReplaceMapEntryCommand testCopyConstructor("Replace", oneToOne2.clone(), 1);
+    babelwires::ReplaceMapEntryCommand command = testCopyConstructor;
     
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);

--- a/Tests/BabelWiresLib/resizeNodeCommandTest.cpp
+++ b/Tests/BabelWiresLib/resizeNodeCommandTest.cpp
@@ -23,7 +23,9 @@ TEST(ResizeNodeCommandTest, executeAndUndo) {
     ASSERT_NE(node, nullptr);
     EXPECT_EQ(node->getUiSize().m_width, 77);
 
-    babelwires::ResizeNodeCommand command("Test command", elementId, babelwires::UiSize{113});
+    babelwires::ResizeNodeCommand testCopyConstructor("Test command", elementId, babelwires::UiSize{113});
+    babelwires::ResizeNodeCommand command = testCopyConstructor;
+    
     EXPECT_EQ(command.getName(), "Test command");
 
     EXPECT_TRUE(command.initialize(testEnvironment.m_project));

--- a/Tests/BabelWiresLib/selectRecordVariantCommandTest.cpp
+++ b/Tests/BabelWiresLib/selectRecordVariantCommandTest.cpp
@@ -97,8 +97,9 @@ TEST(SelectRecordVariantCommandTest, executeAndUndo) {
         }
     };
 
-    babelwires::SelectRecordVariantCommand command("Test command", elementId, testUtils::TestRecordWithVariantsElementData::getPathToRecordWithVariants(),
+    babelwires::SelectRecordVariantCommand testCopyConstructor("Test command", elementId, testUtils::TestRecordWithVariantsElementData::getPathToRecordWithVariants(),
                                                    testUtils::TestRecordWithVariantsType::getTagBId());
+    babelwires::SelectRecordVariantCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
     EXPECT_EQ(getSelectedTag(node->getInput()), testUtils::TestRecordWithVariantsType::getTagAId());

--- a/Tests/BabelWiresLib/setArraySizeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setArraySizeCommandTest.cpp
@@ -78,8 +78,9 @@ TEST(SetArraySizeCommandTest, executeAndUndoArrayGrow) {
     EXPECT_EQ(element->getInput()->getNumChildren(), 3);
     checkModifiers();
 
-    babelwires::SetArraySizeCommand command("Test command", elementId,
-                                            testUtils::TestArrayElementData::getPathToArray(), 5);
+    babelwires::SetArraySizeCommand testCopyConstructor("Test command", elementId,
+        testUtils::TestArrayElementData::getPathToArray(), 5);
+    babelwires::SetArraySizeCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/setExpandedCommandTest.cpp
+++ b/Tests/BabelWiresLib/setExpandedCommandTest.cpp
@@ -19,7 +19,8 @@ TEST(SetExpandedCommandTest, executeAndUndoTrue) {
     const babelwires::Node* node = testEnvironment.m_project.getNode(elementId);
     ASSERT_NE(node, nullptr);
 
-    babelwires::SetExpandedCommand command("Test command", elementId, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(), true);
+    babelwires::SetExpandedCommand testCopyConstructor("Test command", elementId, testUtils::TestComplexRecordElementData::getPathToRecordSubrecord(), true);
+    babelwires::SetExpandedCommand command = testCopyConstructor;
 
     EXPECT_EQ(command.getName(), "Test command");
 

--- a/Tests/BabelWiresLib/setMapCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapCommandTest.cpp
@@ -62,7 +62,8 @@ TEST(SetMapCommandTest, executeAndUndo) {
     mapValue2.emplaceBack(oneToOne2.clone());
     mapValue2.emplaceBack(allToOne.clone());
 
-    babelwires::SetMapCommand command("Set map", mapValue2.clone());
+    babelwires::SetMapCommand testCopyConstructor("Set map", mapValue2.clone());
+    babelwires::SetMapCommand command = testCopyConstructor;
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);

--- a/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapSourceTypeCommandTest.cpp
@@ -55,7 +55,8 @@ TEST(SetMapSourceTypeCommandTest, executeAndUndo) {
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(3).getValidity());
 
-    babelwires::SetMapSourceTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisType());
+    babelwires::SetMapSourceTypeCommand testCopyConstructor("Set type", testUtils::TestSubSubEnum2::getThisType());
+    babelwires::SetMapSourceTypeCommand command = testCopyConstructor;
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);

--- a/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
+++ b/Tests/BabelWiresLib/setMapTargetTypeCommandTest.cpp
@@ -57,7 +57,8 @@ TEST(SetMapTargetTypeCommandTest, executeAndUndo) {
     EXPECT_FALSE(mapProject.getMapEntry(2).getValidity());
     EXPECT_TRUE(mapProject.getMapEntry(3).getValidity());
 
-    babelwires::SetMapTargetTypeCommand command("Set type", testUtils::TestSubSubEnum2::getThisType());
+    babelwires::SetMapTargetTypeCommand testCopyConstructor("Set type", testUtils::TestSubSubEnum2::getThisType());
+    babelwires::SetMapTargetTypeCommand command = testCopyConstructor;
 
     EXPECT_TRUE(command.initialize(mapProject));
     command.execute(mapProject);


### PR DESCRIPTION
This will allow commands to be used as templates.

Only the copying of commands in their pre-initialized state is tested (since that's the important case at the moment).

