### PR TITLE
Use cmake presets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-test:
     if: github.event.pull_request.draft == false
-    name: ${{ matrix.platform.name }}-${{ matrix.lib_mode.name }}
+    name: ${{ matrix.platform.name }}-${{ matrix.preset.name }}
     runs-on: ${{ matrix.platform.os }}
     env:
       CC: ${{ matrix.platform.cc }}
@@ -20,14 +20,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lib_mode:
+        preset:
         - {
-            name: "Debug-StaticLibs",
-            preset: "static"
+            name: "static-debug",
+            preset: "static-debug"
           }
         - {
-            name: "Debug-SharedLibs",
-            preset: "shared"
+            name: "shared-debug",
+            preset: "shared-debug"
           }
         platform: 
         - {
@@ -84,10 +84,10 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
-      run: cmake --preset ${{ matrix.lib_mode.preset }}
+      run: cmake --preset ${{ matrix.preset.preset }}
 
     - name: Build
-      run: cmake --build --preset ${{ matrix.lib_mode.preset }}
+      run: cmake --build --preset ${{ matrix.preset.preset }}
 
     - name: Run Tests
-      run: ctest --preset ${{ matrix.lib_mode.preset }}
+      run: ctest --preset ${{ matrix.preset.preset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           }
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-test:
     if: github.event.pull_request.draft == false
-    name: ${{ matrix.platform.name }}-${{ matrix.preset.name }}
+    name: ${{ matrix.platform.name }}-${{ matrix.cmake_preset }}
     runs-on: ${{ matrix.platform.os }}
     env:
       CC: ${{ matrix.platform.cc }}
@@ -20,15 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset:
-        - {
-            name: "static-debug",
-            preset: "static-debug"
-          }
-        - {
-            name: "shared-debug",
-            preset: "shared-debug"
-          }
+        cmake_preset: [static-debug, shared-debug]
         platform: 
         - {
             name: "Ubuntu_GCC",
@@ -84,10 +76,10 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
-      run: cmake --preset ${{ matrix.preset.preset }}
+      run: cmake --preset ${{ matrix.cmake_preset }}
 
     - name: Build
-      run: cmake --build --preset ${{ matrix.preset.preset }}
+      run: cmake --build --preset ${{ matrix.cmake_preset }}
 
     - name: Run Tests
-      run: ctest --preset ${{ matrix.preset.preset }}
+      run: ctest --preset ${{ matrix.cmake_preset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
         sudo apt-get install cmake ${{ matrix.platform.cc }} ${{ matrix.platform.cxx }} qt6-base-dev libasound2-dev
         cmake --version
         ninja --version
-        gcc --version
-        g++ --version
+        $CC --version
+        $CXX --version
 
     - name: Install dependencies on macOS
       if: startsWith(matrix.platform.os, 'macos')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,23 @@ on:
 jobs:
   build-and-test:
     if: github.event.pull_request.draft == false
-    name: ${{ matrix.platform.name }}-${{ matrix.build_type }}-SharedLibs${{ matrix.build_shared_libs }}
+    name: ${{ matrix.platform.name }}-${{ matrix.lib_mode.name }}
     runs-on: ${{ matrix.platform.os }}
+    env:
+      CC: ${{ matrix.platform.cc }}
+      CXX: ${{ matrix.platform.cxx }}
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ "Debug" ]
-        build_shared_libs: [ "OFF", "ON" ]
+        lib_mode:
+        - {
+            name: "Debug-StaticLibs",
+            preset: "static"
+          }
+        - {
+            name: "Debug-SharedLibs",
+            preset: "shared"
+          }
         platform: 
         - {
             name: "Ubuntu_GCC",
@@ -50,6 +60,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install cmake ${{ matrix.platform.cc }} ${{ matrix.platform.cxx }} qt6-base-dev libasound2-dev
         cmake --version
+        ninja --version
         gcc --version
         g++ --version
 
@@ -58,6 +69,7 @@ jobs:
       run: |
         brew install cmake qt6
         cmake --version
+        ninja --version
         clang --version
 
     - name: Install Qt on Windows
@@ -67,15 +79,15 @@ jobs:
         version: '6.8.3'
         host: 'windows'
 
+    - name: Configure MSVC environment on Windows
+      if: startsWith(matrix.platform.os, 'windows')
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: Configure CMake
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libs }}
-      env:
-        CC:   ${{ matrix.platform.cc }}
-        CXX:  ${{ matrix.platform.cxx }}
+      run: cmake --preset ${{ matrix.lib_mode.preset }}
 
     - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }}
+      run: cmake --build --preset ${{ matrix.lib_mode.preset }}
 
     - name: Run Tests
-      run: ctest --test-dir build -C ${{ matrix.build_type }} --output-on-failure
+      run: ctest --preset ${{ matrix.lib_mode.preset }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ build/*
 .vscode
 
 .github/*
-!.github/workflows/*
+!.github/workflows/
+!.github/workflows/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CTest)
 
 # MSVC's legacy preprocessor has bugs with variadic macros.
 if(MSVC)
-    add_compile_options(/Zc:preprocessor)
+    add_compile_options(/Zc:preprocessor /utf-8)
 endif()
 
 option(BUILD_SHARED_LIBS "Build all BabelWires libraries as shared libraries" ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,22 +7,22 @@
   },
   "configurePresets": [
     {
-      "name": "static",
-      "displayName": "Static Libraries",
+      "name": "static-debug",
+      "displayName": "Static Libraries (Debug)",
       "description": "Configure BabelWires with BUILD_SHARED_LIBS=OFF.",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/static",
+      "binaryDir": "${sourceDir}/build/static-debug",
       "cacheVariables": {
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "shared",
-      "displayName": "Shared Libraries",
+      "name": "shared-debug",
+      "displayName": "Shared Libraries (Debug)",
       "description": "Configure BabelWires with BUILD_SHARED_LIBS=ON.",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/shared",
+      "binaryDir": "${sourceDir}/build/shared-debug",
       "cacheVariables": {
         "BUILD_SHARED_LIBS": "ON",
         "CMAKE_BUILD_TYPE": "Debug"
@@ -31,29 +31,29 @@
   ],
   "buildPresets": [
     {
-      "name": "static",
-      "displayName": "Build Static Libraries",
-      "configurePreset": "static"
+      "name": "static-debug",
+      "displayName": "Build Static Libraries (Debug)",
+      "configurePreset": "static-debug"
     },
     {
-      "name": "shared",
-      "displayName": "Build Shared Libraries",
-      "configurePreset": "shared"
+      "name": "shared-debug",
+      "displayName": "Build Shared Libraries (Debug)",
+      "configurePreset": "shared-debug"
     }
   ],
   "testPresets": [
     {
-      "name": "static",
-      "displayName": "Test Static Libraries",
-      "configurePreset": "static",
+      "name": "static-debug",
+      "displayName": "Test Static Libraries (Debug)",
+      "configurePreset": "static-debug",
       "output": {
         "outputOnFailure": true
       }
     },
     {
-      "name": "shared",
-      "displayName": "Test Shared Libraries",
-      "configurePreset": "shared",
+      "name": "shared-debug",
+      "displayName": "Test Shared Libraries (Debug)",
+      "configurePreset": "shared-debug",
       "output": {
         "outputOnFailure": true
       }

--- a/Docs/TODO.md
+++ b/Docs/TODO.md
@@ -1,4 +1,5 @@
 Bugs:
+* Windows: Cannot open ".mid" files.
 * Moving compound connections targets between nodes does not work properly.
   e.g. Three test record values. 
   1. Wire two together. 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Windows:
 
 ## Building
 
-It's recommended to use CMake `shared` preset. On Windows, run these commands from inside a "x64 Native Tools Command Prompt" (installed with Visual Studio). Qt6 must also be discoverable by CMake, e.g. via `CMAKE_PREFIX_PATH` or `Qt6_DIR`. To run the executable from the build folder, ensure the Qt6 `bin` folder is also in your `PATH`.
+It's recommended to use CMake `shared-debug` preset. On Windows, run these commands from inside a "x64 Native Tools Command Prompt" (installed with Visual Studio). Qt6 must also be discoverable by CMake, e.g. via `CMAKE_PREFIX_PATH` or `Qt6_DIR`. To run the executable from the build folder, ensure the Qt6 `bin` folder is also in your `PATH`.
 
 ```
-cmake --preset shared
-cmake --build --preset shared -j
+cmake --preset shared-debug
+cmake --build --preset shared-debug -j
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Since GNU/Linux is my primary development platform, UI issues may be present on 
 BabelWires is under active development, but please do not expect development to be rapid.
 My focus is on fundamentals.
 
-## Downloading and Building
+## Downloading
 
 Clone recursively to ensure submodules are populated:
 
@@ -47,7 +47,25 @@ Clone recursively to ensure submodules are populated:
 git clone --recurse-submodules https://github.com/Malcohol/BabelWires.git
 ```
 
-To build as shared libraries (recommended):
+## Requirements
+
+All platforms:
+* CMake 3.25 or later (on Windows, this is provided by Visual Studio)
+* ninja (on Windows, this is provided by Visual Studio)
+* Qt6
+
+Linux:
+* g++ 14 or later.
+
+Mac: 
+* clang 17 or later
+
+Windows: 
+* Visual Studio 2022 or later.
+
+## Building
+
+It's recommended to use CMake `shared` preset. On Windows, run these commands from inside a "x64 Native Tools Command Prompt" (installed with Visual Studio). Qt6 must also be discoverable by CMake, e.g. via `CMAKE_PREFIX_PATH` or `Qt6_DIR`. To run the executable from the build folder, ensure the Qt6 `bin` folder is also in your `PATH`.
 
 ```
 cmake --preset shared
@@ -61,4 +79,3 @@ See the [LICENSE](LICENSE) file.
 
 BabelWires uses a customized version of the [Nodeeditor](https://github.com/paceholder/nodeeditor) project for its GUI.
 My fork with the customizations is [here](https://github.com/Malcohol/nodeeditor/tree/Malcohol/V3ChangesForBabelwires), and that libary (and my customizations) are licensed under the BSD 3-Clause License.
-


### PR DESCRIPTION
* Speed up CI by using Ninja, which is specified by the cmake presets. 
* Update the checkout action to version 6.
* Add clearer build instructions in the README
* Rename the presets to "shared-debug" and "static-debug".