### PR TITLE
File Formats should take a path

### DIFF
--- a/BabelWiresLib/FileFormat/sourceFileFormat.hpp
+++ b/BabelWiresLib/FileFormat/sourceFileFormat.hpp
@@ -14,8 +14,9 @@
 #include <string>
 #include <vector>
 
+#include <filesystem>
+
 namespace babelwires {
-    class DataSource;
     struct UserLogger;
 } // namespace babelwires
 
@@ -26,7 +27,7 @@ namespace babelwires {
     class SourceFileFormat : public FileTypeEntry, ProductInfo {
       public:
         SourceFileFormat(LongId identifier, VersionNumber version, Extensions extensions);
-        virtual std::unique_ptr<babelwires::ValueTreeRoot> loadFromFile(DataSource& dataSource, const ProjectContext& projectContext,
+        virtual std::unique_ptr<babelwires::ValueTreeRoot> loadFromFile(const std::filesystem::path& path, const ProjectContext& projectContext,
                                                                       UserLogger& userLogger) const = 0;
     };
 

--- a/BabelWiresLib/FileFormat/targetFileFormat.hpp
+++ b/BabelWiresLib/FileFormat/targetFileFormat.hpp
@@ -2,7 +2,7 @@
  * Factories for code which knows how to create, load and save FileFeatures.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
@@ -10,7 +10,7 @@
 #include <Common/Registry/fileTypeRegistry.hpp>
 #include <Common/productInfo.hpp>
 
-#include <istream>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -28,7 +28,8 @@ namespace babelwires {
       public:
         TargetFileFormat(LongId identifier, VersionNumber version, Extensions extensions);
         virtual std::unique_ptr<ValueTreeRoot> createNewValue(const ProjectContext& projectContext) const = 0;
-        virtual void writeToFile(const ProjectContext& projectContext, UserLogger& userLogger, const ValueTreeRoot& contents, std::ostream& os) const = 0;
+        virtual void writeToFile(const ProjectContext& projectContext, UserLogger& userLogger,
+                                 const ValueTreeRoot& contents, const std::filesystem::path& path) const = 0;
     };
 
     /// Registry of TargetFileFactories.

--- a/BabelWiresLib/Project/Nodes/SourceFileNode/sourceFileNode.cpp
+++ b/BabelWiresLib/Project/Nodes/SourceFileNode/sourceFileNode.cpp
@@ -16,7 +16,6 @@
 #include <BabelWiresLib/Types/Failure/failureType.hpp>
 #include <BabelWiresLib/Types/File/fileType.hpp>
 
-#include <Common/IO/fileDataSource.hpp>
 #include <Common/Log/userLogger.hpp>
 
 babelwires::SourceFileNode::SourceFileNode(const ProjectContext& context, UserLogger& userLogger,
@@ -89,8 +88,7 @@ bool babelwires::SourceFileNode::reload(const ProjectContext& context, UserLogge
             throw ModelException() << "No file name";
         }
 
-        FileDataSource file(data.m_filePath);
-        setValueTreeRoot(format.loadFromFile(file, context, userLogger));
+        setValueTreeRoot(format.loadFromFile(data.m_filePath, context, userLogger));
         clearInternalFailure();
         return true;
     } catch (const RegistryException& e) {

--- a/BabelWiresLib/Project/Nodes/TargetFileNode/targetFileNode.cpp
+++ b/BabelWiresLib/Project/Nodes/TargetFileNode/targetFileNode.cpp
@@ -17,7 +17,6 @@
 #include <BabelWiresLib/Types/Failure/failureType.hpp>
 
 #include <Common/Hash/hash.hpp>
-#include <Common/IO/outFileStream.hpp>
 #include <Common/Log/userLogger.hpp>
 
 #include <fstream>
@@ -109,11 +108,9 @@ bool babelwires::TargetFileNode::save(const ProjectContext& context, UserLogger&
         return false;
     }
     try {
-        OutFileStream outStream(data.m_filePath);
         const TargetFileFormat* format = context.m_targetFileFormatReg.getEntryByIdentifier(data.m_factoryIdentifier);
         assert(format && "FileFeature with unregistered file format");
-        format->writeToFile(context, userLogger, *m_valueTreeRoot, outStream);
-        outStream.close();
+        format->writeToFile(context, userLogger, *m_valueTreeRoot, data.m_filePath);
         if (m_saveHashWhenSaved != m_saveHash) {
             setChanged(Changes::NodeLabelChanged);
             m_saveHashWhenSaved = m_saveHash;

--- a/Domains/TestDomain/testFileFormats.cpp
+++ b/Domains/TestDomain/testFileFormats.cpp
@@ -80,10 +80,10 @@ char testDomain::TestSourceFileFormat::getFileData(const std::filesystem::path& 
 }
 
 std::unique_ptr<babelwires::ValueTreeRoot>
-testDomain::TestSourceFileFormat::loadFromFile(babelwires::DataSource& dataSource,
+testDomain::TestSourceFileFormat::loadFromFile(const std::filesystem::path& path,
                                               const babelwires::ProjectContext& projectContext,
                                               babelwires::UserLogger& userLogger) const {
-    const int value = getFileDataInternal(dataSource);
+    const int value = getFileData(path);
     auto newFeature = std::make_unique<babelwires::ValueTreeRoot>(projectContext.m_typeSystem, getTestFileType());
     newFeature->setToDefault();
     TestSimpleRecordType::Instance instance{newFeature->getChild(0)->is<babelwires::ValueTreeNode>()};

--- a/Domains/TestDomain/testFileFormats.cpp
+++ b/Domains/TestDomain/testFileFormats.cpp
@@ -15,8 +15,7 @@
 #include <fstream>
 
 namespace {
-    const char s_fileFormatId[] = "testFileFormat";
-    const char s_factoryFormatId[] = "testFactoryFormat";
+    const char s_fileFormat[] = "testFileFormat";
     const char s_manufacturer[] = "Test Manufacturer";
     const char s_product[] = "Test Product";
 } // namespace
@@ -33,18 +32,15 @@ babelwires::Path testDomain::getTestFileElementPathToInt0() {
 }
 
 babelwires::LongId testDomain::TestSourceFileFormat::getThisIdentifier() {
-    return s_fileFormatId;
+    return BW_LONG_ID("TestSourceFormat", "Test Source File Format", "c2e45d49-2707-4109-8642-a0a87143c315");
 }
 
 std::string testDomain::TestSourceFileFormat::getFileExtension() {
-    return s_fileFormatId;
+    return s_fileFormat;
 }
 
 testDomain::TestSourceFileFormat::TestSourceFileFormat()
-    : SourceFileFormat(babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
-                           s_fileFormatId, s_fileFormatId, "f557b89a-2499-465a-a605-5ef7f69284c4",
-                           babelwires::IdentifierRegistry::Authority::isAuthoritative),
-                       1, {s_fileFormatId}) {}
+    : SourceFileFormat(getThisIdentifier(), 1, {s_fileFormat}) {}
 
 std::string testDomain::TestSourceFileFormat::getManufacturerName() const {
     return s_manufacturer;
@@ -54,56 +50,41 @@ std::string testDomain::TestSourceFileFormat::getProductName() const {
     return s_product;
 }
 
-namespace {
-    char getFileDataInternal(babelwires::DataSource& dataSource) {
-        int value = 0;
-        for (char c : s_fileFormatId) {
-            babelwires::Byte d = dataSource.getNextByte();
-            if (c != 0) {
-                if (d != c) {
-                    throw babelwires::ParseException() << "Invalid TestSourceFileFormat file";
-                }
-            } else {
-                value = d;
-            }
-        }
-        if (!dataSource.isEof()) {
-            throw babelwires::ParseException() << "Invalid TestSourceFileFormat file";
-        }
-        return value;
-    }
-} // namespace
+void testDomain::TestSourceFileFormat::writeToTestFile(const std::filesystem::path& path, int r0, int r1) {
+    std::ofstream fs(path);
+    fs << s_fileFormat << " " << r0 << " " << r1 << "\n";
+}
 
-char testDomain::TestSourceFileFormat::getFileData(const std::filesystem::path& path) {
-    babelwires::FileDataSource dataSource(path);
-    return getFileDataInternal(dataSource);
+std::tuple<int, int> testDomain::TestSourceFileFormat::getFileData(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    std::string formatId;
+    int r0, r1;
+    is >> formatId >> r0 >> r1;
+    if (formatId != s_fileFormat) {
+        throw babelwires::ParseException() << "File at " << path << " was not in the expected format";
+    }
+    return {r0, r1};
 }
 
 std::unique_ptr<babelwires::ValueTreeRoot>
 testDomain::TestSourceFileFormat::loadFromFile(const std::filesystem::path& path,
                                               const babelwires::ProjectContext& projectContext,
                                               babelwires::UserLogger& userLogger) const {
-    const int value = getFileData(path);
+    auto [r0, r1] = getFileData(path);
     auto newFeature = std::make_unique<babelwires::ValueTreeRoot>(projectContext.m_typeSystem, getTestFileType());
     newFeature->setToDefault();
     TestSimpleRecordType::Instance instance{newFeature->getChild(0)->is<babelwires::ValueTreeNode>()};
-    instance.getintR0().set(value);
+    instance.getintR0().set(r0);
+    instance.getintR1().set(r1);
     return newFeature;
 }
 
-void testDomain::TestSourceFileFormat::writeToTestFile(const std::filesystem::path& path, char testData) {
-    std::ofstream fs(path);
-    fs << s_fileFormatId << testData;
-}
-
 testDomain::TestTargetFileFormat::TestTargetFileFormat()
-    : TargetFileFormat(babelwires::IdentifierRegistry::write()->addLongIdWithMetadata(
-                           s_factoryFormatId, s_factoryFormatId, "a9a603aa-9d83-4f12-ac35-de0056d5a568",
-                           babelwires::IdentifierRegistry::Authority::isAuthoritative),
-                       3, {s_fileFormatId}) {}
+    : TargetFileFormat(getThisIdentifier(),
+                       3, {s_fileFormat}) {}
 
 babelwires::LongId testDomain::TestTargetFileFormat::getThisIdentifier() {
-    return s_factoryFormatId;
+    return BW_LONG_ID("TestTargetFormat", "Test Target File Format", "0e0bf791-c161-41d0-9690-223d05a057bd");
 }
 
 std::string testDomain::TestTargetFileFormat::getManufacturerName() const {
@@ -125,5 +106,5 @@ void testDomain::TestTargetFileFormat::writeToFile(const babelwires::ProjectCont
                                                   const std::filesystem::path& path) const {
     std::ofstream os(path);    
     TestSimpleRecordType::ConstInstance instance{contents.getChild(0)->is<babelwires::ValueTreeNode>()};
-    os << s_fileFormatId << char(instance.getintR0().get());
+    TestSourceFileFormat::writeToTestFile(path, instance.getintR0().get(), instance.getintR1().get());
 }

--- a/Domains/TestDomain/testFileFormats.cpp
+++ b/Domains/TestDomain/testFileFormats.cpp
@@ -56,10 +56,15 @@ void testDomain::TestSourceFileFormat::writeToTestFile(const std::filesystem::pa
 }
 
 std::tuple<int, int> testDomain::TestSourceFileFormat::getFileData(const std::filesystem::path& path) {
-    std::ifstream is(path);
     std::string formatId;
     int r0, r1;
-    is >> formatId >> r0 >> r1;
+    try {
+        std::ifstream is(path);
+        is.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+        is >> formatId >> r0 >> r1;
+    } catch (...) {
+        throw babelwires::ParseException() << "Failed to parse file at " << path;
+    }
     if (formatId != s_fileFormat) {
         throw babelwires::ParseException() << "File at " << path << " was not in the expected format";
     }

--- a/Domains/TestDomain/testFileFormats.cpp
+++ b/Domains/TestDomain/testFileFormats.cpp
@@ -122,7 +122,8 @@ testDomain::TestTargetFileFormat::createNewValue(const babelwires::ProjectContex
 void testDomain::TestTargetFileFormat::writeToFile(const babelwires::ProjectContext& projectContext,
                                                   babelwires::UserLogger& userLogger,
                                                   const babelwires::ValueTreeRoot& contents,
-                                                  std::ostream& os) const {
+                                                  const std::filesystem::path& path) const {
+    std::ofstream os(path);    
     TestSimpleRecordType::ConstInstance instance{contents.getChild(0)->is<babelwires::ValueTreeNode>()};
     os << s_fileFormatId << char(instance.getintR0().get());
 }

--- a/Domains/TestDomain/testFileFormats.hpp
+++ b/Domains/TestDomain/testFileFormats.hpp
@@ -22,7 +22,7 @@ namespace testDomain {
         TestSourceFileFormat();
         std::string getManufacturerName() const override;
         std::string getProductName() const override;
-        std::unique_ptr<babelwires::ValueTreeRoot> loadFromFile(babelwires::DataSource& dataSource,
+        std::unique_ptr<babelwires::ValueTreeRoot> loadFromFile(const std::filesystem::path& path,
                                                               const babelwires::ProjectContext& projectContext,
                                                               babelwires::UserLogger& userLogger) const override;
 

--- a/Domains/TestDomain/testFileFormats.hpp
+++ b/Domains/TestDomain/testFileFormats.hpp
@@ -13,8 +13,7 @@ namespace testDomain {
     babelwires::Path getTestFileElementPathToInt0();
 
     /// A file format that can save and load some test data.
-    /// The serialized format is just the identifier followed by a single byte which carries the value of
-    /// intChildFeature. This has version 1.
+    /// The serialized format is just the identifier followed two ints. This has version 1.
     struct TestSourceFileFormat : babelwires::SourceFileFormat {
         static babelwires::LongId getThisIdentifier();
         static std::string getFileExtension();
@@ -26,8 +25,8 @@ namespace testDomain {
                                                               const babelwires::ProjectContext& projectContext,
                                                               babelwires::UserLogger& userLogger) const override;
 
-        static char getFileData(const std::filesystem::path& path);
-        static void writeToTestFile(const std::filesystem::path& path, char testData = 3);
+        static std::tuple<int, int> getFileData(const std::filesystem::path& path);
+        static void writeToTestFile(const std::filesystem::path& path, int r0 = 0, int r1 = 0);
     };
 
     /// A factor for construction new file features.

--- a/Domains/TestDomain/testFileFormats.hpp
+++ b/Domains/TestDomain/testFileFormats.hpp
@@ -41,7 +41,7 @@ namespace testDomain {
         std::unique_ptr<babelwires::ValueTreeRoot>
         createNewValue(const babelwires::ProjectContext& projectContext) const override;
         void writeToFile(const babelwires::ProjectContext& projectContext, babelwires::UserLogger& userLogger,
-                         const babelwires::ValueTreeRoot& contents, std::ostream& os) const override;
+                         const babelwires::ValueTreeRoot& contents, const std::filesystem::path& path) const override;
     };
 
 } // namespace testDomain

--- a/Tests/BabelWiresLib/changeFileCommandTest.cpp
+++ b/Tests/BabelWiresLib/changeFileCommandTest.cpp
@@ -25,10 +25,10 @@ namespace {
         testUtils::TempFilePath filePath2("erm" + testDomain::TestSourceFileFormat::getFileExtension());
 
         if (source1Present) {
-            testDomain::TestSourceFileFormat::writeToTestFile(filePath1, 'x');
+            testDomain::TestSourceFileFormat::writeToTestFile(filePath1, 100);
         }
         if (source2Present) {
-            testDomain::TestSourceFileFormat::writeToTestFile(filePath2, 'q');
+            testDomain::TestSourceFileFormat::writeToTestFile(filePath2, 200);
         }
 
         babelwires::SourceFileNodeData elementData;
@@ -46,7 +46,7 @@ namespace {
 
         EXPECT_EQ(element->getFilePath(), filePath1.m_filePath);
         if (source1Present) {
-            EXPECT_EQ(getOutput().getintR0().get(), 'x');
+            EXPECT_EQ(getOutput().getintR0().get(), 100);
         }
 
         babelwires::ChangeFileCommand testCopyConstructor("Test command", elementId, filePath2.m_filePath);
@@ -61,7 +61,7 @@ namespace {
 
         EXPECT_EQ(element->getFilePath(), filePath2.m_filePath);
         if (source2Present) {
-            EXPECT_EQ(getOutput().getintR0().get(), 'q');
+            EXPECT_EQ(getOutput().getintR0().get(), 200);
         }
 
         command.undo(testEnvironment.m_project);
@@ -69,7 +69,7 @@ namespace {
 
         EXPECT_EQ(element->getFilePath(), filePath1.m_filePath);
         if (source1Present) {
-            EXPECT_EQ(getOutput().getintR0().get(), 'x');
+            EXPECT_EQ(getOutput().getintR0().get(), 100);
         }
 
         command.execute(testEnvironment.m_project);
@@ -77,7 +77,7 @@ namespace {
 
         EXPECT_EQ(element->getFilePath(), filePath2.m_filePath);
         if (source2Present) {
-            EXPECT_EQ(getOutput().getintR0().get(), 'q');
+            EXPECT_EQ(getOutput().getintR0().get(), 200);
         }
     }
 } // namespace

--- a/Tests/BabelWiresLib/elementDataTest.cpp
+++ b/Tests/BabelWiresLib/elementDataTest.cpp
@@ -127,15 +127,13 @@ TEST(ElementDataTest, sourceFileDataCreateElement) {
     tempFileName << "foo." << testDomain::TestSourceFileFormat::getFileExtension();
     testUtils::TempFilePath tempFilePath(tempFileName.str());
     {
-        std::ofstream tempFile = tempFilePath.openForWriting();
-
         auto targetFileFormat = std::make_unique<testDomain::TestTargetFileFormat>();
         auto fileFeature = std::make_unique<babelwires::ValueTreeRoot>(testEnvironment.m_projectContext.m_typeSystem,
                                                                        testDomain::getTestFileType());
         fileFeature->setToDefault();
         testDomain::TestSimpleRecordType::Instance instance{fileFeature->getChild(0)->is<babelwires::ValueTreeNode>()};
         instance.getintR0().set(14);
-        targetFileFormat->writeToFile(testEnvironment.m_projectContext, testEnvironment.m_log, *fileFeature, tempFile);
+        targetFileFormat->writeToFile(testEnvironment.m_projectContext, testEnvironment.m_log, *fileFeature, tempFilePath);
     }
 
     // Create sourceFileData which expect to be able to load the file.

--- a/Tests/BabelWiresLib/pasteNodesCommandTest.cpp
+++ b/Tests/BabelWiresLib/pasteNodesCommandTest.cpp
@@ -31,7 +31,7 @@ TEST(PasteNodesCommandTest, executeAndUndoEmptyProject) {
     testUtils::TempFilePath targetFilePath(projectData.m_targetFilePath);
     projectData.setFilePaths(babelwires::pathToString(sourceFilePath.m_filePath),
                              babelwires::pathToString(targetFilePath.m_filePath));
-    testDomain::TestSourceFileFormat::writeToTestFile(sourceFilePath);
+    testDomain::TestSourceFileFormat::writeToTestFile(sourceFilePath, 3);
 
     babelwires::PasteNodesCommand testCopyConstructor("Test command", std::move(projectData));
     babelwires::PasteNodesCommand command = testCopyConstructor;

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -163,10 +163,10 @@ TEST(ProjectBundleTest, factoryMetadata) {
         testEnvironment.m_projectContext, std::filesystem::current_path(), testEnvironment.m_log);
 
     EXPECT_TRUE(testEnvironment.m_log.hasSubstringIgnoreCase(
-        "Data for the factory \"testFactoryFormat\" (testFactoryFormat) corresponds to an old version (1)"));
+        "Data for the factory \"Test Target File Format\" (TestTargetFormat) corresponds to an old version (1)"));
     EXPECT_FALSE(testEnvironment.m_log.hasSubstringIgnoreCase("Data for the factory \"testProcessor\""));
     EXPECT_TRUE(testEnvironment.m_log.hasSubstringIgnoreCase(
-        "Data for the factory \"testFileFormat\" (testFileFormat) has an unknown version (3)"));
+        "Data for the factory \"Test Source File Format\" (TestSourceFormat) has an unknown version (3)"));
 }
 
 TEST(ProjectBundleTest, filePathResolution) {

--- a/Tests/BabelWiresLib/projectTest.cpp
+++ b/Tests/BabelWiresLib/projectTest.cpp
@@ -442,15 +442,24 @@ TEST(ProjectTest, saveTarget) {
 
     testEnvironment.m_project.tryToSaveTarget(elementId);
 
-    EXPECT_EQ(testDomain::TestSourceFileFormat::getFileData(tempFilePath), 47);
+    {
+        auto [r0, r1] = testDomain::TestSourceFileFormat::getFileData(tempFilePath);
+        EXPECT_EQ(r0, 47);
+    }
 
     instance.getintR0().set(30);
     testEnvironment.m_project.tryToSaveTarget(elementId);
-    EXPECT_EQ(testDomain::TestSourceFileFormat::getFileData(tempFilePath), 30);
+    {
+        auto [r0, r1] = testDomain::TestSourceFileFormat::getFileData(tempFilePath);
+        EXPECT_EQ(r0, 30);
+    }
 
     instance.getintR0().set(79);
     testEnvironment.m_project.tryToSaveAllTargets();
-    EXPECT_EQ(testDomain::TestSourceFileFormat::getFileData(tempFilePath), 79);
+    {
+        auto [r0, r1] = testDomain::TestSourceFileFormat::getFileData(tempFilePath);
+        EXPECT_EQ(r0, 79);
+    }
 
     std::ofstream lockThisStream = tempFilePath.openForWriting();
 

--- a/Tests/BabelWiresLib/sourceFileNodeTest.cpp
+++ b/Tests/BabelWiresLib/sourceFileNodeTest.cpp
@@ -18,15 +18,13 @@
 namespace {
     void createTestFile(testUtils::TestEnvironment& testEnvironment, const std::filesystem::path& path,
                         int value = 14) {
-        std::ofstream tempFile(path);
-
         auto fileFormat = std::make_unique<testDomain::TestTargetFileFormat>();
         auto fileFeature = std::make_unique<babelwires::ValueTreeRoot>(testEnvironment.m_projectContext.m_typeSystem,
                                                                        testDomain::getTestFileType());
         fileFeature->setToDefault();
         testDomain::TestSimpleRecordType::Instance instance{fileFeature->getChild(0)->is<babelwires::ValueTreeNode>()};
         instance.getintR0().set(value);
-        fileFormat->writeToFile(testEnvironment.m_projectContext, testEnvironment.m_log, *fileFeature, tempFile);
+        fileFormat->writeToFile(testEnvironment.m_projectContext, testEnvironment.m_log, *fileFeature, path);
     }
 } // namespace
 


### PR DESCRIPTION
It's much more flexible if file formats take a file path rather than an abstraction defined by this codebase. If a format happened to wrap an external API, there might be no common representation of file contents. Adapters could probably be written but using a path seems general and simple, even if it does lock the semantics firmly to the filesystem.