### PR TITLE
Windows file handling fixes and improvements

### DIFF
--- a/BabelWiresQtUi/Utilities/fileDialogs.cpp
+++ b/BabelWiresQtUi/Utilities/fileDialogs.cpp
@@ -9,6 +9,8 @@
 
 #include <BaseLib/Registry/fileTypeRegistry.hpp>
 
+#include <cctype>
+
 #include <QtWidgets/QFileDialog>
 
 #include <QStringBuilder>
@@ -22,10 +24,16 @@ namespace {
                 dialogFormats = dialogFormats + " ";
             }
             dialogFormats = dialogFormats + "*.";
-            // Force case-insensitivity using reg-ex
-            for (auto c : extensions[i]) {
-                dialogFormats = dialogFormats % QChar('[') % QChar(std::tolower(c)) % QChar(std::toupper(c)) % QChar(']');
+#ifdef _WIN32
+            // Windows native file dialogs are case-insensitive, so we can just add the extensions as they are.
+            dialogFormats = dialogFormats + extensions[i].c_str();
+#else
+            // For non-Windows platforms, force case-insensitivity using reg-ex
+            for (unsigned char c : extensions[i]) {
+                dialogFormats = dialogFormats % QChar('[') % QChar(static_cast<char>(std::tolower(c)))
+                                % QChar(static_cast<char>(std::toupper(c))) % QChar(']');
             }
+#endif
         }
         dialogFormats = dialogFormats + ")";
         return dialogFormats + ";;" + QObject::tr("All files (*)");
@@ -36,7 +44,6 @@ QString babelwires::showOpenFileDialog(QWidget* parent, const FileTypeEntry& for
     QString dialogCaption = QObject::tr("Open ") + format.getName().c_str();
     QString dialogFormats = getFormatString(format);
     QFileDialog dialog(parent, dialogCaption, QString(), dialogFormats);
-    dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
     QString filePath;
     if (dialog.exec()) {
@@ -52,7 +59,6 @@ QString babelwires::showSaveFileDialog(QWidget* parent, const FileTypeEntry& for
     QString dialogCaption = QObject::tr("Save ") + format.getName().c_str();
     QString dialogFormats = getFormatString(format);
     QFileDialog dialog(parent, dialogCaption, QString(), dialogFormats);
-    dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix(format.getFileExtensions()[0].c_str());
     QString filePath;

--- a/BabelWiresQtUi/Utilities/fileDialogs.cpp
+++ b/BabelWiresQtUi/Utilities/fileDialogs.cpp
@@ -38,11 +38,12 @@ QString babelwires::showOpenFileDialog(QWidget* parent, const FileTypeEntry& for
     QFileDialog dialog(parent, dialogCaption, QString(), dialogFormats);
     dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
-    dialog.exec();
     QString filePath;
-    QStringList selectedFiles = dialog.selectedFiles();
-    if (!selectedFiles.isEmpty()) {
-        filePath = selectedFiles.first();
+    if (dialog.exec()) {
+        QStringList selectedFiles = dialog.selectedFiles();
+        if (!selectedFiles.isEmpty()) {
+            filePath = selectedFiles.first();
+        }
     }
     return filePath;
 }
@@ -54,11 +55,12 @@ QString babelwires::showSaveFileDialog(QWidget* parent, const FileTypeEntry& for
     dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix(format.getFileExtensions()[0].c_str());
-    dialog.exec();
     QString filePath;
-    QStringList selectedFiles = dialog.selectedFiles();
-    if (!selectedFiles.isEmpty()) {
-        filePath = selectedFiles.first();
+    if (dialog.exec()) {
+        QStringList selectedFiles = dialog.selectedFiles();
+        if (!selectedFiles.isEmpty()) {
+            filePath = selectedFiles.first();
+        }
     }
     return filePath;
 }

--- a/BabelWiresQtUi/Utilities/fileDialogs.cpp
+++ b/BabelWiresQtUi/Utilities/fileDialogs.cpp
@@ -28,21 +28,30 @@ namespace {
             }
         }
         dialogFormats = dialogFormats + ")";
-        return dialogFormats;
+        return dialogFormats + ";;" + QObject::tr("All files (*)");
     }
 } // namespace
 
 QString babelwires::showOpenFileDialog(QWidget* parent, const FileTypeEntry& format) {
     QString dialogCaption = QObject::tr("Open ") + format.getName().c_str();
     QString dialogFormats = getFormatString(format);
-    // Currently case sensitive for me. Could use QFileDialog::DontUseNativeDialog to get around this.
-    return QFileDialog::getOpenFileName(parent, dialogCaption, QString(), dialogFormats);
+    QFileDialog dialog(parent, dialogCaption, QString(), dialogFormats);
+    dialog.setOption(QFileDialog::DontUseNativeDialog, true);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.exec();
+    QString filePath;
+    QStringList selectedFiles = dialog.selectedFiles();
+    if (!selectedFiles.isEmpty()) {
+        filePath = selectedFiles.first();
+    }
+    return filePath;
 }
 
 QString babelwires::showSaveFileDialog(QWidget* parent, const FileTypeEntry& format) {
     QString dialogCaption = QObject::tr("Save ") + format.getName().c_str();
     QString dialogFormats = getFormatString(format);
     QFileDialog dialog(parent, dialogCaption, QString(), dialogFormats);
+    dialog.setOption(QFileDialog::DontUseNativeDialog, true);
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix(format.getFileExtensions()[0].c_str());
     dialog.exec();

--- a/BaseLib/DataContext/filePath.cpp
+++ b/BaseLib/DataContext/filePath.cpp
@@ -31,27 +31,42 @@ bool babelwires::FilePath::empty() const {
 }
 
 void babelwires::FilePath::resolveRelativeTo(const std::filesystem::path& newBase, const std::filesystem::path& oldBase, UserLogger& userLogger) {
-    // Note: A Windows-style absolute path might appear relative to a posix platform.
-    // Since project paths are intended to be absolute, we rely on the fact that they will appear relative too
-    // to avoid building a nonsensical path like c:/path/to/project/d:/path/to/file.
-    if (!m_filePath.is_absolute() && (oldBase.empty() || oldBase.is_absolute())) {
-        std::filesystem::path newPath = newBase / m_filePath;
-        std::filesystem::path oldPath = oldBase / m_filePath;
+    const auto isAbsoluteOrRooted = [](const std::filesystem::path& path) {
+        return path.is_absolute() || path.has_root_directory();
+    };
+
+    const auto preferResolvedPath = [&userLogger](const std::filesystem::path& newPath,
+                                                  const std::filesystem::path& oldPath) -> std::filesystem::path {
         // Prefer new relative file locations to old ones.
         if (std::filesystem::exists(newPath)) {
-            m_filePath = std::filesystem::canonical(newPath);
+            std::filesystem::path resolvedPath = std::filesystem::canonical(newPath);
             if (std::filesystem::exists(oldPath)) {
                 const std::filesystem::path oldCanonical = std::filesystem::canonical(oldPath);
-                if (m_filePath != oldPath) {
+                if (resolvedPath != oldCanonical) {
                     // Info, not warning, because this should be the expected behaviour.
                     userLogger.logInfo()
-                        << "Favouring file " << m_filePath << " over file " << oldCanonical
+                        << "Favouring file " << resolvedPath << " over file " << oldCanonical
                         << ", because its location relative to the project is preserved";
                 }
             }
-        } else {
-            // We presume the old path provides more context.
-            m_filePath = std::move(oldPath);
+            return resolvedPath;
+        }
+        // We presume the old path provides more context.
+        return oldPath;
+    };
+
+    // Note: A Windows-style absolute path might appear relative to a posix platform.
+    // Since project paths are intended to be absolute, we rely on the fact that they will appear relative too
+    // to avoid building a nonsensical path like c:/path/to/project/d:/path/to/file.
+    if (!isAbsoluteOrRooted(m_filePath) && (oldBase.empty() || isAbsoluteOrRooted(oldBase))) {
+        m_filePath = preferResolvedPath(newBase / m_filePath, oldBase / m_filePath);
+        return;
+    }
+
+    if (isAbsoluteOrRooted(m_filePath) && !newBase.empty() && !oldBase.empty() && isAbsoluteOrRooted(oldBase)) {
+        const std::filesystem::path relativePath = m_filePath.lexically_relative(oldBase);
+        if (!relativePath.empty() && !isAbsoluteOrRooted(relativePath)) {
+            m_filePath = preferResolvedPath(newBase / relativePath, m_filePath);
         }
     }
 }

--- a/Docs/TODO.md
+++ b/Docs/TODO.md
@@ -1,5 +1,4 @@
 Bugs:
-* Windows: Cannot open ".mid" files.
 * Moving compound connections targets between nodes does not work properly.
   e.g. Three test record values. 
   1. Wire two together. 

--- a/Tests/BabelWiresLib/projectBundleTest.cpp
+++ b/Tests/BabelWiresLib/projectBundleTest.cpp
@@ -189,8 +189,8 @@ TEST(ProjectBundleTest, filePathResolution) {
 
     struct TestScenario {
         std::filesystem::path m_pathInProjectData;
-        std::filesystem::path m_newBase;
-        std::filesystem::path m_oldBase;
+        std::filesystem::path m_oldProjectPath;
+        std::filesystem::path m_newProjectPath;
         std::filesystem::path m_expectedResolvedPath;
     };
 
@@ -198,21 +198,23 @@ TEST(ProjectBundleTest, filePathResolution) {
     // Because we interpret / resolve on the same platform, some of those tests do not carry over.
     std::vector<TestScenario> scenarios = {
         // Same testEnvironment.
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/Bar", root / "Foo/Bar", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/Bar/project.bw", root / "Foo/Bar/project.bw",
+                     root / "Foo/Bar/Bar.boo"},
         // Same testEnvironment.
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo", root / "Foo", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/project.bw", root / "Foo/project.bw", root / "Foo/Bar/Bar.boo"},
         // Same testEnvironment, file doesn't exist.
-        TestScenario{root / "Flerm/Bar/Bar.boo", root / "Flerm", root / "Flerm", root / "Flerm/Bar/Bar.boo"},
+        TestScenario{root / "Flerm/Bar/Bar.boo", root / "Flerm/project.bw", root / "Flerm/project.bw",
+                     root / "Flerm/Bar/Bar.boo"},
         // New exists, old doesn't.
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo", root / "Flerm", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Flerm/Bar/Bar.boo", root / "Flerm/project.bw", root / "Foo/project.bw", root / "Foo/Bar/Bar.boo"},
         // Old exists, new doesn't.
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo", root / "Flerm", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/project.bw", root / "Flerm/project.bw", root / "Foo/Bar/Bar.boo"},
         // Both exist. New prefered. Check log.
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo", root / "Oom", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/project.bw", root / "Oom/project.bw", root / "Oom/Bar/Bar.boo"},
         // Empty new
-        TestScenario{root / "Foo/Bar/Bar.boo", std::filesystem::path(), root / "Foo", root / "Foo/Bar/Bar.boo"},
+        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo/project.bw", std::filesystem::path(), root / "Foo/Bar/Bar.boo"},
         // Empty old
-        TestScenario{root / "Foo/Bar/Bar.boo", root / "Foo", std::filesystem::path(), root / "Foo/Bar/Bar.boo"}};
+        TestScenario{root / "Foo/Bar/Bar.boo", std::filesystem::path(), root / "Foo/project.bw", root / "Foo/Bar/Bar.boo"}};
 
     // Check that the files in the element data get resolved in the expected way were the project to be opened
     // in a different place.
@@ -232,11 +234,11 @@ TEST(ProjectBundleTest, filePathResolution) {
                 elementData.m_factoryIdentifier = "MyOtherFactory";
                 projectData.m_nodes.emplace_back(elementData.clone());
             }
-            bundle = babelwires::ProjectBundle(scenario.m_oldBase, std::move(projectData));
+            bundle = babelwires::ProjectBundle(scenario.m_oldProjectPath, std::move(projectData));
         }
 
         const babelwires::ResultT<babelwires::ProjectData> projectDataResult =
-            std::move(bundle).resolveAgainstCurrentContext(testEnvironment.m_projectContext, scenario.m_newBase, log);
+            std::move(bundle).resolveAgainstCurrentContext(testEnvironment.m_projectContext, scenario.m_newProjectPath, log);
 
         ASSERT_TRUE(projectDataResult);
         const babelwires::ProjectData& projectData = *projectDataResult;

--- a/Tests/BaseLib/filePathTest.cpp
+++ b/Tests/BaseLib/filePathTest.cpp
@@ -116,10 +116,28 @@ TEST(FilePathTest, resolveRelativeTo) {
         path.resolveRelativeTo(root / "Foo", std::filesystem::path(), log);
         EXPECT_EQ(path, root / "Foo/Bar/Bar.boo");
     }
+#if defined(_WIN64) || defined(_WIN32)
+    // Posix-style absolute old base on Windows should still be treated as a rooted project path.
+    {
+        const std::filesystem::path oldBase("/home/username/babelwires-project");
+        ASSERT_TRUE(oldBase.has_root_directory());
+        ASSERT_FALSE(oldBase.is_absolute());
+
+        babelwires::FilePath path("Bar/Bar.boo");
+        path.resolveRelativeTo(root / "Foo", oldBase, log);
+        EXPECT_EQ(path, root / "Foo/Bar/Bar.boo");
+    }
+#endif
     // Absolute file
     {
         babelwires::FilePath path(root / "Foo/Bar/Bar.boo");
-        path.resolveRelativeTo(root / "Flerm", root / "Glurg", log);
+        path.resolveRelativeTo(root / "Oom", root / "Foo", log);
+        EXPECT_EQ(path, root / "Oom/Bar/Bar.boo");
+    }
+    // Absolute file, new relative location doesn't exist so keep the saved absolute path.
+    {
+        babelwires::FilePath path(root / "Foo/Bar/Bar.boo");
+        path.resolveRelativeTo(root / "Flerm", root / "Foo", log);
         EXPECT_EQ(path, root / "Foo/Bar/Bar.boo");
     }
     // Windows-style absolute file
@@ -129,4 +147,3 @@ TEST(FilePathTest, resolveRelativeTo) {
         EXPECT_EQ(path, "c:/Foo/Bar/Bar.boo");
     }
 }
-


### PR DESCRIPTION
* Ensure Windows correctly interprets absolute posix paths when loading projects.
* Cancelling the file open dialog no longer creates a node. 
* Special-case Windows native file dialogs viz. case insensitivity.