### PR TITLE
Support Variadic Types in the TypeConstructor NAME syntax

### DIFF
--- a/BabelWiresLib/CMakeLists.txt
+++ b/BabelWiresLib/CMakeLists.txt
@@ -98,7 +98,6 @@ SET( BABELWIRESLIB_SRCS
 	Project/Commands/Subcommands/removeSimpleModifierSubcommand.cpp
 	Project/Commands/Subcommands/removeAllEditsSubcommand.cpp
 	Project/Commands/Subcommands/adjustModifiersInArraySubcommand.cpp
-	TypeSystem/typeSystem.cpp
 	Types/Enum/addBlankToEnum.cpp
 	Types/Enum/enumAtomTypeConstructor.cpp
 	Types/Enum/enumType.cpp
@@ -116,10 +115,12 @@ SET( BABELWIRESLIB_SRCS
 	Types/String/stringValue.cpp
 	Instance/instanceUtils.cpp
 	TypeSystem/compoundType.cpp
+	TypeSystem/Detail/typeNameFormatter.cpp
 	TypeSystem/type.cpp
 	TypeSystem/typeRef.cpp
 	TypeSystem/typeConstructorArguments.cpp
 	TypeSystem/typeConstructor.cpp
+	TypeSystem/typeSystem.cpp
 	TypeSystem/value.cpp
 	TypeSystem/valuePath.cpp
 	ValueNames/valueNames.cpp

--- a/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
+++ b/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
@@ -118,12 +118,6 @@ std::string babelwires::typeNameFormatter(std::string_view format, const std::ve
     if (format.size() < 2) {
         return {};
     }
-    if (typeArguments.size() > babelwires::TypeConstructorArguments::s_maxNumArguments) {
-        return {};
-    }
-    if (valueArguments.size() > babelwires::TypeConstructorArguments::s_maxNumArguments) {
-        return {};
-    }
     std::ostringstream oss;
 
     enum {

--- a/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
+++ b/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.cpp
@@ -1,0 +1,206 @@
+/**
+ * A TypeRef describes a type.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresLib/TypeSystem/Detail/typeNameFormatter.hpp>
+
+#include <BabelWiresLib/TypeSystem/typeConstructorArguments.hpp>
+
+#include <sstream>
+
+#include <variant>
+
+namespace {
+    constexpr char openType = '{';
+    constexpr char closeType = '}';
+    constexpr char openValue = '[';
+    constexpr char closeValue = ']';
+    constexpr char operatorDelimiter = '|';
+    constexpr char escapeCharacter = '\\';
+
+    struct RepeatedOperator {
+        unsigned int m_startIndex;
+        std::string m_operator;
+    };
+    using SpecificArgument = unsigned int;
+    // monostate == error.
+    using FormattingExpression = std::variant<std::monostate, SpecificArgument, RepeatedOperator>;
+
+    // Foo{0}[[[0], [0|+]]]
+
+    // <integer>[|<operator>]<closingDelimiter>
+    FormattingExpression parseFormattingExpression(std::string_view::const_iterator& it,
+                                                   std::string_view::const_iterator end, const char closingDelimiter) {
+        const char currentChar = *it;
+        enum { parsingInteger, justReadEscapeCharacter, parsingOperator } state = parsingInteger;
+
+        unsigned int argumentIndex = 0;
+
+        std::ostringstream op;
+
+        // Prevent "{}" meaning the same as "{0}".
+        if (*it == closingDelimiter) {
+            return {};
+        }
+
+        while (it < end) {
+            const char currentChar = *it;
+            switch (state) {
+                case parsingInteger:
+                    if ((currentChar >= '0') && (currentChar <= '9')) {
+                        const std::size_t indexCharAsIndex = currentChar - '0';
+                        argumentIndex = (10 * argumentIndex) + indexCharAsIndex;
+                    } else if (currentChar == operatorDelimiter) {
+                        state = parsingOperator;
+                    } else if (currentChar == closingDelimiter) {
+                        return argumentIndex;
+                    } else {
+                        return {};
+                    }
+                    break;
+                case parsingOperator:
+                    if (currentChar == closingDelimiter) {
+                        return RepeatedOperator{argumentIndex, op.str()};
+                    } else if (currentChar == escapeCharacter) {
+                        state = justReadEscapeCharacter;
+                    } else {
+                        op << currentChar;
+                    }
+                    break;
+                case justReadEscapeCharacter:
+                    if ((currentChar == escapeCharacter) || (currentChar == closeType) || (currentChar == closeValue)) {
+                        op << currentChar;
+                        state = parsingOperator;
+                    } else {
+                        return {};
+                    }
+                    break;
+            }
+            ++it;
+        }
+
+        return {};
+    }
+
+    bool processFormattingExpression(const FormattingExpression& formattingExpression, std::ostream& os,
+                                     const std::vector<std::string>& args) {
+        struct VisitorMethods {
+            bool operator()(std::monostate) { return false; }
+            bool operator()(const SpecificArgument& index) {
+                if (index >= m_args.size()) {
+                    return false;
+                }
+                m_os << m_args[index];
+                return true;
+            }
+            bool operator()(const RepeatedOperator& op) {
+                if (op.m_startIndex >= m_args.size()) {
+                    return false;
+                }
+                m_os << m_args[op.m_startIndex];
+                for (int i = op.m_startIndex + 1; i < m_args.size(); ++i) {
+                    m_os << op.m_operator << m_args[i];
+                }
+                return true;
+            }
+            std::ostream& m_os;
+            const std::vector<std::string>& m_args;
+        } visitorMethods{os, args};
+        return std::visit(visitorMethods, formattingExpression);
+    }
+} // namespace
+
+std::string babelwires::typeNameFormatter(std::string_view format, const std::vector<std::string>& typeArguments,
+                                          const std::vector<std::string>& valueArguments) {
+    if (format.size() < 2) {
+        return {};
+    }
+    if (typeArguments.size() > babelwires::TypeConstructorArguments::s_maxNumArguments) {
+        return {};
+    }
+    if (valueArguments.size() > babelwires::TypeConstructorArguments::s_maxNumArguments) {
+        return {};
+    }
+    std::ostringstream oss;
+
+    enum {
+        normal,
+        justReadOpenType,
+        justReadCloseType,
+        justReadOpenValue,
+        justReadCloseValue,
+    } state = normal;
+    std::string_view::const_iterator it = format.begin();
+    const std::string_view::const_iterator end = format.end();
+    while (it < end) {
+        const char currentChar = *it;
+
+        switch (state) {
+            case normal: {
+                if (currentChar == openType) {
+                    state = justReadOpenType;
+                } else if (currentChar == closeType) {
+                    state = justReadCloseType;
+                } else if (currentChar == openValue) {
+                    state = justReadOpenValue;
+                } else if (currentChar == closeValue) {
+                    state = justReadCloseValue;
+                } else {
+                    oss << currentChar;
+                }
+                break;
+            }
+            case justReadOpenType: {
+                if (currentChar == openType) {
+                    oss << openType;
+                } else {
+                    const auto formatExpression = parseFormattingExpression(it, end, closeType);
+                    if (!processFormattingExpression(formatExpression, oss, typeArguments)) {
+                        return {};
+                    }
+                }
+                state = normal;
+                break;
+            }
+            case justReadCloseType: {
+                if (currentChar == closeType) {
+                    oss << closeType;
+                    state = normal;
+                } else {
+                    return {};
+                }
+                break;
+            }
+            case justReadOpenValue: {
+                if (currentChar == openValue) {
+                    oss << openValue;
+                } else {
+                    const auto formatExpression = parseFormattingExpression(it, end, closeValue);
+                    if (!processFormattingExpression(formatExpression, oss, valueArguments)) {
+                        return {};
+                    }
+                }
+                state = normal;
+                break;
+            }
+            case justReadCloseValue: {
+                if (currentChar == closeValue) {
+                    oss << closeValue;
+                    state = normal;
+                } else {
+                    return {};
+                }
+                break;
+            }
+        }
+        ++it;
+    }
+    if (state == normal) {
+        return oss.str();
+    } else {
+        return {};
+    }
+}

--- a/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.hpp
+++ b/BabelWiresLib/TypeSystem/Detail/typeNameFormatter.hpp
@@ -1,0 +1,27 @@
+/**
+ * A TypeRef describes a type.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace babelwires {
+
+    /// The naming syntax for TypeConstructors allows complex type names without the need for code.
+    /// In particular, a deserialized TypeRef may still be given a user-meaningful name, even if it uses a
+    /// TypeConstructor whose code is not present. The format syntax allows type arguments to be referenced using "{n}"
+    /// and value arguments to be referenced using "[n]". Curly and square brackets can be escaped using "{{", "}}",
+    /// "[[" and "]]". Variadic type constructors can be represented too. A format expression of the form "{n|<operator
+    /// chars>}" describes how the types from n and up will be written with the <operator chars> between them. "}" and
+    /// "]" used in operators by escaping them with a "\" character. So "({0|,})" can build type names like 
+    /// "(Foo, Bar)". The (ridiculous) type constructor name "<{0}>+<[1|...]>+[0]" with type argument "Foo" and value
+    /// arguments "a", "b" and "c" will build the string "<Foo>+b...c+a".
+    std::string typeNameFormatter(std::string_view format, const std::vector<std::string>& typeArguments,
+                                  const std::vector<std::string>& valueArguments);
+} // namespace babelwires

--- a/BabelWiresLib/TypeSystem/typeConstructor.hpp
+++ b/BabelWiresLib/TypeSystem/typeConstructor.hpp
@@ -91,8 +91,6 @@ namespace babelwires {
 
 /// Type constructors need to be registered.
 /// For now, assume this is always done statically.
-/// The NAME of a type constructor is a format string with positional arguments for all its type arguments.
-/// For example, the NAME of the binary product type constructor might be something like "{0} * {1}".
-/// Regular brackets can be written with "{{" and "}}". Non-positional arguments "{}" are not supported.
+/// The NAME of a TypeConstructor is treated as a format string. See the comments in typeNameFormatter.
 #define TYPE_CONSTRUCTOR(IDENTIFIER, NAME, UUID, VERSION)                                                              \
     TYPE_CONSTRUCTOR_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/Types/Array/arrayTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Array/arrayTypeConstructor.hpp
@@ -15,7 +15,7 @@ namespace babelwires {
     class ArrayTypeConstructor : public TypeConstructor {
       public:
         /// Note that the default size is not represented in the name.
-        TYPE_CONSTRUCTOR("Array", "Array<{0}>[{1}..{2}]", "3f8cac9a-2c0b-439f-97ed-bde16874b994", 1);
+        TYPE_CONSTRUCTOR("Array", "Array<{0}>[[[0]..[1]]]", "3f8cac9a-2c0b-439f-97ed-bde16874b994", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Enum/enumAtomTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Enum/enumAtomTypeConstructor.hpp
@@ -14,7 +14,7 @@ namespace babelwires {
     /// Creates an EnumType with a single value.
     class EnumAtomTypeConstructor : public TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR("EnumAtom", "{0}", "cb88eeac-92e6-4a77-aa73-04db08c0d628", 1);
+        TYPE_CONSTRUCTOR("EnumAtom", "[0]", "cb88eeac-92e6-4a77-aa73-04db08c0d628", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Enum/enumUnionTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Enum/enumUnionTypeConstructor.hpp
@@ -14,7 +14,7 @@ namespace babelwires {
     /// Constructs an EnumType by combining other EnumTypes.
     class EnumUnionTypeConstructor : public TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR("EnumUnion", "({0} U {1})", "92eade8a-5315-419f-b3c6-71424ff6ea49", 1);
+        TYPE_CONSTRUCTOR("EnumUnion", "({0| U })", "92eade8a-5315-419f-b3c6-71424ff6ea49", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Int/intTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Int/intTypeConstructor.hpp
@@ -15,7 +15,7 @@ namespace babelwires {
     class IntTypeConstructor : public TypeConstructor {
       public:
         /// Note that the we don't represent the default in the name.
-        TYPE_CONSTRUCTOR("Int", "{{{0}..{1}}}", "96dc61c3-5940-47c4-9d98-9f06d5f01157", 1);
+        TYPE_CONSTRUCTOR("Int", "{{[0]..[1]}}", "96dc61c3-5940-47c4-9d98-9f06d5f01157", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Rational/rationalTypeConstructor.hpp
@@ -17,7 +17,7 @@ namespace babelwires {
       public:
         // The name format is not distinct from that of int, so there can be ambiguity. That's probably
         // alright because type names are not used for anything other than display.
-        TYPE_CONSTRUCTOR("Rational", "{{{0}..{1}}}", "dc2b335e-9336-471e-bc71-466bb65229d2", 1);
+        TYPE_CONSTRUCTOR("Rational", "{{[0]..[1]}}", "dc2b335e-9336-471e-bc71-466bb65229d2", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Sum/sumTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Sum/sumTypeConstructor.hpp
@@ -14,7 +14,8 @@ namespace babelwires {
     /// Construct a new SumType from a pair of types.
     class SumTypeConstructor : public TypeConstructor {
       public:
-        TYPE_CONSTRUCTOR("Sum", "{0}+{1}", "e9978340-49d9-49f3-922a-3c367f5feaec", 1);
+        // SumTypes are variadic.
+        TYPE_CONSTRUCTOR("Sum", "{0|+}", "e9978340-49d9-49f3-922a-3c367f5feaec", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;

--- a/BabelWiresLib/Types/Tuple/tupleTypeConstructor.hpp
+++ b/BabelWiresLib/Types/Tuple/tupleTypeConstructor.hpp
@@ -15,8 +15,8 @@ namespace babelwires {
     /// Construct a new TupleType from a vector of types.
     class TupleTypeConstructor : public TypeConstructor {
       public:
-        // TODO: Only showing first two parameter types.
-        TYPE_CONSTRUCTOR("Tuple", "{0}*{1}", "e55f3a4d-9b62-4f54-964f-bca4a42e8f68", 1);
+        // TupleTypes are variadic.
+        TYPE_CONSTRUCTOR("Tuple", "{0|*}", "e55f3a4d-9b62-4f54-964f-bca4a42e8f68", 1);
 
         std::unique_ptr<Type> constructType(const TypeSystem& typeSystem, TypeRef newTypeRef, const std::vector<const Type*>& typeArguments,
                                             const std::vector<EditableValueHolder>& valueArguments) const override;


### PR DESCRIPTION
Sum and Tuple types are variadic and the syntax for type constructor names meant that the TypeRef::toString could not build a proper string for them. 

This PR provides a richer syntax that allows for variadic types and also makes a cleaner distinction between type and value arguments.

See the comments of TypeNameFormatter for details.