### PR TITLE
Ensure deserialization works when using shared libraries

### DIFF
--- a/BabelWiresLib/TypeSystem/type.hpp
+++ b/BabelWiresLib/TypeSystem/type.hpp
@@ -55,7 +55,7 @@ namespace babelwires {
 
         /// Return a short string which can be used in the UI to give a sense of the data this type handles.
         /// It is not used to impose any formal restrictions.
-        /// In cases where the type has a unique and serializable class of values, the serializationType of that
+        /// In cases where the type has a unique and serializable class of values, the s_serializationTypeName of that
         /// class is a good choice.
         virtual std::string getFlavour() const = 0;
 

--- a/BabelWiresLib/Types/Enum/enumType.cpp
+++ b/BabelWiresLib/Types/Enum/enumType.cpp
@@ -75,7 +75,7 @@ babelwires::NewValueHolder babelwires::EnumType::createValue(const TypeSystem& t
 }
 
 std::string babelwires::EnumType::getFlavour() const {
-    return EnumValue::serializationType;
+    return EnumValue::s_serializationTypeName;
 }
 
 std::optional<babelwires::SubtypeOrder> babelwires::EnumType::compareSubtypeHelper(const TypeSystem& typeSystem,

--- a/BabelWiresLib/Types/Int/intType.cpp
+++ b/BabelWiresLib/Types/Int/intType.cpp
@@ -35,7 +35,7 @@ babelwires::Range<babelwires::IntValue::NativeType> babelwires::IntType::getRang
 }
 
 std::string babelwires::IntType::getFlavour() const {
-    return IntValue::serializationType;
+    return IntValue::s_serializationTypeName;
 }
 
 std::optional<babelwires::SubtypeOrder> babelwires::IntType::compareSubtypeHelper(const TypeSystem& typeSystem,

--- a/BabelWiresLib/Types/Map/mapType.cpp
+++ b/BabelWiresLib/Types/Map/mapType.cpp
@@ -48,7 +48,7 @@ bool babelwires::MapType::visitValue(const TypeSystem& typeSystem, const Value& 
 }
 
 std::string babelwires::MapType::getFlavour() const {
-    return MapValue::serializationType;
+    return MapValue::s_serializationTypeName;
 }
 
 babelwires::TypeExp babelwires::MapType::getSourceTypeExp() const {

--- a/BabelWiresLib/Types/Rational/rationalType.cpp
+++ b/BabelWiresLib/Types/Rational/rationalType.cpp
@@ -35,7 +35,7 @@ babelwires::Range<babelwires::Rational> babelwires::RationalType::getRange() con
 }
 
 std::string babelwires::RationalType::getFlavour() const {
-    return RationalValue::serializationType;
+    return RationalValue::s_serializationTypeName;
 }
 
 std::optional<babelwires::SubtypeOrder> babelwires::RationalType::compareSubtypeHelper(const TypeSystem& typeSystem,

--- a/BabelWiresLib/Types/String/stringType.cpp
+++ b/BabelWiresLib/Types/String/stringType.cpp
@@ -24,7 +24,7 @@ bool babelwires::StringType::visitValue(const TypeSystem& typeSystem, const Valu
 }
 
 std::string babelwires::StringType::getFlavour() const {
-    return StringValue::serializationType;
+    return StringValue::s_serializationTypeName;
 }
 
 

--- a/BaseLib/DataContext/dataBundle_inl.hpp
+++ b/BaseLib/DataContext/dataBundle_inl.hpp
@@ -134,9 +134,9 @@ template <typename DATA> void babelwires::DataBundle<DATA>::serializeContents(Se
 template <typename DATA>
 babelwires::Result babelwires::DataBundle<DATA>::deserializeContents(Deserializer& deserializer) {
     DO_OR_ERROR(deserializer.tryDeserializeValue("filePath", m_pathToFile));
-    DO_OR_ERROR(deserializer.deserializeObjectByValue<DATA>(m_data, DATA::serializationType));
+    DO_OR_ERROR(deserializer.deserializeObjectByValue<DATA>(m_data, DATA::s_serializationTypeName));
     DO_OR_ERROR(deserializeAdditionalMetadata(deserializer));
     DO_OR_ERROR(deserializer.deserializeObjectByValue<IdentifierRegistry>(m_identifierRegistry,
-                                                                          IdentifierRegistry::serializationType));
+                                                                          IdentifierRegistry::s_serializationTypeName));
     return {};
 }

--- a/BaseLib/DataContext/dataSerialization_inl.hpp
+++ b/BaseLib/DataContext/dataSerialization_inl.hpp
@@ -15,7 +15,7 @@ babelwires::DataSerialization<BUNDLE>::loadFromStream(std::istream& is, const Da
     XmlDeserializer deserializer(context.m_deserializationReg, userLogger);
     ON_ERROR(deserializer.finalizeOnError());
     DO_OR_ERROR(deserializer.parse(str));
-    auto projectBundleResult = deserializer.deserializeObject<BUNDLE>(BUNDLE::serializationType);
+    auto projectBundleResult = deserializer.deserializeObject<BUNDLE>(BUNDLE::s_serializationTypeName);
     if (!projectBundleResult) {
         deserializer.augmentResultWithContext(projectBundleResult);
         RETURN_ERROR_VALUE(projectBundleResult.error());

--- a/BaseLib/Serialization/deserializableClassScope.hpp
+++ b/BaseLib/Serialization/deserializableClassScope.hpp
@@ -28,7 +28,7 @@ namespace babelwires {
         ~DeserializableClassScope() { m_deserializer.setDeserializationRegistry(*m_previousRegistry); }
 
         const Entry* findEntry(std::string_view typeName) const override {
-            if (typeName == T::serializationType) {
+            if (typeName == T::s_serializationTypeName) {
                 return T::getDeserializationRegistryEntry();
             }
             return m_previousRegistry->findEntry(typeName);

--- a/BaseLib/Serialization/deserializationRegistry.hpp
+++ b/BaseLib/Serialization/deserializationRegistry.hpp
@@ -17,7 +17,7 @@ namespace babelwires {
     class DeserializationRegistry : public DeserializationRegistryInterface {
       public:
         template <typename T> void registerClass() {
-            registerEntry(T::serializationType, T::getDeserializationRegistryEntry());
+            registerEntry(T::s_serializationTypeName, T::getDeserializationRegistryEntry());
         }
 
         void registerEntry(std::string_view typeName, const Entry* entry);

--- a/BaseLib/Serialization/deserializationRegistryInterface.hpp
+++ b/BaseLib/Serialization/deserializationRegistryInterface.hpp
@@ -2,13 +2,13 @@
  * An interface for looking up deserialization information about classes.
  *
  * (C) 2021 Malcolm Tyrrell
- * 
+ *
  * Licensed under the GPLv3.0. See LICENSE file.
  **/
 #pragma once
 
-#include <BaseLib/common.hpp>
 #include <BaseLib/Result/result.hpp>
+#include <BaseLib/common.hpp>
 #include <functional>
 #include <string_view>
 
@@ -16,6 +16,12 @@ namespace babelwires {
 
     class Deserializer;
     struct Serializable;
+
+    struct DeserializationTreeNode {
+        /// Either the provided name for concrete classes using the SERIALIZABLE macro, or a generated string for abstract classes.
+        std::string_view m_serializationType;
+        const DeserializationTreeNode* m_parentNode = nullptr;
+    };
 
     /// An interface for looking up deserialization information about classes.
     class DeserializationRegistryInterface {
@@ -27,10 +33,9 @@ namespace babelwires {
         /// Instances of this object represent the registration of a single concrete class' deserializingFactory.
         struct Entry {
             Factory m_factory;
-            std::string_view m_serializationType;
             VersionNumber m_version = 0;
-            /// Defines the SerializableBase class the type inherits from.
-            const void* m_baseClassTag = nullptr;
+            // The serializationTypeName of this type and all of its parents.
+            const DeserializationTreeNode* m_node = nullptr;
         };
 
         /// Returns nullptr if an entry cannot be found.

--- a/BaseLib/Serialization/deserializer.cpp
+++ b/BaseLib/Serialization/deserializer.cpp
@@ -45,15 +45,15 @@ void babelwires::Deserializer::finalizeOnError() {
 }
 
 babelwires::ResultT<std::unique_ptr<babelwires::Serializable>>
-babelwires::Deserializer::deserializeCurrentObject(const void* tagOfTypeSought) {
+babelwires::Deserializer::deserializeCurrentObject(const DeserializationTreeNode& treeNodeOfExpectedType) {
     const std::string_view currentTypeName = getCurrentTypeName();
     if (const DeserializationRegistryInterface::Entry* entry = getDeserializationRegistry().findEntry(currentTypeName)) {
-        const void* entryTag = entry->m_baseClassTag;
-        // The tags form a path up the type tree, so search for a match for T.
-        while (entryTag && (tagOfTypeSought != entryTag)) {
-            entryTag = *static_cast<const void* const*>(entryTag);
+        const DeserializationTreeNode* treeNode = entry->m_node;
+        // Look for the expected type in the inheritance hierarchy of the type we deserialized.
+        while (treeNode && (treeNodeOfExpectedType.m_serializationType != treeNode->m_serializationType)) {
+            treeNode = treeNode->m_parentNode;
         }
-        if (entryTag) {
+        if (treeNode) {
             // The registered entry is a subtype of the type we're trying to deserialize.
             return entry->m_factory(*this);
         } else {

--- a/BaseLib/Serialization/deserializer.hpp
+++ b/BaseLib/Serialization/deserializer.hpp
@@ -60,24 +60,24 @@ namespace babelwires {
         /// The key is often the name of a field, but by default it duplicates the name of the object's type.
         /// Returns an error if the key is not found or if there is a parse error.
         template <typename T>
-        ResultT<std::unique_ptr<T>> deserializeObject(std::string_view key = T::serializationType);
+        ResultT<std::unique_ptr<T>> deserializeObject(std::string_view key = T::s_serializationTypeName);
 
         /// Deserialize a child object of type T.
         /// If the key is missing, a nullptr is returned.
         template <typename T>
-        ResultT<std::unique_ptr<T>> tryDeserializeObject(std::string_view key = T::serializationType);
+        ResultT<std::unique_ptr<T>> tryDeserializeObject(std::string_view key = T::s_serializationTypeName);
 
         /// Deserialize a child object of type T.
         /// Returns an error if the key is not found or if there is a parse error.
         /// The object is assigned by value, so any polymorphism is lost.
         template <typename T>
-        babelwires::Result deserializeObjectByValue(T& object, std::string_view key = T::serializationType);
+        babelwires::Result deserializeObjectByValue(T& object, std::string_view key = T::s_serializationTypeName);
 
         /// Deserialize a child object of type T.
         /// If the key is not found, then false is returned and the object is not modified.
         /// The object is assigned by value, so any polymorphism is lost.
         template <typename T>
-        babelwires::ResultT<bool> tryDeserializeObjectByValue(T& object, std::string_view key = T::serializationType);
+        babelwires::ResultT<bool> tryDeserializeObjectByValue(T& object, std::string_view key = T::s_serializationTypeName);
 
         /// A non-standard iterator, which provides access to the deserialized objects of base type T in an array.
         template <typename T> struct Iterator;
@@ -132,7 +132,7 @@ namespace babelwires {
       protected:
         template <typename T> ResultT<std::unique_ptr<T>> deserializeCurrentObject();
 
-        ResultT<std::unique_ptr<Serializable>> deserializeCurrentObject(const void* tagOfTypeSought);
+        ResultT<std::unique_ptr<Serializable>> deserializeCurrentObject(const DeserializationTreeNode& treeNodeOfExpectedType);
 
         struct BaseIterator;
         struct AbstractIterator {

--- a/BaseLib/Serialization/deserializer_inl.hpp
+++ b/BaseLib/Serialization/deserializer_inl.hpp
@@ -48,7 +48,7 @@ inline babelwires::Result babelwires::Deserializer::deserializeValue(std::string
 
 template <typename T>
 inline babelwires::ResultT<std::unique_ptr<T>> babelwires::Deserializer::deserializeCurrentObject() {
-    return deserializeCurrentObject(T::getSerializationTag()).transform([](std::unique_ptr<Serializable>&& basePtr) {
+    return deserializeCurrentObject(T::getDeserializationTreeNode()).transform([](std::unique_ptr<Serializable>&& basePtr) {
         return uniquePtrCast<T>(std::move(basePtr));
     });
 }

--- a/BaseLib/Serialization/serializable.hpp
+++ b/BaseLib/Serialization/serializable.hpp
@@ -9,6 +9,7 @@
 
 #include <BaseLib/Result/resultDSL.hpp>
 #include <BaseLib/Serialization/deserializationRegistryInterface.hpp>
+#include <BaseLib/Utilities/classUniqueString.hpp>
 
 #include <cassert>
 #include <functional>
@@ -31,30 +32,38 @@ namespace babelwires {
         virtual Result deserializeContents(Deserializer& deserializer) = 0;
 
         /// This is supplied automatically by both SERIALIZABLE macros.
-        virtual std::string_view getSerializationType() const = 0;
+        virtual std::string_view getSerializationTypeName() const = 0;
 
         /// This is supplied automatically by the SERIALIZABLE macro.
-        /// If there is a serializationVersion member, that is used. Otherwise the version is assumed to be 1.
+        /// If there is a s_serializationVersion member, that is used. Otherwise the version is assumed to be 1.
         virtual VersionNumber getSerializationVersion() const = 0;
     };
 
 /// For abstract classes whose subtypes can be serialized.
+/// Abstract classes do not need to provide a TYPENAME, so a unique string is generated for them.
 #define SERIALIZABLE_ABSTRACT(T, PARENT)                                                                               \
     using SerializableParent = PARENT;                                                                                 \
-    static constexpr void* getSerializationTag() {                                                                     \
-        return babelwires::Detail::getSerializationTag<T>();                                                           \
+    inline static const babelwires::DeserializationTreeNode s_deserializationTreeNode{                                 \
+        babelwires::getClassUniqueString<T>(), babelwires::Detail::getParentDeserializationTreeNode<T>()};             \
+    static constexpr const babelwires::DeserializationTreeNode& getDeserializationTreeNode() {                         \
+        return s_deserializationTreeNode;                                                                             \
     }
 
 /// For concrete classes which can be serialized and deserialized.
 /// A class must provide implementations of serializeContents and deserializeContents.
 // TODO Macro tricks to make PARENT and VERSION optional.
 #define SERIALIZABLE(T, TYPENAME, PARENT, VERSION)                                                                     \
-    SERIALIZABLE_ABSTRACT(T, PARENT);                                                                                  \
-    std::string_view getSerializationType() const override {                                                           \
-        return serializationType;                                                                                      \
+    using SerializableParent = PARENT;                                                                                 \
+    inline static const babelwires::DeserializationTreeNode s_deserializationTreeNode{                                 \
+        TYPENAME, babelwires::Detail::getParentDeserializationTreeNode<T>()};                                          \
+    static constexpr const babelwires::DeserializationTreeNode& getDeserializationTreeNode() {                         \
+        return s_deserializationTreeNode;                                                                             \
     }                                                                                                                  \
-    static constexpr char serializationType[] = TYPENAME;                                                              \
-    static constexpr int serializationVersion = VERSION;                                                               \
+    std::string_view getSerializationTypeName() const override {                                                       \
+        return s_serializationTypeName;                                                                                \
+    }                                                                                                                  \
+    static constexpr char s_serializationTypeName[] = TYPENAME;                                                        \
+    static constexpr int s_serializationVersion = VERSION;                                                             \
     static_assert(VERSION != 0, "Version must be greater than 0");                                                     \
     babelwires::VersionNumber getSerializationVersion() const override {                                               \
         return VERSION;                                                                                                \
@@ -74,17 +83,10 @@ namespace babelwires {
         return std::move(newObject);                                                                                   \
     }                                                                                                                  \
     inline static const babelwires::DeserializationRegistryInterface::Entry s_registryEntry{                           \
-        deserializingFactory, serializationType, serializationVersion, babelwires::Detail::getSerializationTag<T>()};
+        deserializingFactory, s_serializationVersion, &s_deserializationTreeNode};
 
     // Implementation details
     namespace Detail {
-        template <typename T> struct SerializableType {
-            /// The _address_ of this pointer uniquely defines a type.
-            /// The value is the address of T's parent's tag, or void if the parent doesn't have one.
-            /// This enables the system to validate subtype relationships during deserialization.
-            static const void* s_serializationTag;
-        };
-
         template <typename T> class IsSerializable {
           private:
             using Yes = char[1];
@@ -97,23 +99,13 @@ namespace babelwires {
             enum { value = sizeof(test<T>(0)) == sizeof(Yes) };
         };
 
-        template <typename T> constexpr void* getSerializationTag() {
-            if constexpr (IsSerializable<T>::value) {
-                return &SerializableType<T>::s_serializationTag;
-            } else {
-                return nullptr;
-            }
-        }
-
-        template <typename T> constexpr void* getParentsSerializationTag() {
+        template <typename T> constexpr const DeserializationTreeNode* getParentDeserializationTreeNode() {
             if constexpr (IsSerializable<T>::value && IsSerializable<typename T::SerializableParent>::value) {
-                return T::SerializableParent::getSerializationTag();
+                return &T::SerializableParent::s_deserializationTreeNode;
             } else {
                 return nullptr;
             }
         }
-
-        template <typename T> const void* SerializableType<T>::s_serializationTag = getParentsSerializationTag<T>();
 
     } // namespace Detail
 

--- a/BaseLib/Serialization/serializer.hpp
+++ b/BaseLib/Serialization/serializer.hpp
@@ -24,7 +24,7 @@ namespace babelwires {
 
         /// Serialize the object. The key is often the name of a field, but by
         /// default it duplicates the name of the object's type.
-        template <typename T> void serializeObject(const T& object, std::string_view key = T::serializationType);
+        template <typename T> void serializeObject(const T& object, std::string_view key = T::s_serializationTypeName);
 
         /// Serialize an array of objects, whose contents described by the given span
         /// (i.e. object with begin and end methods).
@@ -92,8 +92,8 @@ namespace babelwires {
 } // namespace babelwires
 
 template <typename T> void babelwires::Serializer::serializeObject(const T& object, std::string_view key) {
-    recordVersion(object.getSerializationType(), object.getSerializationVersion());
-    pushObjectWithKey(object.getSerializationType(), key);
+    recordVersion(object.getSerializationTypeName(), object.getSerializationVersion());
+    pushObjectWithKey(object.getSerializationTypeName(), key);
     object.serializeContents(*this);
     popObject();
 }
@@ -117,8 +117,8 @@ template <typename S> void babelwires::Serializer::serializeArray(std::string_vi
         pushArray(key);
         for (const auto& it : span) {
             auto& obj = asReference(it);
-            recordVersion(obj.getSerializationType(), obj.getSerializationVersion());
-            pushObject(obj.getSerializationType());
+            recordVersion(obj.getSerializationTypeName(), obj.getSerializationVersion());
+            pushObject(obj.getSerializationTypeName());
             obj.serializeContents(*this);
             popObject();
         }

--- a/BaseLib/Utilities/classUniqueString.hpp
+++ b/BaseLib/Utilities/classUniqueString.hpp
@@ -1,0 +1,25 @@
+/**
+ * 
+ *
+ * (C) 2026 Malcolm Tyrrell
+ *
+ * Licensed under the GPLv3.0. See LICENSE file.
+ **/
+#pragma once
+
+#include <string_view>
+
+namespace babelwires {
+
+    /// Get a unique string for the class CLASS
+    template <typename CLASS> constexpr std::string_view getClassUniqueString() {
+#if defined(__clang__) || defined(__GNUC__)
+        return __PRETTY_FUNCTION__;
+#elif defined(_MSC_VER)
+        return __FUNCSIG__;
+#else
+        return "Unsupported compiler";
+#endif
+    }
+
+} // namespace babelwires


### PR DESCRIPTION
The registry of serializable classes depended on static members that could be inconsistent between shared libraries. This has been fixed and the code has been cleaned up using C++17 inline statics.