### PR TITLE
RecordType subtyping fixes

### DIFF
--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -262,6 +262,7 @@ std::optional<babelwires::SubtypeOrder> babelwires::RecordType::compareSubtypeHe
 
     // Field order is not important for subtyping.
     // We use sorted sets of fields to allow mutual traversal by identifier.
+    // MAYBEDO: Consider storing sorted fields in the record at construction.
     std::vector<Field> thisFields = m_fields;
     std::vector<Field> otherFields = otherRecord->m_fields;
     auto fieldLess = [](const Field& a, const Field& b) { return a.m_identifier < b.m_identifier; };
@@ -279,9 +280,15 @@ std::optional<babelwires::SubtypeOrder> babelwires::RecordType::compareSubtypeHe
             const SubtypeOrder fieldComparison = typeSystem.compareSubtype(thisIt->m_type, otherIt->m_type);
             containmentTest = subtypeProduct(containmentTest, fieldComparison);
             if (thisIt->m_optionality == Optionality::alwaysActive) {
+                if (otherIt->m_optionality != Optionality::alwaysActive) {
+                    containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
+                }
                 fixedSubTest = fixedSubTest ? subtypeProduct(*fixedSubTest, fieldComparison) : fieldComparison;
             }
             if (otherIt->m_optionality == Optionality::alwaysActive) {
+                if (thisIt->m_optionality != Optionality::alwaysActive) {
+                    containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
+                }
                 fixedSuperTest = fixedSuperTest ? subtypeProduct(*fixedSuperTest, fieldComparison) : fieldComparison;
             }
             ++thisIt;

--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -7,9 +7,9 @@
  **/
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
-#include <BabelWiresLib/Types/Record/recordValue.hpp>
-#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
 #include <BabelWiresLib/TypeSystem/subtypeUtils.hpp>
+#include <BabelWiresLib/TypeSystem/typeSystem.hpp>
+#include <BabelWiresLib/Types/Record/recordValue.hpp>
 #include <BabelWiresLib/ValueTree/modelExceptions.hpp>
 
 babelwires::RecordType::RecordType(std::vector<Field> fields)
@@ -254,17 +254,12 @@ int babelwires::RecordType::getChildIndexFromStep(const ValueHolder& compoundVal
 }
 
 std::optional<babelwires::SubtypeOrder> babelwires::RecordType::compareSubtypeHelper(const TypeSystem& typeSystem,
-                                                                      const Type& other) const {
+                                                                                     const Type& other) const {
     const RecordType* const otherRecord = other.as<RecordType>();
     if (!otherRecord) {
         return {};
     }
-    SubtypeOrder currentOrder = SubtypeOrder::IsEquivalent;
 
-    auto updateAndCheckDisjoint = [&currentOrder](SubtypeOrder localOrder) {
-        currentOrder = subtypeProduct(currentOrder, localOrder);
-        return (currentOrder == SubtypeOrder::IsDisjoint);
-    };
     // Field order is not important for subtyping.
     // We use sorted sets of fields to allow mutual traversal by identifier.
     std::vector<Field> thisFields = m_fields;
@@ -272,44 +267,61 @@ std::optional<babelwires::SubtypeOrder> babelwires::RecordType::compareSubtypeHe
     auto fieldLess = [](const Field& a, const Field& b) { return a.m_identifier < b.m_identifier; };
     std::sort(thisFields.begin(), thisFields.end(), fieldLess);
     std::sort(otherFields.begin(), otherFields.end(), fieldLess);
+
+    SubtypeOrder containmentTest = SubtypeOrder::IsEquivalent;
+    std::optional<SubtypeOrder> fixedSubTest;
+    std::optional<SubtypeOrder> fixedSuperTest;
+
     auto thisIt = thisFields.begin();
     auto otherIt = otherFields.begin();
     while ((thisIt < thisFields.end()) && (otherIt < otherFields.end())) {
         if (thisIt->m_identifier == otherIt->m_identifier) {
             const SubtypeOrder fieldComparison = typeSystem.compareSubtype(thisIt->m_type, otherIt->m_type);
-            if (updateAndCheckDisjoint(fieldComparison)) {
-                return SubtypeOrder::IsDisjoint;
+            containmentTest = subtypeProduct(containmentTest, fieldComparison);
+            if (thisIt->m_optionality == Optionality::alwaysActive) {
+                fixedSubTest = fixedSubTest ? subtypeProduct(*fixedSubTest, fieldComparison) : fieldComparison;
+            }
+            if (otherIt->m_optionality == Optionality::alwaysActive) {
+                fixedSuperTest = fixedSuperTest ? subtypeProduct(*fixedSuperTest, fieldComparison) : fieldComparison;
             }
             ++thisIt;
             ++otherIt;
         } else if (thisIt->m_identifier < otherIt->m_identifier) {
-            // A record with an additional _required_ field can be a subtype of one without it.
-            // A record with an additional _optional_ field can actually have the same set of valid values as one
-            // without it, since we use a form of "duck typing".
-            if ((thisIt->m_optionality == Optionality::alwaysActive) &&
-                updateAndCheckDisjoint(SubtypeOrder::IsSubtype)) {
-                return SubtypeOrder::IsDisjoint;
+            if (thisIt->m_optionality == Optionality::alwaysActive) {
+                containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
+                fixedSuperTest = SubtypeOrder::IsDisjoint;
             }
             ++thisIt;
         } else { // if (otherIt->m_identifier < thisIt->m_identifier) {
-            if ((otherIt->m_optionality == Optionality::alwaysActive) &&
-                updateAndCheckDisjoint(SubtypeOrder::IsSupertype)) {
-                return SubtypeOrder::IsDisjoint;
+            if (otherIt->m_optionality == Optionality::alwaysActive) {
+                containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
+                fixedSubTest = SubtypeOrder::IsDisjoint;
             }
             ++otherIt;
         }
     }
-    if (thisIt != thisFields.end()) {
-        if ((thisIt->m_optionality == Optionality::alwaysActive) && updateAndCheckDisjoint(SubtypeOrder::IsSubtype)) {
-            return SubtypeOrder::IsDisjoint;
+    while (thisIt != thisFields.end()) {
+        if (thisIt->m_optionality == Optionality::alwaysActive) {
+            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
+            fixedSuperTest = SubtypeOrder::IsDisjoint;
         }
-    } else if (otherIt != otherFields.end()) {
-        if ((otherIt->m_optionality == Optionality::alwaysActive) &&
-            updateAndCheckDisjoint(SubtypeOrder::IsSupertype)) {
-            return SubtypeOrder::IsDisjoint;
-        }
+        ++thisIt;
     }
-    return currentOrder;
+    while (otherIt != otherFields.end()) {
+        if (otherIt->m_optionality == Optionality::alwaysActive) {
+            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
+            fixedSubTest = SubtypeOrder::IsDisjoint;
+        }
+        ++otherIt;
+    }
+    
+    if ((containmentTest != SubtypeOrder::IsIntersecting) && (containmentTest != SubtypeOrder::IsDisjoint)) {
+        return containmentTest;
+    }
+    if ((fixedSubTest && (fixedSubTest != SubtypeOrder::IsDisjoint)) || (fixedSuperTest && (fixedSuperTest != SubtypeOrder::IsDisjoint))) {
+        return SubtypeOrder::IsIntersecting;
+    }
+    return SubtypeOrder::IsDisjoint;
 }
 
 std::string babelwires::RecordType::valueToString(const TypeSystem& typeSystem, const ValueHolder& v) const {

--- a/BabelWiresLib/Types/Record/recordType.cpp
+++ b/BabelWiresLib/Types/Record/recordType.cpp
@@ -294,35 +294,34 @@ std::optional<babelwires::SubtypeOrder> babelwires::RecordType::compareSubtypeHe
             ++thisIt;
             ++otherIt;
         } else if (thisIt->m_identifier < otherIt->m_identifier) {
+            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
             if (thisIt->m_optionality == Optionality::alwaysActive) {
-                containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
                 fixedSuperTest = SubtypeOrder::IsDisjoint;
             }
             ++thisIt;
         } else { // if (otherIt->m_identifier < thisIt->m_identifier) {
+            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
             if (otherIt->m_optionality == Optionality::alwaysActive) {
-                containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
                 fixedSubTest = SubtypeOrder::IsDisjoint;
             }
             ++otherIt;
         }
     }
     while (thisIt != thisFields.end()) {
+        containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
         if (thisIt->m_optionality == Optionality::alwaysActive) {
-            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSubtype);
             fixedSuperTest = SubtypeOrder::IsDisjoint;
         }
         ++thisIt;
     }
     while (otherIt != otherFields.end()) {
+        containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
         if (otherIt->m_optionality == Optionality::alwaysActive) {
-            containmentTest = subtypeProduct(containmentTest, SubtypeOrder::IsSupertype);
             fixedSubTest = SubtypeOrder::IsDisjoint;
         }
         ++otherIt;
     }
-    
-    if ((containmentTest != SubtypeOrder::IsIntersecting) && (containmentTest != SubtypeOrder::IsDisjoint)) {
+    if (containmentTest != SubtypeOrder::IsDisjoint) {
         return containmentTest;
     }
     if ((fixedSubTest && (fixedSubTest != SubtypeOrder::IsDisjoint)) || (fixedSuperTest && (fixedSuperTest != SubtypeOrder::IsDisjoint))) {

--- a/BabelWiresLib/Types/RecordWithVariants/recordWithVariantsType.hpp
+++ b/BabelWiresLib/Types/RecordWithVariants/recordWithVariantsType.hpp
@@ -12,12 +12,9 @@
 namespace babelwires {
 
     /// RecordWithVariantsType is like a RecordType but has a number of variants.
-    /// Variants are selected using tags. The first tag is the default tag.
-    // TODO Allow another tag to be specified as the default.
-    // way to implement this without storing the variant tag in the value.
-    // Alternatively, finding a way to offer this functionality in the UI while implementing it by
-    // a union of record types would be nice.
-    // TODO Find an efficient way to unite this with RecordType or implement support for type coercion.
+    /// Variants are selected using tags.
+    // MAYBEDO Consider implementing this as a SumType of RecordTypes.
+    // MAYBEDO Find an efficient way to unite this with RecordType or implement support for type coercion.
     class RecordWithVariantsType : public CompoundType {
       public:
         using Tags = std::vector<ShortId>;
@@ -36,7 +33,7 @@ namespace babelwires {
         /// The tags used in the fields vector must be found in the tags vector.
         RecordWithVariantsType(Tags tags, std::vector<FieldWithTags> fields, unsigned int defaultTagIndex = 0);
 
-        // For now, this is a separate kind from RecordType.
+        // For now, this has a separate flavour from RecordType.
         std::string getFlavour() const override;
 
         /// Return the set of tags.

--- a/Domains/TestDomain/libRegistration.cpp
+++ b/Domains/TestDomain/libRegistration.cpp
@@ -44,9 +44,12 @@ void testDomain::registerLib(babelwires::ProjectContext& context) {
     context.m_typeSystem.addEntry<testDomain::RecordB>();
     context.m_typeSystem.addEntry<testDomain::RecordAB>();
     context.m_typeSystem.addEntry<testDomain::RecordAOpt>();
+    context.m_typeSystem.addEntry<testDomain::RecordAOptFixed>();
     context.m_typeSystem.addEntry<testDomain::RecordABOpt>();
     context.m_typeSystem.addEntry<testDomain::RecordAOptS>();
     context.m_typeSystem.addEntry<testDomain::RecordABOptChild>(context.m_typeSystem);
+    context.m_typeSystem.addEntry<testDomain::RecordAsub0>();
+    context.m_typeSystem.addEntry<testDomain::RecordAsubBsup>();
 
     context.m_typeSystem.addEntry<testDomain::RecordVWithNoFields>();
     context.m_typeSystem.addEntry<testDomain::RecordVA0>();

--- a/Domains/TestDomain/testRecordTypeHierarchy.cpp
+++ b/Domains/TestDomain/testRecordTypeHierarchy.cpp
@@ -1,5 +1,8 @@
 #include <Domains/TestDomain/testRecordTypeHierarchy.hpp>
 
+#include <BabelWiresLib/Types/Int/intType.hpp>
+#include <BabelWiresLib/Types/String/stringType.hpp>
+
 namespace {
     babelwires::ShortId getIdForA() {
         return BW_SHORT_ID("A", "A", "31b7733a-555c-4970-9ebf-5b863272a86d");

--- a/Domains/TestDomain/testRecordTypeHierarchy.cpp
+++ b/Domains/TestDomain/testRecordTypeHierarchy.cpp
@@ -1,7 +1,8 @@
 #include <Domains/TestDomain/testRecordTypeHierarchy.hpp>
 
-#include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/String/stringType.hpp>
+
+#include <Domains/TestDomain/testEnum.hpp>
 
 namespace {
     babelwires::ShortId getIdForA() {
@@ -25,39 +26,53 @@ testDomain::RecordWithNoFields::RecordWithNoFields()
     : RecordType({}) {}
 
 testDomain::RecordA0::RecordA0()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()}}) {}
+    : RecordType({{getIdForA(), TestSubEnum::getThisType()}}) {}
 
 testDomain::RecordA1::RecordA1()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()}}) {}
+    : RecordType({{getIdForA(), TestSubEnum::getThisType()}}) {}
 
 testDomain::RecordB::RecordB()
-    : RecordType({{getIdForB(), babelwires::DefaultIntType::getThisType()}}) {}
+    : RecordType({{getIdForB(), TestSubEnum::getThisType()}}) {}
 
 testDomain::RecordAB::RecordAB()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()},
-                  {getIdForB(), babelwires::DefaultIntType::getThisType()}}) {}
+    : RecordType({{getIdForA(), TestSubEnum::getThisType()}, {getIdForB(), TestSubEnum::getThisType()}}) {}
 
 testDomain::RecordAS::RecordAS()
     : RecordType({{getIdForA(), babelwires::StringType::getThisType()}}) {}
 
 testDomain::RecordAOpt::RecordAOpt()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()},
-                  {getIdForOpt(), babelwires::DefaultIntType::getThisType(),
-                   babelwires::RecordType::Optionality::optionalDefaultInactive}}) {}
+    : RecordType(
+          {{getIdForA(), TestSubEnum::getThisType()},
+           {getIdForOpt(), TestSubEnum::getThisType(), babelwires::RecordType::Optionality::optionalDefaultInactive}}) {
+}
+
+testDomain::RecordAOptFixed::RecordAOptFixed()
+    : RecordType(
+          {{getIdForA(), TestSubEnum::getThisType()},
+           {getIdForOpt(), TestSubEnum::getThisType()}}) {
+}
 
 testDomain::RecordABOpt::RecordABOpt()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()},
-                  {getIdForB(), babelwires::DefaultIntType::getThisType()},
-                  {getIdForOpt(), babelwires::DefaultIntType::getThisType(),
-                   babelwires::RecordType::Optionality::optionalDefaultInactive}}) {}
+    : RecordType(
+          {{getIdForA(), TestSubEnum::getThisType()},
+           {getIdForB(), TestSubEnum::getThisType()},
+           {getIdForOpt(), TestSubEnum::getThisType(), babelwires::RecordType::Optionality::optionalDefaultInactive}}) {
+}
 
 testDomain::RecordAOptS::RecordAOptS()
-    : RecordType({{getIdForA(), babelwires::DefaultIntType::getThisType()},
+    : RecordType({{getIdForA(), TestSubEnum::getThisType()},
                   {getIdForOpt(), babelwires::StringType::getThisType(),
                    babelwires::RecordType::Optionality::optionalDefaultInactive}}) {}
 
 testDomain::RecordABOptChild::RecordABOptChild(const babelwires::TypeSystem& typeSystem)
     : RecordType(RecordABOpt::getThisType().resolve(typeSystem).is<babelwires::RecordType>(),
-                 {{getIdForC(), babelwires::DefaultIntType::getThisType()},
-                  {getIdForOpt2(), babelwires::DefaultIntType::getThisType(),
+                 {{getIdForC(), TestSubEnum::getThisType()},
+                  {getIdForOpt2(), TestSubEnum::getThisType(),
                    babelwires::RecordType::Optionality::optionalDefaultInactive}}) {}
+
+testDomain::RecordAsub0::RecordAsub0()
+    : RecordType({{getIdForA(), TestSubSubEnum1::getThisType()}}) {}
+
+testDomain::RecordAsubBsup::RecordAsubBsup()
+    : RecordType({{getIdForA(), TestSubSubEnum1::getThisType()}, {getIdForB(), TestEnum::getThisType()}}) {}
+

--- a/Domains/TestDomain/testRecordTypeHierarchy.hpp
+++ b/Domains/TestDomain/testRecordTypeHierarchy.hpp
@@ -38,6 +38,11 @@ namespace testDomain {
         RecordAOpt();
     };
 
+    struct RecordAOptFixed : babelwires::RecordType {
+        PRIMITIVE_TYPE("RecordAOpt", "Record with int fields A and Opt, where in this case, Opt is a fixed field", "a3665c18-e5f2-41b7-8cf0-bf3a1396e029", 1);
+        RecordAOptFixed();
+    };
+
     struct RecordABOpt : babelwires::RecordType {
         PRIMITIVE_TYPE("RecordABOpt", "Record with int fields A, B and Opt", "5a21780a-0a56-481a-a850-4afb18b3bc2d", 1);
         RecordABOpt();
@@ -52,5 +57,16 @@ namespace testDomain {
         RecordABOptChild(const babelwires::TypeSystem& typeSystem);
         PRIMITIVE_TYPE("RecordChild", "Child of RecordABOpt", "0cc46b96-9ce0-4722-aba9-9009d12f1bcc", 1);
     };
+
+    struct RecordAsub0 : babelwires::RecordType {
+        PRIMITIVE_TYPE("RecordAsub0", "Record with field A which is a subtype of the original A", "a2a71062-213e-456e-91dd-0df1ca1a1dae", 1);
+        RecordAsub0();
+    };
+
+    struct RecordAsubBsup : babelwires::RecordType {
+        PRIMITIVE_TYPE("RecordAsubBsup", "Record with field A and B, which is a supertype of the original B", "21418e19-f5d6-4f26-9948-e9497595c11d", 1);
+        RecordAsubBsup();
+    };
+    
 
 } // namespace testDomain

--- a/Domains/TestDomain/testRecordTypeHierarchy.hpp
+++ b/Domains/TestDomain/testRecordTypeHierarchy.hpp
@@ -1,7 +1,5 @@
 #include <BabelWiresLib/TypeSystem/primitiveType.hpp>
-#include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
-#include <BabelWiresLib/Types/String/stringType.hpp>
 
 namespace testDomain {
 

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -344,8 +344,7 @@ TEST(RecordTypeTest, subtype) {
                                                           testDomain::RecordAB::getThisType()),
               babelwires::SubtypeOrder::IsDisjoint);
 
-    // With optionals: Optional fields do not impact subtyping since they are not part of the type's contract,
-    // unless the types are incompatible (see next sequence of tests, below).
+    // With optionals.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordAOpt::getThisType()),
               babelwires::SubtypeOrder::IsEquivalent);
@@ -358,13 +357,33 @@ TEST(RecordTypeTest, subtype) {
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordABOpt::getThisType(),
                                                           testDomain::RecordA0::getThisType()),
               babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
+                                                          testDomain::RecordAOptFixed::getThisType()),
+              babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOptFixed::getThisType(),
+                                                          testDomain::RecordAOpt::getThisType()),
+              babelwires::SubtypeOrder::IsSubtype);
 
-    // Incompatible and optional
+    // Intersecting with optionals
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordAOptS::getThisType()),
               babelwires::SubtypeOrder::IsIntersecting);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOptS::getThisType(),
                                                           testDomain::RecordAOpt::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+
+    // With field subtypes
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAsub0::getThisType(),
+                                                          testDomain::RecordA0::getThisType()),
+              babelwires::SubtypeOrder::IsSubtype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
+                                                          testDomain::RecordAsub0::getThisType()),
+              babelwires::SubtypeOrder::IsSupertype);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAB::getThisType(),
+                                                          testDomain::RecordAsubBsup::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAsubBsup::getThisType(),
+                                                          testDomain::RecordAB::getThisType()),
               babelwires::SubtypeOrder::IsIntersecting);
 }
 

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -329,11 +329,16 @@ TEST(RecordTypeTest, subtype) {
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordB::getThisType(),
                                                           testDomain::RecordAB::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
-
-    // Incompatible types
+    
+    // { A = TestSubEnum::erm, B = TestSubEnum::erm } belongs to both A0 and B.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordB::getThisType()),
-              babelwires::SubtypeOrder::IsDisjoint);
+              babelwires::SubtypeOrder::IsIntersecting);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordB::getThisType(),
+                                                          testDomain::RecordA0::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+
+    // Incompatible types
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAS::getThisType(),
                                                           testDomain::RecordA0::getThisType()),
               babelwires::SubtypeOrder::IsDisjoint);
@@ -345,12 +350,14 @@ TEST(RecordTypeTest, subtype) {
               babelwires::SubtypeOrder::IsDisjoint);
 
     // With optionals.
+    // { A = TestSubEnum::erm, Opt = 100 } belongs to A0 but not to AOpt, where Opt is expected to be a TestSubEnum.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordAOpt::getThisType()),
-              babelwires::SubtypeOrder::IsEquivalent);
+              babelwires::SubtypeOrder::IsSupertype);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordA0::getThisType()),
-              babelwires::SubtypeOrder::IsEquivalent);
+              babelwires::SubtypeOrder::IsSubtype);
+              
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordABOpt::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
@@ -365,6 +372,7 @@ TEST(RecordTypeTest, subtype) {
               babelwires::SubtypeOrder::IsSubtype);
 
     // Intersecting with optionals
+    // { A = TestSubEnum::erm } belongs to both.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordAOptS::getThisType()),
               babelwires::SubtypeOrder::IsIntersecting);

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -329,8 +329,8 @@ TEST(RecordTypeTest, subtype) {
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordB::getThisType(),
                                                           testDomain::RecordAB::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
-    
-    // { A = TestSubEnum::erm, B = TestSubEnum::erm } belongs to both A0 and B.
+
+    // { A = TestSubEnum::erm, B = TestSubEnum::erm } is a member of both A0 and B.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordB::getThisType()),
               babelwires::SubtypeOrder::IsIntersecting);
@@ -350,14 +350,14 @@ TEST(RecordTypeTest, subtype) {
               babelwires::SubtypeOrder::IsDisjoint);
 
     // With optionals.
-    // { A = TestSubEnum::erm, Opt = 100 } belongs to A0 but not to AOpt, where Opt is expected to be a TestSubEnum.
+    // { A = TestSubEnum::erm, Opt = 100 } is a member of A0 but not of AOpt, where Opt is expected to be a TestSubEnum.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordAOpt::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordA0::getThisType()),
               babelwires::SubtypeOrder::IsSubtype);
-              
+
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
                                                           testDomain::RecordABOpt::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
@@ -371,8 +371,16 @@ TEST(RecordTypeTest, subtype) {
                                                           testDomain::RecordAOpt::getThisType()),
               babelwires::SubtypeOrder::IsSubtype);
 
+    // { a : TestSubEnum::erm, b : TestSubEnum::erm } is a member of both.
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOptS::getThisType(),
+                                                          testDomain::RecordABOpt::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordABOpt::getThisType(),
+                                                          testDomain::RecordAOptS::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+
     // Intersecting with optionals
-    // { A = TestSubEnum::erm } belongs to both.
+    // { A = TestSubEnum::erm } is a member of both.
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordAOptS::getThisType()),
               babelwires::SubtypeOrder::IsIntersecting);

--- a/Tests/BabelWiresLib/recordTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordTypeTest.cpp
@@ -331,6 +331,9 @@ TEST(RecordTypeTest, subtype) {
               babelwires::SubtypeOrder::IsSupertype);
 
     // Incompatible types
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordA0::getThisType(),
+                                                          testDomain::RecordB::getThisType()),
+              babelwires::SubtypeOrder::IsDisjoint);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAS::getThisType(),
                                                           testDomain::RecordA0::getThisType()),
               babelwires::SubtypeOrder::IsDisjoint);
@@ -359,10 +362,10 @@ TEST(RecordTypeTest, subtype) {
     // Incompatible and optional
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOpt::getThisType(),
                                                           testDomain::RecordAOptS::getThisType()),
-              babelwires::SubtypeOrder::IsDisjoint);
+              babelwires::SubtypeOrder::IsIntersecting);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordAOptS::getThisType(),
                                                           testDomain::RecordAOpt::getThisType()),
-              babelwires::SubtypeOrder::IsDisjoint);
+              babelwires::SubtypeOrder::IsIntersecting);
 }
 
 // Test the use of the constructor which takes a parent type.

--- a/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
@@ -341,6 +341,9 @@ TEST(RecordWithVariantsTypeTest, subtype) {
               babelwires::SubtypeOrder::IsSupertype);
 
     // Incompatible types
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVA0::getThisType(),
+                                                          testDomain::RecordVB::getThisType()),
+              babelwires::SubtypeOrder::IsDisjoint);
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVAS::getThisType(),
                                                           testDomain::RecordVA0::getThisType()),
               babelwires::SubtypeOrder::IsDisjoint);

--- a/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
+++ b/Tests/BabelWiresLib/recordWithVariantsTypeTest.cpp
@@ -339,11 +339,13 @@ TEST(RecordWithVariantsTypeTest, subtype) {
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVB::getThisType(),
                                                           testDomain::RecordVAB::getThisType()),
               babelwires::SubtypeOrder::IsSupertype);
-
-    // Incompatible types
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVA0::getThisType(),
                                                           testDomain::RecordVB::getThisType()),
-              babelwires::SubtypeOrder::IsDisjoint);
+              babelwires::SubtypeOrder::IsIntersecting);
+    EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVB::getThisType(),
+                                                          testDomain::RecordVA0::getThisType()),
+              babelwires::SubtypeOrder::IsIntersecting);
+    // Incompatible types
     EXPECT_EQ(testEnvironment.m_typeSystem.compareSubtype(testDomain::RecordVAS::getThisType(),
                                                           testDomain::RecordVA0::getThisType()),
               babelwires::SubtypeOrder::IsDisjoint);


### PR DESCRIPTION
Unit tests revealed that the subtype algorithm for record types wasn't quite correct.

Note: The subtype algorithm for RecordWithVariantsType is still pretty bad, but I'm reluctant to invest too much there: I would love instead to replace that type by something like a SumType of RecordTypes, if it could be made relatively efficient.