### PR TITLE
Rename PRIMITIVE_TYPE to REGISTERED_TYPE

### DIFF
--- a/BabelWiresExe/main.cpp
+++ b/BabelWiresExe/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
         smf::registerLib(context);
 
         // Comment / Uncomment to enable a domain of testing data.
-        testDomain::registerLib(context);
+        //testDomain::registerLib(context);
 
         if (options.m_mode == ProgramOptions::MODE_RUN_PROJECT) {
             Project project(context, log);

--- a/BabelWiresExe/main.cpp
+++ b/BabelWiresExe/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
         smf::registerLib(context);
 
         // Comment / Uncomment to enable a domain of testing data.
-        //testDomain::registerLib(context);
+        testDomain::registerLib(context);
 
         if (options.m_mode == ProgramOptions::MODE_RUN_PROJECT) {
             Project project(context, log);

--- a/BabelWiresLib/TypeSystem/registeredType.hpp
+++ b/BabelWiresLib/TypeSystem/registeredType.hpp
@@ -1,5 +1,5 @@
 /**
- * A type describes a valid set of values.
+ * A registered type can be directly referenced using an RegisteredTypeId.
  *
  * (C) 2021 Malcolm Tyrrell
  *
@@ -11,9 +11,9 @@
 
 #include <Common/Identifiers/registeredIdentifier.hpp>
 
-/// Intended mainly for testing.
-#define PRIMITIVE_TYPE_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                         \
-    static babelwires::PrimitiveTypeId getThisIdentifier() {                                                           \
+/// This macro is exists primarily for testing. The REGISTERED_TYPE macro should almost always be used instead.
+#define REGISTERED_TYPE_WITH_REGISTERED_ID(IDENTIFIER, VERSION)                                                        \
+    static babelwires::RegisteredTypeId getThisIdentifier() {                                                          \
         return IDENTIFIER;                                                                                             \
     }                                                                                                                  \
     static babelwires::TypeRef getThisType() {                                                                         \
@@ -26,9 +26,8 @@
         return getThisIdentifier();                                                                                    \
     }
 
-/// Primitive types (i.e. types which are not constructed from other types) need to be directly
-/// registered in the TypeSystem.
+/// A registered type can be directly referenced using a RegisteredTypeId.
 /// The TypeSystem expects them to support certain functions and methods, which
 /// this macro provides.
-#define PRIMITIVE_TYPE(IDENTIFIER, NAME, UUID, VERSION)                                                                \
-    PRIMITIVE_TYPE_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)
+#define REGISTERED_TYPE(IDENTIFIER, NAME, UUID, VERSION)                                                               \
+    REGISTERED_TYPE_WITH_REGISTERED_ID(BW_MEDIUM_ID(IDENTIFIER, NAME, UUID), VERSION)

--- a/BabelWiresLib/TypeSystem/type.hpp
+++ b/BabelWiresLib/TypeSystem/type.hpp
@@ -34,7 +34,7 @@ namespace babelwires {
         virtual bool isValidValue(const TypeSystem& typeSystem, const Value& v) const = 0;
 
         /// Get a TypeRef that describes this type.
-        /// Primitive types get an implementation of this method from the PRIMITIVE_TYPE macro.
+        /// Primitive types get an implementation of this method from the REGISTERED_TYPE macro.
         /// Complex types constructed by TypeConstructors must provide their own implementation.
         virtual TypeRef getTypeRef() const = 0;
 

--- a/BabelWiresLib/TypeSystem/typeRef.cpp
+++ b/BabelWiresLib/TypeSystem/typeRef.cpp
@@ -34,7 +34,7 @@ babelwires::TypeRef::TypeRef(TypeConstructorId typeConstructorId, TypeConstructo
 const babelwires::Type* babelwires::TypeRef::tryResolve(const TypeSystem& typeSystem) const {
     struct VisitorMethods {
         const babelwires::Type* operator()(std::monostate) { return nullptr; }
-        const babelwires::Type* operator()(RegisteredTypeId typeId) { return m_typeSystem.tryGetPrimitiveType(typeId); }
+        const babelwires::Type* operator()(RegisteredTypeId typeId) { return m_typeSystem.tryGetRegisteredType(typeId); }
         const babelwires::Type* operator()(const ConstructedTypeData& higherOrderData) {
             try {
                 const TypeConstructorId typeConstructorId = std::get<0>(higherOrderData);
@@ -57,7 +57,7 @@ const babelwires::Type& babelwires::TypeRef::resolve(const TypeSystem& typeSyste
         const babelwires::Type& operator()(std::monostate) {
             throw TypeSystemException() << "A null type cannot be resolved.";
         }
-        const babelwires::Type& operator()(RegisteredTypeId typeId) { return m_typeSystem.getPrimitiveType(typeId); }
+        const babelwires::Type& operator()(RegisteredTypeId typeId) { return m_typeSystem.getRegisteredType(typeId); }
         const babelwires::Type& operator()(const ConstructedTypeData& higherOrderData) {
             const TypeConstructorId typeConstructorId = std::get<0>(higherOrderData);
             const TypeConstructor& typeConstructor = m_typeSystem.getTypeConstructor(typeConstructorId);
@@ -119,7 +119,7 @@ std::string babelwires::TypeRef::toString() const {
 void babelwires::TypeRef::serializeContents(Serializer& serializer) const {
     struct VisitorMethods {
         void operator()(std::monostate) {}
-        void operator()(const RegisteredTypeId& typeId) { m_serializer.serializeValue("primitiveTypeId", typeId); }
+        void operator()(const RegisteredTypeId& typeId) { m_serializer.serializeValue("typeId", typeId); }
         void operator()(const ConstructedTypeData& constructedTypeData) {
             m_serializer.serializeValue("typeConstructorId", std::get<0>(constructedTypeData));
             m_serializer.serializeArray("typeArguments", std::get<1>(constructedTypeData).m_typeArguments);
@@ -137,10 +137,10 @@ void babelwires::TypeRef::serializeContents(Serializer& serializer) const {
 }
 
 void babelwires::TypeRef::deserializeContents(Deserializer& deserializer) {
-    RegisteredTypeId primitiveTypeId;
-    if (deserializer.deserializeValue("primitiveTypeId", primitiveTypeId,
+    RegisteredTypeId typeId;
+    if (deserializer.deserializeValue("typeId", typeId,
                                       babelwires::Deserializer::IsOptional::Optional)) {
-        m_storage = primitiveTypeId;
+        m_storage = typeId;
     } else {
         TypeConstructorId typeConstructorId;
         if (deserializer.deserializeValue("typeConstructorId", typeConstructorId,

--- a/BabelWiresLib/TypeSystem/typeRef.hpp
+++ b/BabelWiresLib/TypeSystem/typeRef.hpp
@@ -31,7 +31,7 @@ namespace babelwires {
         TypeRef();
 
         /// A TypeRef describing a primitive type.
-        TypeRef(PrimitiveTypeId typeId);
+        TypeRef(RegisteredTypeId typeId);
 
         /// A TypeRef describing a complex type, constructed by applying the TypeConstructor
         /// to the arguments.
@@ -83,7 +83,7 @@ namespace babelwires {
       private:
         // TODO More compact storage.
         using ConstructedTypeData = std::tuple<TypeConstructorId, TypeConstructorArguments>;
-        using Storage = std::variant<std::monostate, PrimitiveTypeId, ConstructedTypeData>;
+        using Storage = std::variant<std::monostate, RegisteredTypeId, ConstructedTypeData>;
 
       private:
         Storage m_storage;

--- a/BabelWiresLib/TypeSystem/typeSystem.cpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 namespace {
-    void insertTypeId(babelwires::TypeSystem::TypeIdSet& typeIds, const babelwires::PrimitiveTypeId& typeId) {
+    void insertTypeId(babelwires::TypeSystem::TypeIdSet& typeIds, const babelwires::RegisteredTypeId& typeId) {
         auto it = std::upper_bound(typeIds.begin(), typeIds.end(), typeId);
         typeIds.insert(it, typeId);
     }
@@ -20,7 +20,7 @@ namespace {
 babelwires::TypeSystem::TypeSystem() = default;
 babelwires::TypeSystem::~TypeSystem() = default;
 
-const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(PrimitiveTypeId id) const {
+const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(RegisteredTypeId id) const {
     auto it = m_primitiveTypeRegistry.find(id);
     if (it != m_primitiveTypeRegistry.end()) {
         return std::get<0>(it->second).get();
@@ -28,7 +28,7 @@ const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(PrimitiveTyp
     return nullptr;
 }
 
-const babelwires::Type& babelwires::TypeSystem::getPrimitiveType(PrimitiveTypeId id) const {
+const babelwires::Type& babelwires::TypeSystem::getPrimitiveType(RegisteredTypeId id) const {
     auto it = m_primitiveTypeRegistry.find(id);
     assert((it != m_primitiveTypeRegistry.end()) && "Primitive Type not registered in type system");
     return *std::get<0>(it->second);

--- a/BabelWiresLib/TypeSystem/typeSystem.cpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.cpp
@@ -20,28 +20,28 @@ namespace {
 babelwires::TypeSystem::TypeSystem() = default;
 babelwires::TypeSystem::~TypeSystem() = default;
 
-const babelwires::Type* babelwires::TypeSystem::tryGetPrimitiveType(RegisteredTypeId id) const {
-    auto it = m_primitiveTypeRegistry.find(id);
-    if (it != m_primitiveTypeRegistry.end()) {
+const babelwires::Type* babelwires::TypeSystem::tryGetRegisteredType(RegisteredTypeId id) const {
+    auto it = m_registeredTypeRegistry.find(id);
+    if (it != m_registeredTypeRegistry.end()) {
         return std::get<0>(it->second).get();
     }
     return nullptr;
 }
 
-const babelwires::Type& babelwires::TypeSystem::getPrimitiveType(RegisteredTypeId id) const {
-    auto it = m_primitiveTypeRegistry.find(id);
-    assert((it != m_primitiveTypeRegistry.end()) && "Primitive Type not registered in type system");
+const babelwires::Type& babelwires::TypeSystem::getRegisteredType(RegisteredTypeId id) const {
+    auto it = m_registeredTypeRegistry.find(id);
+    assert((it != m_registeredTypeRegistry.end()) && "Primitive Type not registered in type system");
     return *std::get<0>(it->second);
 }
 
-babelwires::Type* babelwires::TypeSystem::addPrimitiveType(LongId typeId, VersionNumber version,
+babelwires::Type* babelwires::TypeSystem::addRegisteredType(LongId typeId, VersionNumber version,
                                                            std::unique_ptr<Type> newType) {
-    auto addResult = m_primitiveTypeRegistry.emplace(
-        std::pair<LongId, PrimitiveTypeInfo>{typeId, PrimitiveTypeInfo{std::move(newType), version}});
+    auto addResult = m_registeredTypeRegistry.emplace(
+        std::pair<LongId, RegisteredTypeInfo>{typeId, RegisteredTypeInfo{std::move(newType), version}});
     assert(addResult.second && "Type with that identifier already registered");
     babelwires::Type* const newTypeRaw = std::get<0>(addResult.first->second).get();
     for (auto it : newTypeRaw->getTags()) {
-        m_taggedPrimitiveTypes[it].emplace_back(typeId);
+        m_taggedRegisteredTypes[it].emplace_back(typeId);
     }
     return newTypeRaw;
 }
@@ -96,17 +96,17 @@ bool babelwires::TypeSystem::isRelatedType(const TypeRef& typeRefA, const TypeRe
     return compareSubtype(typeRefA, typeRefB) != SubtypeOrder::IsDisjoint;
 }
 
-babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getTaggedPrimitiveTypes(Type::Tag tag) const {
-    const auto it = m_taggedPrimitiveTypes.find(tag);
-    if (it != m_taggedPrimitiveTypes.end()) {
+babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getTaggedRegisteredTypes(Type::Tag tag) const {
+    const auto it = m_taggedRegisteredTypes.find(tag);
+    if (it != m_taggedRegisteredTypes.end()) {
         return it->second;
     }
     return {};
 }
 
-babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllPrimitiveTypes() const {
+babelwires::TypeSystem::TypeIdSet babelwires::TypeSystem::getAllRegisteredTypes() const {
     babelwires::TypeSystem::TypeIdSet result;
-    for (const auto& it : m_primitiveTypeRegistry) {
+    for (const auto& it : m_registeredTypeRegistry) {
         result.emplace_back(it.first);
     }
     return result;

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -34,8 +34,8 @@ namespace babelwires {
             return getPrimitiveType(TYPE::getThisIdentifier()).template is<TYPE>();
         }
 
-        const Type* tryGetPrimitiveType(PrimitiveTypeId id) const;
-        const Type& getPrimitiveType(PrimitiveTypeId id) const;
+        const Type* tryGetPrimitiveType(RegisteredTypeId id) const;
+        const Type& getPrimitiveType(RegisteredTypeId id) const;
 
         template <typename TYPE_CONSTRUCTOR, typename... ARGS,
                   std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
@@ -52,7 +52,7 @@ namespace babelwires {
         const TypeConstructor* tryGetTypeConstructor(TypeConstructorId id) const;
         const TypeConstructor& getTypeConstructor(TypeConstructorId id) const;
 
-        using TypeIdSet = std::vector<PrimitiveTypeId>;
+        using TypeIdSet = std::vector<RegisteredTypeId>;
 
         /// Determine how typeA and typeB are related by the subtype order.
         SubtypeOrder compareSubtype(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
@@ -74,13 +74,13 @@ namespace babelwires {
 
       protected:
         using PrimitiveTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
-        std::unordered_map<PrimitiveTypeId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
+        std::unordered_map<RegisteredTypeId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
 
         using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor>, VersionNumber>;
         std::unordered_map<TypeConstructorId, TypeConstructorInfo> m_typeConstructorRegistry;
 
         /// Fast look-up of tagged types.
-        std::unordered_map<Type::Tag, std::vector<PrimitiveTypeId>> m_taggedPrimitiveTypes;
+        std::unordered_map<Type::Tag, std::vector<RegisteredTypeId>> m_taggedPrimitiveTypes;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/TypeSystem/typeSystem.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystem.hpp
@@ -25,17 +25,17 @@ namespace babelwires {
         template <typename TYPE, typename... ARGS,
                   std::enable_if_t<std::is_base_of_v<Type, TYPE>, std::nullptr_t> = nullptr>
         TYPE* addEntry(ARGS&&... args) {
-            Type* newType = addPrimitiveType(TYPE::getThisIdentifier(), TYPE::getVersion(), std::make_unique<TYPE>(std::forward<ARGS>(args)...));
+            Type* newType = addRegisteredType(TYPE::getThisIdentifier(), TYPE::getVersion(), std::make_unique<TYPE>(std::forward<ARGS>(args)...));
             return &newType->is<TYPE>();
         }
 
         template <typename TYPE, std::enable_if_t<std::is_base_of_v<Type, TYPE>, std::nullptr_t> = nullptr>
         const TYPE& getEntryByType() const {
-            return getPrimitiveType(TYPE::getThisIdentifier()).template is<TYPE>();
+            return getRegisteredType(TYPE::getThisIdentifier()).template is<TYPE>();
         }
 
-        const Type* tryGetPrimitiveType(RegisteredTypeId id) const;
-        const Type& getPrimitiveType(RegisteredTypeId id) const;
+        const Type* tryGetRegisteredType(RegisteredTypeId id) const;
+        const Type& getRegisteredType(RegisteredTypeId id) const;
 
         template <typename TYPE_CONSTRUCTOR, typename... ARGS,
                   std::enable_if_t<std::is_base_of_v<TypeConstructor, TYPE_CONSTRUCTOR>, std::nullptr_t> = nullptr>
@@ -63,24 +63,24 @@ namespace babelwires {
         /// Do the two types have some values in common?
         bool isRelatedType(const TypeRef& typeRefA, const TypeRef& typeRefB) const;
 
-        TypeIdSet getAllPrimitiveTypes() const;
+        TypeIdSet getAllRegisteredTypes() const;
 
-        /// Get all the primitive types tagged with the given tag.
-        TypeIdSet getTaggedPrimitiveTypes(Type::Tag tag) const;
+        /// Get all the registered types tagged with the given tag.
+        TypeIdSet getTaggedRegisteredTypes(Type::Tag tag) const;
 
       protected:
-        Type* addPrimitiveType(LongId typeId, VersionNumber version, std::unique_ptr<Type> newType);
+        Type* addRegisteredType(LongId typeId, VersionNumber version, std::unique_ptr<Type> newType);
         TypeConstructor* addTypeConstructorInternal(TypeConstructorId typeConstructorId, VersionNumber version, std::unique_ptr<TypeConstructor> newTypeConstructor);
 
       protected:
-        using PrimitiveTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
-        std::unordered_map<RegisteredTypeId, PrimitiveTypeInfo> m_primitiveTypeRegistry;
+        using RegisteredTypeInfo = std::tuple<std::unique_ptr<Type>, VersionNumber>;
+        std::unordered_map<RegisteredTypeId, RegisteredTypeInfo> m_registeredTypeRegistry;
 
         using TypeConstructorInfo = std::tuple<std::unique_ptr<TypeConstructor>, VersionNumber>;
         std::unordered_map<TypeConstructorId, TypeConstructorInfo> m_typeConstructorRegistry;
 
         /// Fast look-up of tagged types.
-        std::unordered_map<Type::Tag, std::vector<RegisteredTypeId>> m_taggedPrimitiveTypes;
+        std::unordered_map<Type::Tag, std::vector<RegisteredTypeId>> m_taggedRegisteredTypes;
     };
 
 } // namespace babelwires

--- a/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
+++ b/BabelWiresLib/TypeSystem/typeSystemCommon.hpp
@@ -10,7 +10,7 @@
 #include <Common/Identifiers/identifier.hpp>
 
 namespace babelwires {
-    using PrimitiveTypeId = MediumId;
+    using RegisteredTypeId = MediumId;
     using TypeConstructorId = MediumId;
 
     /// The maximum supported number of type arguments for a type constructor.

--- a/BabelWiresLib/Types/Failure/failureType.hpp
+++ b/BabelWiresLib/Types/Failure/failureType.hpp
@@ -9,7 +9,7 @@
 
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace babelwires {
 
@@ -17,7 +17,7 @@ namespace babelwires {
     /// For now, just implement as an empty record.
     class FailureType : public RecordType {
       public:
-        PRIMITIVE_TYPE("failed", "Failed", "d58040ff-00dc-4f25-a9a7-17c54b56d57d", 1);
+        REGISTERED_TYPE("failed", "Failed", "d58040ff-00dc-4f25-a9a7-17c54b56d57d", 1);
 
         FailureType() : RecordType({}) {}
 

--- a/BabelWiresLib/Types/File/fileType.hpp
+++ b/BabelWiresLib/Types/File/fileType.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/Types/Record/recordType.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace babelwires {
 

--- a/BabelWiresLib/Types/Int/intType.hpp
+++ b/BabelWiresLib/Types/Int/intType.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/TypeSystem/type.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intValue.hpp>
 
 namespace babelwires {
@@ -40,7 +40,7 @@ namespace babelwires {
       public:
         DefaultIntType();
 
-        PRIMITIVE_TYPE("int", "Integer", "90ed4c0c-2fa1-4373-9b67-e711358af824", 1);
+        REGISTERED_TYPE("int", "Integer", "90ed4c0c-2fa1-4373-9b67-e711358af824", 1);
     };
 
     /// An Int type which covers the range between 0 and the maximum NativeInt value.
@@ -48,6 +48,6 @@ namespace babelwires {
       public:
         NonNegativeIntType();
 
-        PRIMITIVE_TYPE("NonNegInt", "Non-Negative Integer", "33d35b26-d8ab-4af9-bc63-958ffb37b261", 1);
+        REGISTERED_TYPE("NonNegInt", "Non-Negative Integer", "33d35b26-d8ab-4af9-bc63-958ffb37b261", 1);
     };
 }

--- a/BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp
+++ b/BabelWiresLib/Types/Map/MapEntries/mapEntryData.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/Project/projectVisitable.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
 
 #include <Common/Cloning/cloneable.hpp>
@@ -30,7 +30,7 @@ namespace babelwires {
     /// The enum that determines the algorithm used.
     class MapEntryFallbackKind : public babelwires::EnumType {
       public:
-        PRIMITIVE_TYPE("FallbackKind", "MapEntryFallbackKind", "11e020d5-526e-412d-aa9f-ac464ea34d26", 1);
+        REGISTERED_TYPE("FallbackKind", "MapEntryFallbackKind", "11e020d5-526e-412d-aa9f-ac464ea34d26", 1);
         MapEntryFallbackKind();
 
         ENUM_DEFINE_CPP_ENUM(BW_MAP_ENTRY_FALLBACK_KIND);

--- a/BabelWiresLib/Types/Rational/rationalType.hpp
+++ b/BabelWiresLib/Types/Rational/rationalType.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <BabelWiresLib/TypeSystem/type.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 #include <Common/Math/rational.hpp>
 
@@ -41,6 +41,6 @@ namespace babelwires {
       public:
         DefaultRationalType();
 
-        PRIMITIVE_TYPE("rational", "Rational", "995624d6-6f1d-4407-babd-66ec74989c07", 1);
+        REGISTERED_TYPE("rational", "Rational", "995624d6-6f1d-4407-babd-66ec74989c07", 1);
     };
 }

--- a/BabelWiresLib/Types/String/stringType.hpp
+++ b/BabelWiresLib/Types/String/stringType.hpp
@@ -8,14 +8,14 @@
 #pragma once
 
 #include <BabelWiresLib/TypeSystem/type.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace babelwires {
 
     // TODO Strings should have a length limit.
     class StringType : public Type {
       public:
-        PRIMITIVE_TYPE("string", "String", "0e422e25-cb94-40a3-8790-4918c918e637", 1);
+        REGISTERED_TYPE("string", "String", "0e422e25-cb94-40a3-8790-4918c918e637", 1);
 
         NewValueHolder createValue(const TypeSystem& typeSystem) const override;
 

--- a/BabelWiresQtUi/NodeEditorBridge/NodeFactories/valueNodeFactory.cpp
+++ b/BabelWiresQtUi/NodeEditorBridge/NodeFactories/valueNodeFactory.cpp
@@ -27,7 +27,7 @@ QString babelwires::ValueNodeFactory::getCategoryName() const {
 QList<QString> babelwires::ValueNodeFactory::getFactoryNames() const {
     QList<QString> factoryNames;
     auto identifierRegistry = IdentifierRegistry::read();
-    for (const auto& typeId : m_typeSystem.getAllPrimitiveTypes()) {
+    for (const auto& typeId : m_typeSystem.getAllRegisteredTypes()) {
         factoryNames.append(identifierRegistry->getName(typeId).c_str());
     }
     return factoryNames;
@@ -38,7 +38,7 @@ void babelwires::ValueNodeFactory::createNode(ProjectGraphModel& projectGraphMod
     std::optional<RegisteredTypeId> typeId;
     {
         auto identifierRegistry = IdentifierRegistry::read();
-        for (const auto& tid : m_typeSystem.getAllPrimitiveTypes()) {
+        for (const auto& tid : m_typeSystem.getAllRegisteredTypes()) {
             if(factoryName == identifierRegistry->getName(tid).c_str()) {
                 typeId = tid;
                 break;

--- a/BabelWiresQtUi/NodeEditorBridge/NodeFactories/valueNodeFactory.cpp
+++ b/BabelWiresQtUi/NodeEditorBridge/NodeFactories/valueNodeFactory.cpp
@@ -35,7 +35,7 @@ QList<QString> babelwires::ValueNodeFactory::getFactoryNames() const {
 
 void babelwires::ValueNodeFactory::createNode(ProjectGraphModel& projectGraphModel, QString factoryName,
                                               QPointF scenePos) {
-    std::optional<PrimitiveTypeId> typeId;
+    std::optional<RegisteredTypeId> typeId;
     {
         auto identifierRegistry = IdentifierRegistry::read();
         for (const auto& tid : m_typeSystem.getAllPrimitiveTypes()) {

--- a/Domains/TestDomain/testArrayType.hpp
+++ b/Domains/TestDomain/testArrayType.hpp
@@ -1,5 +1,5 @@
 #include <BabelWiresLib/Project/Nodes/ValueNode/valueNodeData.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Array/arrayType.hpp>
 
 namespace testDomain {
@@ -14,7 +14,7 @@ namespace testDomain {
 
         static babelwires::TypeRef getEntryTypeStatic();
 
-        PRIMITIVE_TYPE("sarray", "Test Simple Array", "2bca3f50-8d9d-46ba-bf43-e0a583f5bcf7", 1);
+        REGISTERED_TYPE("sarray", "Test Simple Array", "2bca3f50-8d9d-46ba-bf43-e0a583f5bcf7", 1);
     };
 
     class TestCompoundArrayType : public babelwires::ArrayType {
@@ -27,7 +27,7 @@ namespace testDomain {
 
         static babelwires::TypeRef getEntryTypeStatic();
 
-        PRIMITIVE_TYPE("carray", "Test Compound Array", "e2125eb9-b8a5-470a-a287-7142ff5a6b9c", 1);
+        REGISTERED_TYPE("carray", "Test Compound Array", "e2125eb9-b8a5-470a-a287-7142ff5a6b9c", 1);
     };
 
     /// ValueNodeData which creates an element carrying a simple array.

--- a/Domains/TestDomain/testEnum.hpp
+++ b/Domains/TestDomain/testEnum.hpp
@@ -1,5 +1,5 @@
 #include <BabelWiresLib/Types/Enum/enumWithCppEnum.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 #pragma once
 
@@ -18,7 +18,7 @@ namespace testDomain {
 
 // Foo, Bar, Erm, Oom, Boo
     struct TestEnum : babelwires::EnumType {
-        PRIMITIVE_TYPE("Enum", "Enum", "d5cbc549-0c16-45aa-874b-c81b9bef21f3", 1);
+        REGISTERED_TYPE("Enum", "Enum", "d5cbc549-0c16-45aa-874b-c81b9bef21f3", 1);
         TestEnum();
 
         /// Expose a C++ enum which matches the Enum.
@@ -27,19 +27,19 @@ namespace testDomain {
 
     // Bar, Erm, Oom
     struct TestSubEnum : babelwires::EnumType {
-        PRIMITIVE_TYPE("SubEnum", "SubEnum", "80ba8f33-3851-48b4-a510-52770468d5f6", 1);
+        REGISTERED_TYPE("SubEnum", "SubEnum", "80ba8f33-3851-48b4-a510-52770468d5f6", 1);
         TestSubEnum();
     };
 
     // Bar, Erm
     struct TestSubSubEnum1 : babelwires::EnumType {
-        PRIMITIVE_TYPE("SubSubEnum1", "SubSubEnum1", "5cdf92b9-6d0e-4477-b853-336dafc2828d", 1);
+        REGISTERED_TYPE("SubSubEnum1", "SubSubEnum1", "5cdf92b9-6d0e-4477-b853-336dafc2828d", 1);
         TestSubSubEnum1();
     };
 
     // Erm, Oom
     struct TestSubSubEnum2 : babelwires::EnumType {
-        PRIMITIVE_TYPE("SubSubEnum2", "SubSubEnum2", "e787e345-0138-4b46-9f43-d12ed57d4ee9", 1);
+        REGISTERED_TYPE("SubSubEnum2", "SubSubEnum2", "e787e345-0138-4b46-9f43-d12ed57d4ee9", 1);
         TestSubSubEnum2();
     };
 } // namespace testDomain

--- a/Domains/TestDomain/testParallelProcessor.hpp
+++ b/Domains/TestDomain/testParallelProcessor.hpp
@@ -11,14 +11,14 @@ namespace testDomain {
 
     class TestParallelProcessorInput : public babelwires::ParallelProcessorInputBase {
       public:
-        PRIMITIVE_TYPE("TestProcIn", "TestProcIn", "2b414a3b-fe41-41dc-894f-889e8e15f0ff", 1);
+        REGISTERED_TYPE("TestProcIn", "TestProcIn", "2b414a3b-fe41-41dc-894f-889e8e15f0ff", 1);
 
         TestParallelProcessorInput();
     };
 
     class TestParallelProcessorOutput : public babelwires::ParallelProcessorOutputBase {
       public:
-        PRIMITIVE_TYPE("TestProcOut", "TestProcOut", "b61c5cf6-cada-416e-8fca-57f360c346e9", 1);
+        REGISTERED_TYPE("TestProcOut", "TestProcOut", "b61c5cf6-cada-416e-8fca-57f360c346e9", 1);
 
         TestParallelProcessorOutput();
     };

--- a/Domains/TestDomain/testProcessor.hpp
+++ b/Domains/TestDomain/testProcessor.hpp
@@ -19,7 +19,7 @@ namespace testDomain {
       public:
         TestProcessorInputOutputType();
 
-        PRIMITIVE_TYPE("TestProcInOut", "TestProcInputOutput", "a6dd948b-e9f4-4f03-bd5d-ecf2d608f026", 1);
+        REGISTERED_TYPE("TestProcInOut", "TestProcInputOutput", "a6dd948b-e9f4-4f03-bd5d-ecf2d608f026", 1);
 
         DECLARE_INSTANCE_BEGIN(TestProcessorInputOutputType)
         DECLARE_INSTANCE_FIELD(Int, babelwires::IntType)

--- a/Domains/TestDomain/testRecordType.hpp
+++ b/Domains/TestDomain/testRecordType.hpp
@@ -4,7 +4,7 @@
 
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Project/Nodes/ValueNode/valueNodeData.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace testDomain {
 
@@ -12,7 +12,7 @@ namespace testDomain {
       public:
         TestSimpleRecordType();
 
-        PRIMITIVE_TYPE("srecordT", "SimpleRecord", "ea96a409-6424-4924-aefe-ecbe66139f17", 1);
+        REGISTERED_TYPE("srecordT", "SimpleRecord", "ea96a409-6424-4924-aefe-ecbe66139f17", 1);
 
         DECLARE_INSTANCE_BEGIN(TestSimpleRecordType)
         DECLARE_INSTANCE_FIELD(intR0, babelwires::IntType)
@@ -38,7 +38,7 @@ namespace testDomain {
       public:
         TestComplexRecordType();
 
-        PRIMITIVE_TYPE("crecordT", "ComplexRecord", "87291871-677d-41a1-81e7-bf1206b1d396", 1);
+        REGISTERED_TYPE("crecordT", "ComplexRecord", "87291871-677d-41a1-81e7-bf1206b1d396", 1);
 
         static constexpr int c_int1min = -10;
         static constexpr int c_int1max = 10;

--- a/Domains/TestDomain/testRecordTypeHierarchy.hpp
+++ b/Domains/TestDomain/testRecordTypeHierarchy.hpp
@@ -1,70 +1,70 @@
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Record/recordType.hpp>
 
 namespace testDomain {
 
     struct RecordWithNoFields : babelwires::RecordType {
-        PRIMITIVE_TYPE("NoFields", "Record with no fields", "d5d8e6a4-97f4-4aab-a6a0-35a4704ecda2", 1);
+        REGISTERED_TYPE("NoFields", "Record with no fields", "d5d8e6a4-97f4-4aab-a6a0-35a4704ecda2", 1);
         RecordWithNoFields();
     };
 
     struct RecordA0 : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordA0", "Record with field A", "19d7acd1-9097-40fa-866b-94256ef7382c", 1);
+        REGISTERED_TYPE("RecordA0", "Record with field A", "19d7acd1-9097-40fa-866b-94256ef7382c", 1);
         RecordA0();
     };
 
     struct RecordA1 : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordA1", "Different record with field A", "b648e0ed-1911-4daf-9338-b2f449851f0f", 1);
+        REGISTERED_TYPE("RecordA1", "Different record with field A", "b648e0ed-1911-4daf-9338-b2f449851f0f", 1);
         RecordA1();
     };
 
     struct RecordB : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordB", "Record with int field B", "e5a1e186-60f9-448e-bd75-b9c7e8d6c1ce", 1);
+        REGISTERED_TYPE("RecordB", "Record with int field B", "e5a1e186-60f9-448e-bd75-b9c7e8d6c1ce", 1);
         RecordB();
     };
 
     struct RecordAB : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAB", "Record with int fields A and B", "35090f6e-5c3e-45b8-94dc-4be3392290a7", 1);
+        REGISTERED_TYPE("RecordAB", "Record with int fields A and B", "35090f6e-5c3e-45b8-94dc-4be3392290a7", 1);
         RecordAB();
     };
 
     struct RecordAS : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAS", "Record with string field A", "f8ff70ac-a175-447e-89e2-15375d9418ac", 1);
+        REGISTERED_TYPE("RecordAS", "Record with string field A", "f8ff70ac-a175-447e-89e2-15375d9418ac", 1);
         RecordAS();
     };
 
     struct RecordAOpt : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAOpt", "Record with int fields A and Opt", "d7cecf7f-0f95-4120-808b-86bd99e2f504", 1);
+        REGISTERED_TYPE("RecordAOpt", "Record with int fields A and Opt", "d7cecf7f-0f95-4120-808b-86bd99e2f504", 1);
         RecordAOpt();
     };
 
     struct RecordAOptFixed : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAOpt", "Record with int fields A and Opt, where in this case, Opt is a fixed field", "a3665c18-e5f2-41b7-8cf0-bf3a1396e029", 1);
+        REGISTERED_TYPE("RecordAOpt", "Record with int fields A and Opt, where in this case, Opt is a fixed field", "a3665c18-e5f2-41b7-8cf0-bf3a1396e029", 1);
         RecordAOptFixed();
     };
 
     struct RecordABOpt : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordABOpt", "Record with int fields A, B and Opt", "5a21780a-0a56-481a-a850-4afb18b3bc2d", 1);
+        REGISTERED_TYPE("RecordABOpt", "Record with int fields A, B and Opt", "5a21780a-0a56-481a-a850-4afb18b3bc2d", 1);
         RecordABOpt();
     };
 
     struct RecordAOptS : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAOptS", "Record with int field A and string field Opt", "62fd3ee0-3a98-4775-b6fc-2c37143491f6", 1);
+        REGISTERED_TYPE("RecordAOptS", "Record with int field A and string field Opt", "62fd3ee0-3a98-4775-b6fc-2c37143491f6", 1);
         RecordAOptS();
     };
 
     struct RecordABOptChild : babelwires::RecordType {
         RecordABOptChild(const babelwires::TypeSystem& typeSystem);
-        PRIMITIVE_TYPE("RecordChild", "Child of RecordABOpt", "0cc46b96-9ce0-4722-aba9-9009d12f1bcc", 1);
+        REGISTERED_TYPE("RecordChild", "Child of RecordABOpt", "0cc46b96-9ce0-4722-aba9-9009d12f1bcc", 1);
     };
 
     struct RecordAsub0 : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAsub0", "Record with field A which is a subtype of the original A", "a2a71062-213e-456e-91dd-0df1ca1a1dae", 1);
+        REGISTERED_TYPE("RecordAsub0", "Record with field A which is a subtype of the original A", "a2a71062-213e-456e-91dd-0df1ca1a1dae", 1);
         RecordAsub0();
     };
 
     struct RecordAsubBsup : babelwires::RecordType {
-        PRIMITIVE_TYPE("RecordAsubBsup", "Record with field A and B, which is a supertype of the original B", "21418e19-f5d6-4f26-9948-e9497595c11d", 1);
+        REGISTERED_TYPE("RecordAsubBsup", "Record with field A and B, which is a supertype of the original B", "21418e19-f5d6-4f26-9948-e9497595c11d", 1);
         RecordAsubBsup();
     };
     

--- a/Domains/TestDomain/testRecordWithVariantsType.hpp
+++ b/Domains/TestDomain/testRecordWithVariantsType.hpp
@@ -2,7 +2,7 @@
 
 #include <BabelWiresLib/Project/Nodes/ValueNode/valueNodeData.hpp>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 
 namespace testDomain {
 
@@ -10,7 +10,7 @@ namespace testDomain {
       public:
         TestRecordWithVariantsType();
 
-        PRIMITIVE_TYPE("vrecordT", "RecordWithVariants", "45442c6b-fa02-4a48-b7f8-9ca062c568ea", 1);
+        REGISTERED_TYPE("vrecordT", "RecordWithVariants", "45442c6b-fa02-4a48-b7f8-9ca062c568ea", 1);
 
         static babelwires::ShortId getTagAId();
         static babelwires::ShortId getTagBId(); // The default tag.

--- a/Domains/TestDomain/testRecordWithVariantsTypeHierarchy.hpp
+++ b/Domains/TestDomain/testRecordWithVariantsTypeHierarchy.hpp
@@ -1,4 +1,4 @@
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/RecordWithVariants/recordWithVariantsType.hpp>
 #include <BabelWiresLib/Types/String/stringType.hpp>
@@ -6,58 +6,58 @@
 namespace testDomain {
 
     struct RecordVWithNoFields : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("VarNoFields", "RecordWithVariants with no fields", "20cc79e4-d93b-4c88-a0ff-36b13d415092", 1);
+        REGISTERED_TYPE("VarNoFields", "RecordWithVariants with no fields", "20cc79e4-d93b-4c88-a0ff-36b13d415092", 1);
         RecordVWithNoFields();
     };
 
     struct RecordVA0 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVA0", "RecordWithVariants with field A", "5bbc0266-4223-43e3-b1be-6fe44ee921bc", 1);
+        REGISTERED_TYPE("RecordVA0", "RecordWithVariants with field A", "5bbc0266-4223-43e3-b1be-6fe44ee921bc", 1);
         RecordVA0();
     };
 
     struct RecordVA1 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVA1", "Different RecordWithVariants with field A", "a58a442f-ec25-4b71-99f6-d26478869368", 1);
+        REGISTERED_TYPE("RecordVA1", "Different RecordWithVariants with field A", "a58a442f-ec25-4b71-99f6-d26478869368", 1);
         RecordVA1();
     };
 
     struct RecordVB : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVB", "RecordWithVariants with field B", "64c451fc-6cdf-4b11-9e81-bf9f6a166aba", 1);
+        REGISTERED_TYPE("RecordVB", "RecordWithVariants with field B", "64c451fc-6cdf-4b11-9e81-bf9f6a166aba", 1);
         RecordVB();
     };
 
     struct RecordVAB : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVAB", "RecordWithVariants with fields A and B", "277df5de-5ae4-49b6-b0d0-cb161a2f6133", 1);
+        REGISTERED_TYPE("RecordVAB", "RecordWithVariants with fields A and B", "277df5de-5ae4-49b6-b0d0-cb161a2f6133", 1);
         RecordVAB();
     };
 
     struct RecordVAS : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVAS", "RecordWithVariants with string field A", "c002ae48-d33e-43d9-ab71-466128e02f9b", 1);
+        REGISTERED_TYPE("RecordVAS", "RecordWithVariants with string field A", "c002ae48-d33e-43d9-ab71-466128e02f9b", 1);
         RecordVAS();
     };
 
     struct RecordVAV0 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVAV0", "RecordWithVariants with fields A and 0", "c7ec2e91-a621-4da9-aadb-196b0e566cab", 1);
+        REGISTERED_TYPE("RecordVAV0", "RecordWithVariants with fields A and 0", "c7ec2e91-a621-4da9-aadb-196b0e566cab", 1);
         RecordVAV0();
     };
 
     struct RecordVABV0 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVABV0", "RecordWithVariants with fields A, 0 and B", "b6c11598-6393-45d8-939e-45a3cbf5f0d7", 1);
+        REGISTERED_TYPE("RecordVABV0", "RecordWithVariants with fields A, 0 and B", "b6c11598-6393-45d8-939e-45a3cbf5f0d7", 1);
         RecordVABV0();
     };
 
 
     struct RecordVABV1 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVABV1", "RecordWithVariants with fields A, 1 and B", "77756b6b-0388-4359-a103-36eeefe023f6", 1);
+        REGISTERED_TYPE("RecordVABV1", "RecordWithVariants with fields A, 1 and B", "77756b6b-0388-4359-a103-36eeefe023f6", 1);
         RecordVABV1();
     };
 
     struct RecordVABV01 : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVABV01", "RecordWithVariants with fields A, 0, B and 1", "65c4a33e-c88c-4c61-bc9d-0dd2b2f7b021", 1);
+        REGISTERED_TYPE("RecordVABV01", "RecordWithVariants with fields A, 0, B and 1", "65c4a33e-c88c-4c61-bc9d-0dd2b2f7b021", 1);
         RecordVABV01();
     };
 
     struct RecordVAVB : babelwires::RecordWithVariantsType {
-        PRIMITIVE_TYPE("RecordVAVB", "RecordWithVariants with fields A, and B in default", "0d4e6599-a15b-41eb-aa8a-8d6c51db77b7", 1);
+        REGISTERED_TYPE("RecordVAVB", "RecordWithVariants with fields A, and B in default", "0d4e6599-a15b-41eb-aa8a-8d6c51db77b7", 1);
         RecordVAVB();
     };
 

--- a/Domains/TestDomain/testSumType.hpp
+++ b/Domains/TestDomain/testSumType.hpp
@@ -1,4 +1,4 @@
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/Int/intTypeConstructor.hpp>
 #include <BabelWiresLib/Types/Rational/rationalType.hpp>
@@ -9,7 +9,7 @@
 namespace testDomain {
     class TestSumType : public babelwires::SumType {
       public:
-        PRIMITIVE_TYPE("TestSumType", "TestSumType", "19c1e116-5e37-489e-9205-8d0b0a023f13", 1);
+        REGISTERED_TYPE("TestSumType", "TestSumType", "19c1e116-5e37-489e-9205-8d0b0a023f13", 1);
         TestSumType(unsigned int defaultType = 1)
             : babelwires::SumType(
                   {babelwires::DefaultIntType::getThisType(), babelwires::DefaultRationalType::getThisType()},

--- a/Domains/TestDomain/testTupleType.hpp
+++ b/Domains/TestDomain/testTupleType.hpp
@@ -1,4 +1,4 @@
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/Rational/rationalType.hpp>
 #include <BabelWiresLib/Types/Tuple/tupleType.hpp>
@@ -6,7 +6,7 @@
 namespace testDomain {
     class TestTupleType : public babelwires::TupleType {
       public:
-        PRIMITIVE_TYPE("TestTupleType", "TestTupleType", "48585b19-90bc-4282-b5d0-dc7987ad5310", 1);
+        REGISTERED_TYPE("TestTupleType", "TestTupleType", "48585b19-90bc-4282-b5d0-dc7987ad5310", 1);
         TestTupleType()
             : babelwires::TupleType(
                   {babelwires::DefaultIntType::getThisType(), babelwires::DefaultRationalType::getThisType()}) {}

--- a/Tests/BabelWiresLib/TestData/testProject.babelwires
+++ b/Tests/BabelWiresLib/TestData/testProject.babelwires
@@ -55,7 +55,7 @@
                     </expandedPaths>
                 </targetFile>
                 <value id="8" factory="nofact">
-                    <type primitiveTypeId="crecordT'1"/>
+                    <type typeId="crecordT'1"/>
                     <modifiers>
                         <assignFrom path="rec'1" sourceId="4" sourcePath="Record'1"/>
                     </modifiers>

--- a/Tests/BabelWiresLib/TestUtils/testValueAndType.hpp
+++ b/Tests/BabelWiresLib/TestUtils/testValueAndType.hpp
@@ -1,4 +1,4 @@
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/TypeSystem/type.hpp>
 #include <BabelWiresLib/TypeSystem/value.hpp>
 
@@ -28,7 +28,7 @@ namespace testUtils {
     /// The Type of TestValues.
     class TestType : public babelwires::Type {
       public:
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("TestType"), 1);
+        REGISTERED_TYPE_WITH_REGISTERED_ID(getTestRegisteredMediumIdentifier("TestType"), 1);
 
         /// 0 == unbounded.
         TestType(unsigned int maximumLength = 0, std::string defaultValue = "Default value");

--- a/Tests/BabelWiresLib/intTypeTest.cpp
+++ b/Tests/BabelWiresLib/intTypeTest.cpp
@@ -57,7 +57,7 @@ TEST(IntTypeTest, defaultIntTypeIsRegistered) {
     testUtils::TestEnvironment testEnvironment;
 
     const auto* const foundType =
-        testEnvironment.m_typeSystem.tryGetPrimitiveType(babelwires::DefaultIntType::getThisIdentifier());
+        testEnvironment.m_typeSystem.tryGetRegisteredType(babelwires::DefaultIntType::getThisIdentifier());
     EXPECT_NE(foundType, nullptr);
     EXPECT_NE(foundType->as<babelwires::DefaultIntType>(), nullptr);
 }

--- a/Tests/BabelWiresLib/mapProjectTest.cpp
+++ b/Tests/BabelWiresLib/mapProjectTest.cpp
@@ -19,8 +19,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::PrimitiveTypeId testTypeId1 = "TestType1";
-    const babelwires::PrimitiveTypeId testTypeId2 = "TestType2";
+    const babelwires::RegisteredTypeId testTypeId1 = "TestType1";
+    const babelwires::RegisteredTypeId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapProjectTest, mapProjectEntry) {

--- a/Tests/BabelWiresLib/mapValueTest.cpp
+++ b/Tests/BabelWiresLib/mapValueTest.cpp
@@ -17,8 +17,8 @@
 #include <Tests/TestUtils/testLog.hpp>
 
 namespace {
-    const babelwires::PrimitiveTypeId testTypeId1 = "TestType1";
-    const babelwires::PrimitiveTypeId testTypeId2 = "TestType2";
+    const babelwires::RegisteredTypeId testTypeId1 = "TestType1";
+    const babelwires::RegisteredTypeId testTypeId2 = "TestType2";
 } // namespace
 
 TEST(MapValueTest, types) {

--- a/Tests/BabelWiresLib/parallelProcessorTest.cpp
+++ b/Tests/BabelWiresLib/parallelProcessorTest.cpp
@@ -3,7 +3,7 @@
 #include <BabelWiresLib/Instance/instance.hpp>
 #include <BabelWiresLib/Path/path.hpp>
 #include <BabelWiresLib/Processors/parallelProcessor.hpp>
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intTypeConstructor.hpp>
 #include <BabelWiresLib/ValueTree/valueTreePathUtils.hpp>
 #include <BabelWiresLib/ValueTree/valueTreeRoot.hpp>

--- a/Tests/BabelWiresLib/rationalTypeTest.cpp
+++ b/Tests/BabelWiresLib/rationalTypeTest.cpp
@@ -57,7 +57,7 @@ TEST(RationalTypeTest, defaultRationalTypeIsRegistered) {
     testUtils::TestEnvironment testEnvironment;
 
     const auto* const foundType =
-        testEnvironment.m_typeSystem.tryGetPrimitiveType(babelwires::DefaultRationalType::getThisIdentifier());
+        testEnvironment.m_typeSystem.tryGetRegisteredType(babelwires::DefaultRationalType::getThisIdentifier());
     EXPECT_NE(foundType, nullptr);
     EXPECT_NE(foundType->as<babelwires::DefaultRationalType>(), nullptr);
 }

--- a/Tests/BabelWiresLib/stringTypeTest.cpp
+++ b/Tests/BabelWiresLib/stringTypeTest.cpp
@@ -41,7 +41,7 @@ TEST(StringTypeTest, stringTypeIsRegistered) {
     testUtils::TestEnvironment testEnvironment;
 
     const auto* const foundType =
-        testEnvironment.m_typeSystem.tryGetPrimitiveType(babelwires::StringType::getThisIdentifier());
+        testEnvironment.m_typeSystem.tryGetRegisteredType(babelwires::StringType::getThisIdentifier());
     EXPECT_NE(foundType, nullptr);
     EXPECT_NE(foundType->as<babelwires::StringType>(), nullptr);
 }

--- a/Tests/BabelWiresLib/sumOfMapsTypeTest.cpp
+++ b/Tests/BabelWiresLib/sumOfMapsTypeTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/Int/intValue.hpp>
 #include <BabelWiresLib/Types/Map/SumOfMaps/sumOfMapsType.hpp>
@@ -16,7 +16,7 @@
 namespace {
     class TestSumOfMapsType : public babelwires::SumOfMapsType {
       public:
-        PRIMITIVE_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("TestSumOfMapsType"), 1);
+        REGISTERED_TYPE_WITH_REGISTERED_ID(testUtils::getTestRegisteredMediumIdentifier("TestSumOfMapsType"), 1);
         TestSumOfMapsType()
             : babelwires::SumOfMapsType(
                   {babelwires::DefaultIntType::getThisType(),

--- a/Tests/BabelWiresLib/sumTypeTest.cpp
+++ b/Tests/BabelWiresLib/sumTypeTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <BabelWiresLib/TypeSystem/primitiveType.hpp>
+#include <BabelWiresLib/TypeSystem/registeredType.hpp>
 #include <BabelWiresLib/Types/Int/intType.hpp>
 #include <BabelWiresLib/Types/Int/intValue.hpp>
 #include <BabelWiresLib/Types/Rational/rationalType.hpp>

--- a/Tests/BabelWiresLib/sumTypeTest.cpp
+++ b/Tests/BabelWiresLib/sumTypeTest.cpp
@@ -31,7 +31,7 @@ TEST(SumTypeTest, sumTypeDefault0) {
     EXPECT_NE(newValue->as<babelwires::IntValue>(), nullptr);
 
     babelwires::ValueHolder rationalValue =
-        testEnvironment.m_typeSystem.getPrimitiveType(babelwires::DefaultRationalType::getThisIdentifier())
+        testEnvironment.m_typeSystem.getRegisteredType(babelwires::DefaultRationalType::getThisIdentifier())
             .createValue(testEnvironment.m_typeSystem);
 
     EXPECT_EQ(sumType.getIndexOfValue(testEnvironment.m_typeSystem, *rationalValue), 1);
@@ -56,7 +56,7 @@ TEST(SumTypeTest, sumTypeDefault1) {
     EXPECT_NE(newValue->as<babelwires::RationalValue>(), nullptr);
 
     babelwires::ValueHolder intValue =
-        testEnvironment.m_typeSystem.getPrimitiveType(babelwires::DefaultIntType::getThisIdentifier())
+        testEnvironment.m_typeSystem.getRegisteredType(babelwires::DefaultIntType::getThisIdentifier())
             .createValue(testEnvironment.m_typeSystem);
 
     EXPECT_EQ(sumType.getIndexOfValue(testEnvironment.m_typeSystem, *intValue), 0);

--- a/Tests/BabelWiresLib/tupleTypeTest.cpp
+++ b/Tests/BabelWiresLib/tupleTypeTest.cpp
@@ -26,8 +26,8 @@ TEST(TupleTypeTest, createValue) {
     EXPECT_TRUE(newValue);
     EXPECT_TRUE(tupleType.isValidValue(testEnvironment.m_typeSystem, *newValue));
 
-    const auto& intType = testEnvironment.m_typeSystem.getPrimitiveType(babelwires::DefaultIntType::getThisIdentifier());
-    const auto& rationalType = testEnvironment.m_typeSystem.getPrimitiveType(babelwires::DefaultRationalType::getThisIdentifier());
+    const auto& intType = testEnvironment.m_typeSystem.getRegisteredType(babelwires::DefaultIntType::getThisIdentifier());
+    const auto& rationalType = testEnvironment.m_typeSystem.getRegisteredType(babelwires::DefaultRationalType::getThisIdentifier());
 
     const auto* newTuple = newValue->as<babelwires::TupleValue>();
     ASSERT_NE(newTuple, nullptr);

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -19,8 +19,8 @@
 
 TEST(TypeRefTest, equality) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef registeredTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef registeredTypeRef2(babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
                                             babelwires::RegisteredTypeId("Flerm"));
@@ -33,34 +33,34 @@ TEST(TypeRefTest, equality) {
         babelwires::TypeConstructorArguments{{babelwires::RegisteredTypeId("Bar")}, {babelwires::IntValue(16)}});
 
     EXPECT_EQ(nullTypeRef, nullTypeRef);
-    EXPECT_EQ(primitiveTypeRef1, primitiveTypeRef1);
-    EXPECT_EQ(primitiveTypeRef2, primitiveTypeRef2);
+    EXPECT_EQ(registeredTypeRef1, registeredTypeRef1);
+    EXPECT_EQ(registeredTypeRef2, registeredTypeRef2);
     EXPECT_EQ(constructedTypeRef1, constructedTypeRef1);
     EXPECT_EQ(constructedTypeRef2, constructedTypeRef2);
     EXPECT_EQ(constructedTypeRef3, constructedTypeRef3);
     EXPECT_EQ(constructedTypeRefValue1, constructedTypeRefValue1);
     EXPECT_EQ(constructedTypeRefMixed1, constructedTypeRefMixed1);
 
-    EXPECT_NE(nullTypeRef, primitiveTypeRef1);
-    EXPECT_NE(nullTypeRef, primitiveTypeRef2);
+    EXPECT_NE(nullTypeRef, registeredTypeRef1);
+    EXPECT_NE(nullTypeRef, registeredTypeRef2);
     EXPECT_NE(nullTypeRef, constructedTypeRef1);
     EXPECT_NE(nullTypeRef, constructedTypeRef2);
     EXPECT_NE(nullTypeRef, constructedTypeRef3);
     EXPECT_NE(nullTypeRef, constructedTypeRefValue1);
     EXPECT_NE(nullTypeRef, constructedTypeRefMixed1);
 
-    EXPECT_NE(primitiveTypeRef1, primitiveTypeRef2);
-    EXPECT_NE(primitiveTypeRef1, constructedTypeRef1);
-    EXPECT_NE(primitiveTypeRef1, constructedTypeRef2);
-    EXPECT_NE(primitiveTypeRef1, constructedTypeRef3);
-    EXPECT_NE(primitiveTypeRef1, constructedTypeRefValue1);
-    EXPECT_NE(primitiveTypeRef1, constructedTypeRefMixed1);
+    EXPECT_NE(registeredTypeRef1, registeredTypeRef2);
+    EXPECT_NE(registeredTypeRef1, constructedTypeRef1);
+    EXPECT_NE(registeredTypeRef1, constructedTypeRef2);
+    EXPECT_NE(registeredTypeRef1, constructedTypeRef3);
+    EXPECT_NE(registeredTypeRef1, constructedTypeRefValue1);
+    EXPECT_NE(registeredTypeRef1, constructedTypeRefMixed1);
 
-    EXPECT_NE(primitiveTypeRef2, constructedTypeRef1);
-    EXPECT_NE(primitiveTypeRef2, constructedTypeRef2);
-    EXPECT_NE(primitiveTypeRef2, constructedTypeRef3);
-    EXPECT_NE(primitiveTypeRef2, constructedTypeRefValue1);
-    EXPECT_NE(primitiveTypeRef2, constructedTypeRefMixed1);
+    EXPECT_NE(registeredTypeRef2, constructedTypeRef1);
+    EXPECT_NE(registeredTypeRef2, constructedTypeRef2);
+    EXPECT_NE(registeredTypeRef2, constructedTypeRef3);
+    EXPECT_NE(registeredTypeRef2, constructedTypeRefValue1);
+    EXPECT_NE(registeredTypeRef2, constructedTypeRefMixed1);
 
     EXPECT_NE(constructedTypeRef1, constructedTypeRef2);
     EXPECT_NE(constructedTypeRef1, constructedTypeRef3);
@@ -328,8 +328,8 @@ TEST(TypeRefTest, toStringMalformed) {
 
 TEST(TypeRefTest, serialization) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef registeredTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef registeredTypeRef2(babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
                                             babelwires::RegisteredTypeId("Flerm"));
@@ -342,7 +342,7 @@ TEST(TypeRefTest, serialization) {
         babelwires::TypeConstructorArguments{{babelwires::RegisteredTypeId("Bar")}, {babelwires::IntValue(16)}});
 
     std::vector<babelwires::TypeRef> testRefs = {
-        nullTypeRef,         primitiveTypeRef1,   primitiveTypeRef2,        constructedTypeRef1,
+        nullTypeRef,         registeredTypeRef1,   registeredTypeRef2,        constructedTypeRef1,
         constructedTypeRef2, constructedTypeRef3, constructedTypeRefValue1, constructedTypeRefMixed1};
 
     for (auto typeRef : testRefs) {
@@ -412,8 +412,8 @@ TEST(TypeRefTest, visitIdentifiers) {
 
 TEST(TypeRefTest, hash) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef registeredTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef registeredTypeRef2(babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef2(
         babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
@@ -430,14 +430,14 @@ TEST(TypeRefTest, hash) {
     std::hash<babelwires::TypeRef> hasher;
 
     // In theory, some of these could fail due to a hash collision.
-    EXPECT_NE(hasher(nullTypeRef), hasher(primitiveTypeRef1));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(primitiveTypeRef2));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRef1));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRef2));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRef3));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRefValue1));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRefValue2));
-    EXPECT_NE(hasher(primitiveTypeRef1), hasher(constructedTypeRefMixed1));
+    EXPECT_NE(hasher(nullTypeRef), hasher(registeredTypeRef1));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(registeredTypeRef2));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRef1));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRef2));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRef3));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRefValue1));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRefValue2));
+    EXPECT_NE(hasher(registeredTypeRef1), hasher(constructedTypeRefMixed1));
     EXPECT_NE(hasher(constructedTypeRef1), hasher(constructedTypeRef2));
     EXPECT_NE(hasher(constructedTypeRef1), hasher(constructedTypeRef3));
     EXPECT_NE(hasher(constructedTypeRef1), hasher(constructedTypeRefValue1));

--- a/Tests/BabelWiresLib/typeRefTest.cpp
+++ b/Tests/BabelWiresLib/typeRefTest.cpp
@@ -19,18 +19,18 @@
 
 TEST(TypeRefTest, equality) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-                                            babelwires::PrimitiveTypeId("Flerm"));
+    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+                                            babelwires::RegisteredTypeId("Flerm"));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
+        babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::RegisteredTypeId("Erm")));
     babelwires::TypeRef constructedTypeRefValue1(babelwires::TypeConstructorId("Foo"), babelwires::StringValue("Bar"));
     babelwires::TypeRef constructedTypeRefMixed1(
         babelwires::TypeConstructorId("Foo"),
-        babelwires::TypeConstructorArguments{{babelwires::PrimitiveTypeId("Bar")}, {babelwires::IntValue(16)}});
+        babelwires::TypeConstructorArguments{{babelwires::RegisteredTypeId("Bar")}, {babelwires::IntValue(16)}});
 
     EXPECT_EQ(nullTypeRef, nullTypeRef);
     EXPECT_EQ(primitiveTypeRef1, primitiveTypeRef1);
@@ -116,7 +116,7 @@ TEST(TypeRefTest, tryResolveFailure) {
     babelwires::TypeSystem typeSystem;
 
     EXPECT_EQ(nullptr, babelwires::TypeRef().tryResolve(typeSystem));
-    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::PrimitiveTypeId("Foo")).tryResolve(typeSystem));
+    EXPECT_EQ(nullptr, babelwires::TypeRef(babelwires::RegisteredTypeId("Foo")).tryResolve(typeSystem));
 }
 
 TEST(TypeRefTest, tryResolveParallel) {
@@ -179,7 +179,7 @@ TEST(TypeRefTest, toStringSuccessTypes) {
 
     EXPECT_EQ(babelwires::TypeRef().toString(), "[]");
 
-    babelwires::PrimitiveTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
+    babelwires::RegisteredTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -281,7 +281,7 @@ TEST(TypeRefTest, toStringSuccessMixed) {
     testUtils::TestLog log;
     babelwires::IdentifierRegistryScope identifierRegistry;
 
-    babelwires::PrimitiveTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
+    babelwires::RegisteredTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Foo", "Foofoo", "325d9560-6330-43bb-80b4-963843ec8fba",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
     babelwires::StringValue bar("bar");
@@ -299,7 +299,7 @@ TEST(TypeRefTest, toStringMalformed) {
     testUtils::TestLog log;
     babelwires::IdentifierRegistryScope identifierRegistry;
 
-    babelwires::PrimitiveTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
+    babelwires::RegisteredTypeId foo = babelwires::IdentifierRegistry::write()->addMediumIdWithMetadata(
         "Foo", "Foofoo", "00000000-2222-3333-4444-555566667777",
         babelwires::IdentifierRegistry::Authority::isAuthoritative);
 
@@ -328,18 +328,18 @@ TEST(TypeRefTest, toStringMalformed) {
 
 TEST(TypeRefTest, serialization) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-                                            babelwires::PrimitiveTypeId("Flerm"));
+    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef2(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+                                            babelwires::RegisteredTypeId("Flerm"));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
+        babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::RegisteredTypeId("Erm")));
     babelwires::TypeRef constructedTypeRefValue1(babelwires::TypeConstructorId("Foo"), babelwires::StringValue("Bar"));
     babelwires::TypeRef constructedTypeRefMixed1(
         babelwires::TypeConstructorId("Foo"),
-        babelwires::TypeConstructorArguments{{babelwires::PrimitiveTypeId("Bar")}, {babelwires::IntValue(16)}});
+        babelwires::TypeConstructorArguments{{babelwires::RegisteredTypeId("Bar")}, {babelwires::IntValue(16)}});
 
     std::vector<babelwires::TypeRef> testRefs = {
         nullTypeRef,         primitiveTypeRef1,   primitiveTypeRef2,        constructedTypeRef1,
@@ -412,20 +412,20 @@ TEST(TypeRefTest, visitIdentifiers) {
 
 TEST(TypeRefTest, hash) {
     babelwires::TypeRef nullTypeRef;
-    babelwires::TypeRef primitiveTypeRef1(babelwires::PrimitiveTypeId("Foo"));
-    babelwires::TypeRef primitiveTypeRef2(babelwires::PrimitiveTypeId("Bar"));
-    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"));
+    babelwires::TypeRef primitiveTypeRef1(babelwires::RegisteredTypeId("Foo"));
+    babelwires::TypeRef primitiveTypeRef2(babelwires::RegisteredTypeId("Bar"));
+    babelwires::TypeRef constructedTypeRef1(babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"));
     babelwires::TypeRef constructedTypeRef2(
-        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::PrimitiveTypeId("Erm")));
+        babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Flerm"), babelwires::RegisteredTypeId("Erm")));
     babelwires::TypeRef constructedTypeRef3(
-        babelwires::TypeConstructorId("Foo"), babelwires::PrimitiveTypeId("Bar"),
-        babelwires::TypeRef(babelwires::TypeConstructorId("Oom"), babelwires::PrimitiveTypeId("Erm")));
+        babelwires::TypeConstructorId("Foo"), babelwires::RegisteredTypeId("Bar"),
+        babelwires::TypeRef(babelwires::TypeConstructorId("Oom"), babelwires::RegisteredTypeId("Erm")));
     babelwires::TypeRef constructedTypeRefValue1(babelwires::TypeConstructorId("Foo"), babelwires::StringValue("Bar"));
     babelwires::TypeRef constructedTypeRefValue2(babelwires::TypeConstructorId("Foo"), babelwires::StringValue("Erm"));
     babelwires::TypeRef constructedTypeRefMixed1(
         babelwires::TypeConstructorId("Foo"),
-        babelwires::TypeConstructorArguments{{babelwires::PrimitiveTypeId("Bar")}, {babelwires::IntValue(16)}});
+        babelwires::TypeConstructorArguments{{babelwires::RegisteredTypeId("Bar")}, {babelwires::IntValue(16)}});
 
     std::hash<babelwires::TypeRef> hasher;
 

--- a/Tests/BabelWiresLib/typeSystemTest.cpp
+++ b/Tests/BabelWiresLib/typeSystemTest.cpp
@@ -121,7 +121,7 @@ TEST(TypeSystemTest, isRelatedTypes) {
 TEST(TypeSystemTest, getTaggedTypes) {
     testUtils::TestEnvironment testEnvironment;   
 
-    auto types = testEnvironment.m_typeSystem.getTaggedPrimitiveTypes(testUtils::TestType::getTestTypeTag());
+    auto types = testEnvironment.m_typeSystem.getTaggedRegisteredTypes(testUtils::TestType::getTestTypeTag());
 
     EXPECT_EQ(types.size(), 1);
     EXPECT_EQ(types[0], testUtils::TestType::getThisType());


### PR DESCRIPTION
I was misusing the word "Primitive" for types which were registered in the type system. If I wanted to use the term "primitive" then the term should means something like "non-compound" or perhaps refer specifically to non-compound built-in types. 

I was using it for types that are registered directly in the type system vs constructed from type constructors, so I've switched to using the more appropriate term "Registered Type".