### PR TITLE
BlockStream supports reverse iteration. Latest BabelWires-Music with TrackBuilder

### DIFF
--- a/Common/BlockStream/blockStream.cpp
+++ b/Common/BlockStream/blockStream.cpp
@@ -75,8 +75,9 @@ void babelwires::BlockStream::fixBlockAfterEventAdded(DataBlock& block, StreamEv
     if (block.m_firstEvent == nullptr) {
         block.m_firstEvent = &newEvent;
     } else {
-        block.m_lastEvent->m_numBytesToNextEvent =
-            reinterpret_cast<babelwires::Byte*>(&newEvent) - reinterpret_cast<babelwires::Byte*>(block.m_lastEvent);
+        const std::uint16_t diff = reinterpret_cast<babelwires::Byte*>(&newEvent) - reinterpret_cast<babelwires::Byte*>(block.m_lastEvent);
+        block.m_lastEvent->m_numBytesToNextEvent = diff;
+        newEvent.m_numBytesFromPreviousEvent = diff;
     }
     block.m_lastEvent = &newEvent;
     ++m_numEvents;

--- a/Common/BlockStream/blockStream.cpp
+++ b/Common/BlockStream/blockStream.cpp
@@ -125,3 +125,20 @@ babelwires::BlockStream::const_iterator babelwires::BlockStream::end() const {
 babelwires::BlockStream::const_iterator babelwires::BlockStream::begin() const {
     return begin_impl<StreamEvent>();
 }
+
+
+std::reverse_iterator<babelwires::BlockStream::iterator> babelwires::BlockStream::rend() {
+    return std::make_reverse_iterator(begin());
+}
+
+std::reverse_iterator<babelwires::BlockStream::iterator> babelwires::BlockStream::rbegin() {
+    return std::make_reverse_iterator(end());
+}
+
+std::reverse_iterator<babelwires::BlockStream::const_iterator> babelwires::BlockStream::rend() const {
+    return std::make_reverse_iterator(begin());
+}
+
+std::reverse_iterator<babelwires::BlockStream::const_iterator> babelwires::BlockStream::rbegin() const {
+    return std::make_reverse_iterator(end());
+}

--- a/Common/BlockStream/blockStream.hpp
+++ b/Common/BlockStream/blockStream.hpp
@@ -52,6 +52,11 @@ namespace babelwires {
         const_iterator begin() const;
         const_iterator end() const;
 
+        std::reverse_iterator<iterator> rbegin();
+        std::reverse_iterator<iterator> rend();
+        std::reverse_iterator<const_iterator> rbegin() const;
+        std::reverse_iterator<const_iterator> rend() const;
+
         // Iteration when the stream is known to contain events of certain StreamEvent subtypes only.
         template <typename EVENT> Iterator<BlockStream, EVENT> begin_impl();
         template <typename EVENT> Iterator<const BlockStream, const EVENT> begin_impl() const;

--- a/Common/BlockStream/blockStream.hpp
+++ b/Common/BlockStream/blockStream.hpp
@@ -63,6 +63,11 @@ namespace babelwires {
         template <typename EVENT> Iterator<BlockStream, EVENT> end_impl();
         template <typename EVENT> Iterator<const BlockStream, const EVENT> end_impl() const;
 
+        template <typename EVENT> std::reverse_iterator<Iterator<BlockStream, EVENT>> rbegin_impl();
+        template <typename EVENT> std::reverse_iterator<Iterator<const BlockStream, const EVENT>> rbegin_impl() const;
+        template <typename EVENT> std::reverse_iterator<Iterator<BlockStream, EVENT>> rend_impl();
+        template <typename EVENT> std::reverse_iterator<Iterator<const BlockStream, const EVENT>> rend_impl() const;
+
       public:
         // Public for testing.
 

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -5,8 +5,22 @@
  *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
-template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::Iterator {
+template <typename BLOCKSTREAM, typename EVENT>
+struct babelwires::BlockStream::Iterator : std::bidirectional_iterator_tag {
     using value_type = EVENT;
+    using difference_type = std::ptrdiff_t;
+
+    Iterator(BLOCKSTREAM* blockStream)
+        : m_blockStream(blockStream)
+        , m_blockIndex(0) {
+        if (!m_blockStream->m_blocks.empty()) {
+            m_current = static_cast<EVENT*>(blockStream->m_blocks[0]->m_firstEvent);
+        }
+    }
+
+    Iterator(BLOCKSTREAM* blockStream, bool)
+        : m_blockStream(blockStream)
+        , m_blockIndex(m_blockStream->m_blocks.size()) {}
 
     bool operator==(const Iterator& other) const {
         assert((m_blockStream == other.m_blockStream) &&
@@ -21,11 +35,8 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
     EVENT* operator->() const { return m_current; }
 
     Iterator& operator++() {
-        if (!m_current) {
-            assert((m_blockIndex == -1) && "Operator++ called in unexpected state");
-            m_blockIndex = 0;
-            m_current = static_cast<EVENT*>(m_blockStream->m_blocks[0]->m_firstEvent);
-        } else if (m_current->m_numBytesToNextEvent > 0) {
+        assert((m_current != nullptr) && "operator++ called in unexpected state");
+        if (m_current->m_numBytesToNextEvent > 0) {
             auto* nextEvent = m_current->getNextEventInBlock();
             assert((nextEvent->template as<EVENT>() != nullptr) && "The stream contained an event of unexpected type");
             m_current = static_cast<EVENT*>(nextEvent);
@@ -45,6 +56,12 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
         return *this;
     }
 
+    Iterator operator++(int) {
+        Iterator tmp;
+        ++(*this);
+        return tmp;
+    }
+
     Iterator& operator--() {
         if (m_current == nullptr) {
             assert((m_blockIndex == m_blockStream->m_blocks.size()) && "operator-- called in unexpected state");
@@ -58,53 +75,47 @@ template <typename BLOCKSTREAM, typename EVENT> struct babelwires::BlockStream::
         } else {
             assert((m_current == m_blockStream->m_blocks[m_blockIndex]->m_firstEvent) &&
                    "The event is not the first in its block");
+            assert((m_blockIndex > 0) && "operator-- called in unexpected state");
             --m_blockIndex;
-            if (m_blockIndex == -1) {
-                m_current = nullptr;
-            } else {
-                auto* previousEvent = m_blockStream->m_blocks[m_blockIndex]->m_lastEvent;
-                assert((previousEvent->template as<EVENT>() != nullptr) &&
-                       "The stream contained an event of unexpected type");
-                m_current = static_cast<EVENT*>(previousEvent);
-            }
+            auto* previousEvent = m_blockStream->m_blocks[m_blockIndex]->m_lastEvent;
+            assert((previousEvent->template as<EVENT>() != nullptr) &&
+                    "The stream contained an event of unexpected type");
+            m_current = static_cast<EVENT*>(previousEvent);
         }
         return *this;
     }
 
+    Iterator operator--(int) {
+        Iterator tmp;
+        --(*this);
+        return tmp;
+    }
+
     BLOCKSTREAM* m_blockStream;
-    /// This will be m_blockStream->m_blocks.size() in the end iterator, and -1 in the rend iterator.
-    int m_blockIndex = 0;
+    /// This will be m_blockStream->m_blocks.size() in the end iterator.
+    std::size_t m_blockIndex = 0;
     /// This will be nullptr in the end and rend iterator
     EVENT* m_current = nullptr;
 };
 
 template <typename EVENT>
 babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT> babelwires::BlockStream::begin_impl() {
-    if (!m_blocks.empty()) {
-        return Iterator<babelwires::BlockStream, EVENT>{this, 0, static_cast<EVENT*>(m_blocks[0]->m_firstEvent)};
-    } else {
-        return end_impl<EVENT>();
-    }
+    return Iterator<babelwires::BlockStream, EVENT>(this);
 }
 
 template <typename EVENT>
 babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>
 babelwires::BlockStream::begin_impl() const {
-    if (!m_blocks.empty()) {
-        return Iterator<const babelwires::BlockStream, const EVENT>{this, 0,
-                                                                    static_cast<EVENT*>(m_blocks[0]->m_firstEvent)};
-    } else {
-        return end_impl<EVENT>();
-    }
+    return Iterator<const babelwires::BlockStream, const EVENT>(this);
 }
 
 template <typename EVENT>
 babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT> babelwires::BlockStream::end_impl() {
-    return Iterator<BlockStream, EVENT>{this, static_cast<typeof(babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>::m_blockIndex)>(m_blocks.size()), nullptr};
+    return Iterator<BlockStream, EVENT>(this, false);
 }
 
 template <typename EVENT>
 babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>
 babelwires::BlockStream::end_impl() const {
-    return Iterator<const BlockStream, const EVENT>{this, static_cast<typeof(babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>::m_blockIndex)>(m_blocks.size()), nullptr};
+    return Iterator<const BlockStream, const EVENT>(this, false);
 }

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -57,7 +57,7 @@ struct babelwires::BlockStream::Iterator : std::bidirectional_iterator_tag {
     }
 
     Iterator operator++(int) {
-        Iterator tmp;
+        Iterator tmp = *this;
         ++(*this);
         return tmp;
     }
@@ -86,7 +86,7 @@ struct babelwires::BlockStream::Iterator : std::bidirectional_iterator_tag {
     }
 
     Iterator operator--(int) {
-        Iterator tmp;
+        Iterator tmp = *this;
         --(*this);
         return tmp;
     }

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -79,7 +79,7 @@ struct babelwires::BlockStream::Iterator : std::bidirectional_iterator_tag {
             --m_blockIndex;
             auto* previousEvent = m_blockStream->m_blocks[m_blockIndex]->m_lastEvent;
             assert((previousEvent->template as<EVENT>() != nullptr) &&
-                    "The stream contained an event of unexpected type");
+                   "The stream contained an event of unexpected type");
             m_current = static_cast<EVENT*>(previousEvent);
         }
         return *this;
@@ -118,4 +118,28 @@ template <typename EVENT>
 babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>
 babelwires::BlockStream::end_impl() const {
     return Iterator<const BlockStream, const EVENT>(this, false);
+}
+
+template <typename EVENT>
+std::reverse_iterator<babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>>
+babelwires::BlockStream::rbegin_impl() {
+    return std::make_reverse_iterator(begin_impl<EVENT>());
+}
+
+template <typename EVENT>
+std::reverse_iterator<babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>>
+babelwires::BlockStream::rbegin_impl() const {
+    return std::make_reverse_iterator(begin_impl<EVENT>());
+}
+
+template <typename EVENT>
+std::reverse_iterator<babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>>
+babelwires::BlockStream::rend_impl() {
+    return std::make_reverse_iterator(end_impl<EVENT>());
+}
+
+template <typename EVENT>
+std::reverse_iterator<babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>>
+babelwires::BlockStream::rend_impl() const {
+    return std::make_reverse_iterator(end_impl<EVENT>());
 }

--- a/Common/BlockStream/blockStream_inl.hpp
+++ b/Common/BlockStream/blockStream_inl.hpp
@@ -123,23 +123,23 @@ babelwires::BlockStream::end_impl() const {
 template <typename EVENT>
 std::reverse_iterator<babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>>
 babelwires::BlockStream::rbegin_impl() {
-    return std::make_reverse_iterator(begin_impl<EVENT>());
+    return std::make_reverse_iterator(end_impl<EVENT>());
 }
 
 template <typename EVENT>
 std::reverse_iterator<babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>>
 babelwires::BlockStream::rbegin_impl() const {
-    return std::make_reverse_iterator(begin_impl<EVENT>());
+    return std::make_reverse_iterator(end_impl<EVENT>());
 }
 
 template <typename EVENT>
 std::reverse_iterator<babelwires::BlockStream::Iterator<babelwires::BlockStream, EVENT>>
 babelwires::BlockStream::rend_impl() {
-    return std::make_reverse_iterator(end_impl<EVENT>());
+    return std::make_reverse_iterator(begin_impl<EVENT>());
 }
 
 template <typename EVENT>
 std::reverse_iterator<babelwires::BlockStream::Iterator<const babelwires::BlockStream, const EVENT>>
 babelwires::BlockStream::rend_impl() const {
-    return std::make_reverse_iterator(end_impl<EVENT>());
+    return std::make_reverse_iterator(begin_impl<EVENT>());
 }

--- a/Common/BlockStream/streamEvent.hpp
+++ b/Common/BlockStream/streamEvent.hpp
@@ -72,18 +72,32 @@ namespace babelwires {
         friend BlockStream;
 
         StreamEvent* getNextEventInBlock() {
-            assert(m_numBytesToNextEvent && "There is no next event");
+            assert(m_numBytesToNextEvent && "There is no next event in this block");
             return reinterpret_cast<StreamEvent*>(reinterpret_cast<babelwires::Byte*>(this) + m_numBytesToNextEvent);
         }
 
         const StreamEvent* getNextEventInBlock() const {
-            assert(m_numBytesToNextEvent && "There is no next event");
+            assert(m_numBytesToNextEvent && "There is no next event in this block");
             return reinterpret_cast<const StreamEvent*>(reinterpret_cast<const babelwires::Byte*>(this) +
                                                         m_numBytesToNextEvent);
+        }
+
+        StreamEvent* getPreviousEventInBlock() {
+            assert(m_numBytesFromPreviousEvent && "There is no previous event in this block");
+            return reinterpret_cast<StreamEvent*>(reinterpret_cast<babelwires::Byte*>(this) - m_numBytesFromPreviousEvent);
+        }
+
+        const StreamEvent* getPreviousEventInBlock() const {
+            assert(m_numBytesFromPreviousEvent && "There is no previous event in this block");
+            return reinterpret_cast<const StreamEvent*>(reinterpret_cast<const babelwires::Byte*>(this) -
+                                                        m_numBytesFromPreviousEvent);
         }
 
       private:
         /// The number of bytes from the address of this event to the address of the next event.
         std::uint16_t m_numBytesToNextEvent = 0;
+
+        /// The number of bytes from the address of the preview event to the address of this event.
+        std::uint16_t m_numBytesFromPreviousEvent = 0;
     };
 } // namespace babelwires

--- a/Common/BlockStream/streamEventHolder.hpp
+++ b/Common/BlockStream/streamEventHolder.hpp
@@ -84,6 +84,8 @@ namespace babelwires {
 
         bool hasEvent() const { return m_event; }
 
+        operator bool() const { return hasEvent(); }
+
         /// This just makes the carried event available for moving.
         EVENT&& release() { return std::move(*m_event); }
 

--- a/Common/BlockStream/streamEventHolder.hpp
+++ b/Common/BlockStream/streamEventHolder.hpp
@@ -17,13 +17,13 @@ namespace babelwires {
         StreamEventHolder() = default;
 
         /// Construct a StreamEventHolder by copying or moving the given event into the buffer.
-        template <typename EVENT2, typename = std::enable_if_t<std::is_convertible_v<EVENT2, EVENT>>>
+        template <typename EVENT2, typename = std::enable_if_t<std::is_convertible_v<EVENT2, const EVENT&>>>
         StreamEventHolder(EVENT2&& srcEvent) {
             m_event = &std::forward<EVENT2>(srcEvent).cloneInto(m_buffer);
         };
 
         /// Replace the carried event by the given one, either copying or moving it.
-        template <typename EVENT2, typename = std::enable_if_t<std::is_convertible_v<EVENT2, EVENT>>>
+        template <typename EVENT2, typename = std::enable_if_t<std::is_convertible_v<EVENT2, const EVENT&>>>
         StreamEventHolder& operator=(EVENT2&& srcEvent) {
             reset();
             m_event = &std::forward<EVENT2>(srcEvent).cloneInto(m_buffer);

--- a/Common/BlockStream/streamEventHolder.hpp
+++ b/Common/BlockStream/streamEventHolder.hpp
@@ -87,7 +87,11 @@ namespace babelwires {
         operator bool() const { return hasEvent(); }
 
         /// This just makes the carried event available for moving.
-        EVENT&& release() { return std::move(*m_event); }
+        EVENT&& release() { 
+            EVENT* event = m_event;
+            m_event = nullptr;
+            return std::move(*event);
+        }
 
         /// Destroy the contained event if there is one.
         void reset() {

--- a/Tests/Common/blockStreamTest.cpp
+++ b/Tests/Common/blockStreamTest.cpp
@@ -56,6 +56,13 @@ TEST(BlockStream, BlocksAndAlignment) {
         ++count;
     }
     EXPECT_EQ(count, loopCount * 2);
+
+    // Reverse iteration.
+    count = 0;
+    for (auto it = --stream.end(); it != --stream.begin(); --it ) {
+        ++count;
+    }
+    EXPECT_EQ(count, loopCount * 2);
 }
 
 namespace {

--- a/Tests/Common/blockStreamTest.cpp
+++ b/Tests/Common/blockStreamTest.cpp
@@ -59,7 +59,7 @@ TEST(BlockStream, BlocksAndAlignment) {
 
     // Reverse iteration.
     count = 0;
-    for (auto it = --stream.end(); it != --stream.begin(); --it ) {
+    for (auto it = stream.rbegin(); it != stream.rend(); ++it ) {
         ++count;
     }
     EXPECT_EQ(count, loopCount * 2);


### PR DESCRIPTION
The BlockStream now supports reverse iteration. This supports the TrackBuilder in BabelWires-Music.

