### PR TITLE
Limit the vertical size of the DropDownValueEditor popup

### DIFF
--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -212,7 +212,7 @@ const babelwires::RecordType::Field& babelwires::RecordType::getFieldFromChildIn
         }
     }
     assert(false && "Child index out of range");
-    return {};
+    return *static_cast<babelwires::RecordType::Field*>(0);
 }
 
 std::tuple<const babelwires::ValueHolder*, babelwires::PathStep, const babelwires::TypeRef&>

--- a/BabelWiresQtUi/CMakeLists.txt
+++ b/BabelWiresQtUi/CMakeLists.txt
@@ -39,6 +39,7 @@ SET( BABELWIRESQTUI_SRCS
     ModelBridge/ContextMenu/setArraySizeAction.cpp
     ModelBridge/ContextMenu/openValueEditorAction.cpp
     Utilities/fileDialogs.cpp
+    Utilities/qtUtils.cpp
     ComplexValueEditors/complexValueEditor.cpp
     ComplexValueEditors/complexValueEditorFactory.cpp
     ComplexValueEditors/complexValueEditorManager.cpp

--- a/BabelWiresQtUi/ModelBridge/nodeContentsView.hpp
+++ b/BabelWiresQtUi/ModelBridge/nodeContentsView.hpp
@@ -2,7 +2,7 @@
  * NodeContentsModel is the QAbstractTableModel which represents the data in a Node.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -13,14 +13,14 @@
 #include <QAbstractTableModel>
 #include <QAction>
 #include <QMenu>
+#include <QMouseEvent>
 #include <QStyledItemDelegate>
 #include <QTableView>
-#include <QMouseEvent>
 
 #include <optional>
 
 namespace QtNodes {
-  class NodeGraphicsObject;
+    class NodeGraphicsObject;
 }
 
 namespace babelwires {
@@ -39,20 +39,21 @@ namespace babelwires {
         QSize minimumSizeHint() const override;
 
         void mousePressEvent(QMouseEvent* event) override;
-        void mouseMoveEvent(QMouseEvent *event) override;
-        void mouseReleaseEvent(QMouseEvent *event) override;
+        void mouseMoveEvent(QMouseEvent* event) override;
+        void mouseReleaseEvent(QMouseEvent* event) override;
 
         /// Get the position in scene coordinates corresponding to a position local to this widget.
         QPointF mapToScene(QPoint localPos) const;
 
         /// The regular mapToGlobal of this widget does not give the correct answer.
+        /// If you have a widget that may or may not be within a NodeContentsView, see mapToGlobalCorrect in QtUtils.
         QPoint mapToGlobalCorrect(QPoint localPos) const;
 
       private:
         /// The position in scene coordinates, converted to a UiPosition.
         UiPosition getFlowScenePositionFromLocalPosition(QPoint localPos);
 
-        /// Get the QtNode::NodeGraphicsObject which contains this widget 
+        /// Get the QtNode::NodeGraphicsObject which contains this widget
         const QtNodes::NodeGraphicsObject& getNodeGraphicsObject() const;
 
         /// Get the horizontal distance from the left edge of the contents to the left edge of the node.
@@ -73,4 +74,4 @@ namespace babelwires {
         std::optional<DragState> m_dragState;
     };
 
-}
+} // namespace babelwires

--- a/BabelWiresQtUi/Utilities/qtUtils.cpp
+++ b/BabelWiresQtUi/Utilities/qtUtils.cpp
@@ -1,0 +1,22 @@
+/**
+ * Some useful Qt functionality for working with BabelWires.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#include <BabelWiresQtUi/Utilities/qtUtils.hpp>
+
+#include <BabelWiresQtUi/ModelBridge/nodeContentsView.hpp>
+
+// If the popup is somewhere inside the graphicsview, then mapToGlobal doesn't work correctly.
+QPoint babelwires::mapToGlobalCorrect(const QWidget* widget, QPoint point) {
+    if (const auto* nodeContentsView = qobject_cast<const NodeContentsView*>(widget)) {
+        return nodeContentsView->mapToGlobalCorrect(point);
+    } else if (const auto* parent = qobject_cast<const QWidget*>(widget->parent())) {
+        return mapToGlobalCorrect(parent, widget->mapToParent(point));
+    } else {
+        // The widget isn't in the graphicsview after all, so we can use regular mapToGlobal.
+        return widget->mapToGlobal(point);
+    }
+}

--- a/BabelWiresQtUi/Utilities/qtUtils.hpp
+++ b/BabelWiresQtUi/Utilities/qtUtils.hpp
@@ -1,0 +1,17 @@
+/**
+ * Some useful Qt functionality for working with BabelWires.
+ *
+ * (C) 2021 Malcolm Tyrrell
+ * 
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <QWidget>
+
+namespace babelwires {
+    /// Get the global point corresponding to the widget local point.
+    /// This accounts for the fact that regular mapToGlobal doesn't work if a widget is inside a graphics view.
+    // TODO Ironically (given the name) there is a bug in the calculations and the result is slightly affected by scale.
+    QPoint mapToGlobalCorrect(const QWidget* widget, QPoint point);
+}

--- a/BabelWiresQtUi/Utilities/qtUtils.hpp
+++ b/BabelWiresQtUi/Utilities/qtUtils.hpp
@@ -12,6 +12,5 @@
 namespace babelwires {
     /// Get the global point corresponding to the widget local point.
     /// This accounts for the fact that regular mapToGlobal doesn't work if a widget is inside a graphics view.
-    // TODO Ironically (given the name) there is a bug in the calculations and the result is slightly affected by scale.
     QPoint mapToGlobalCorrect(const QWidget* widget, QPoint point);
 }

--- a/BabelWiresQtUi/ValueEditors/dropDownValueEditor.cpp
+++ b/BabelWiresQtUi/ValueEditors/dropDownValueEditor.cpp
@@ -29,10 +29,17 @@ void babelwires::DropDownValueEditor::setFeatureIsModified(bool isModified) {
 
 void babelwires::DropDownValueEditor::showPopup() {
     QComboBox::showPopup();
-    QWidget *popup = this->findChild<QFrame*>(); 
-    assert(popup);
+    auto *popup = this->findChild<QFrame*>(); 
+    assert(popup && "QComboBox structure not as expected");
+
+    auto* scrollArea = popup->findChild<QAbstractScrollArea*>();
+    assert(scrollArea && "QComboBox structure not as expected");
+    
     const int maximumHeight = 300;
     popup->setMaximumHeight(maximumHeight);
+
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
     // Place the popup downwards until it grows to more than half its maximum allowed height.
     const int offsetY = -std::max(0, popup->height() - (maximumHeight / 2));
     QPoint globalPoint = mapToGlobalCorrect(this, QPoint(0, offsetY));

--- a/BabelWiresQtUi/ValueEditors/dropDownValueEditor.cpp
+++ b/BabelWiresQtUi/ValueEditors/dropDownValueEditor.cpp
@@ -9,8 +9,10 @@
 
 #include <BabelWiresQtUi/ModelBridge/RowModels/rowModel.hpp>
 #include <BabelWiresQtUi/ModelBridge/nodeContentsModel.hpp>
+#include <BabelWiresQtUi/Utilities/qtUtils.hpp>
 
 #include <QLineEdit>
+#include <QAbstractItemView>
 
 babelwires::DropDownValueEditor::DropDownValueEditor(QWidget* parent)
     : ValueEditorCommonBase(parent) {
@@ -23,4 +25,16 @@ babelwires::DropDownValueEditor::DropDownValueEditor(QWidget* parent)
 
 void babelwires::DropDownValueEditor::setFeatureIsModified(bool isModified) {
     // TODO: when you click on the row value the value is not bold.
+}
+
+void babelwires::DropDownValueEditor::showPopup() {
+    QComboBox::showPopup();
+    QWidget *popup = this->findChild<QFrame*>(); 
+    assert(popup);
+    const int maximumHeight = 300;
+    popup->setMaximumHeight(maximumHeight);
+    // Place the popup downwards until it grows to more than half its maximum allowed height.
+    const int offsetY = -std::max(0, popup->height() - (maximumHeight / 2));
+    QPoint globalPoint = mapToGlobalCorrect(this, QPoint(0, offsetY));
+    popup->move(globalPoint);
 }

--- a/BabelWiresQtUi/ValueEditors/dropDownValueEditor.hpp
+++ b/BabelWiresQtUi/ValueEditors/dropDownValueEditor.hpp
@@ -20,6 +20,9 @@ namespace babelwires {
 
         /// Set the text to bold.
         void setFeatureIsModified(bool isModified) override;
+
+        // This is overridden to ensure the popup does not have an excessive height.
+        void showPopup() override;
     };
 
 } // namespace babelwires

--- a/TODO.md
+++ b/TODO.md
@@ -63,6 +63,7 @@ Refactor:
   - Review plugin initialization
   - add support for removing plugins.
 * Replace assert handler with own macros.
+  - Provide an assert false macro that can be used in return values of arbitrary type.
 * Use std::format in logs and exceptions instead of streams - Better, esp. for internationalization
 * Proper CMake usage
 * Arrays and optional modification are special-cased in the project: Could that be handled instead by a virtual "merge" method?


### PR DESCRIPTION
There was no vertical limit to the size of the popup produced by QComboBox if it occurred within the QGraphicsView. It was OK if it occurred within the map editor. This PR ensures that there's a maximum size and scroll bars are used to move within it.

The new handling works OK, but doesn't look perfect. At least it is now possible to select all pitches in SeqWires' SplitAtPitchProcessor.

As commented within the code, there seems to be a (Qt?) bug where the move doesn't quite place the popup in the correct vertical position, despite the horizontal position being correct. This is particularly visible when zoomed out.